### PR TITLE
perf: fold node claim sidecars into atomic programs

### DIFF
--- a/.changeset/atomic-node-claim-sidecars.md
+++ b/.changeset/atomic-node-claim-sidecars.md
@@ -4,4 +4,4 @@
 
 Fold single disjointness claims and owner-side node claim cleanup into bundled atomic mutation programs. Eligible `nodes.bulkInsert()` and `nodes.bulkCreate()` calls for a `disjointWith` kind now retain one schema-fenced transport submission on Neon HTTP, Cloudflare D1, and libSQL, including legacy live-row detection and typed `DisjointError` rollback. Restricted node deletes release owned uniqueness and disjointness claims inside the same atomic program, and update-only upserts no longer fall back merely because their kind participates in disjointness.
 
-Custom mutation executors now advertise claim support explicitly through `claimSupport.families`, `claimSupport.maxEntries`, and `releasedClaimFamilies`; omitted claim families remain on the portable path.
+Custom mutation executors now advertise claim support explicitly through family-scoped `claimSupport.maxEntriesByFamily`, the optional mixed-family ceiling `claimSupport.maxMixedEntries`, and `releasedClaimFamilies`; omitted claim families remain on the portable path and an empty claim-limit map is an honest opt-out.

--- a/.changeset/atomic-node-claim-sidecars.md
+++ b/.changeset/atomic-node-claim-sidecars.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Fold single disjointness claims and owner-side node claim cleanup into bundled atomic mutation programs. Eligible `nodes.bulkInsert()` and `nodes.bulkCreate()` calls for a `disjointWith` kind now retain one schema-fenced transport submission on Neon HTTP, Cloudflare D1, and libSQL, including legacy live-row detection and typed `DisjointError` rollback. Restricted node deletes release owned uniqueness and disjointness claims inside the same atomic program, and update-only upserts no longer fall back merely because their kind participates in disjointness.
+
+Custom mutation executors now advertise claim support explicitly through `claimSupport.families`, `claimSupport.maxEntries`, and `releasedClaimFamilies`; omitted claim families remain on the portable path.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1534,11 +1534,14 @@ The profile is family-scoped:
 | `updateNodes` / `updateEdges` | Eligible resolved update-only sets                                                        |
 | `mutateNodes` / `mutateEdges` | Eligible mixed create/update sets; the edge family also owns durable endpoint convergence |
 
-Executor limits such as `maxEntries`, `maxClaimedEntries`, and the two edge
-mutation ceilings are part of the registration contract and must be
+Executor limits such as `maxEntries`, `createNodes.claimSupport.maxEntries`,
+and the two edge mutation ceilings are part of the registration contract and must be
 nonnegative integers; zero honestly declares that the backend's bind budget
 cannot admit one member of that shape. TypeGraph validates those declarations
-before publishing the exact-root profile. On a transactionless root, dedicated
+before publishing the exact-root profile. `claimSupport.families` explicitly
+names `uniqueness` and/or `disjointness`; the Store never infers one family from
+the other's limit. `deleteNodes.releasedClaimFamilies` similarly declares which
+owner-side claim cleanup the delete program proves. On a transactionless root, dedicated
 update-only and mixed mutation executors are independently reachable Store
 families even when their entry ceilings are equal, so each requires its own
 conformance evidence. On an interactive root, the collection-level

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1534,14 +1534,17 @@ The profile is family-scoped:
 | `updateNodes` / `updateEdges` | Eligible resolved update-only sets                                                        |
 | `mutateNodes` / `mutateEdges` | Eligible mixed create/update sets; the edge family also owns durable endpoint convergence |
 
-Executor limits such as `maxEntries`, `createNodes.claimSupport.maxEntries`,
-and the two edge mutation ceilings are part of the registration contract and must be
-nonnegative integers; zero honestly declares that the backend's bind budget
-cannot admit one member of that shape. TypeGraph validates those declarations
-before publishing the exact-root profile. `claimSupport.families` explicitly
-names `uniqueness` and/or `disjointness`; the Store never infers one family from
-the other's limit. `deleteNodes.releasedClaimFamilies` similarly declares which
-owner-side claim cleanup the delete program proves. On a transactionless root, dedicated
+Executor limits such as `maxEntries`,
+`createNodes.claimSupport.maxEntriesByFamily`, the optional
+`maxMixedEntries`, and the two edge mutation ceilings are part of the
+registration contract and must be nonnegative integers; zero honestly declares
+that the backend's bind budget cannot admit one member of that shape. TypeGraph
+validates those declarations before publishing the exact-root profile. A key in
+`maxEntriesByFamily` explicitly advertises `uniqueness` or `disjointness`; an
+empty map honestly opts out of all claim work. A batch containing both families
+also requires `maxMixedEntries`, so one family's cheaper ceiling cannot
+authorize the other's SQL. `deleteNodes.releasedClaimFamilies` similarly
+declares which owner-side claim cleanup the delete program proves. On a transactionless root, dedicated
 update-only and mixed mutation executors are independently reachable Store
 families even when their entry ceilings are equal, so each requires its own
 conformance evidence. On an interactive root, the collection-level

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -342,6 +342,9 @@ claim-free batches, generated-ID batches with one same-kind uniqueness claim,
 and single-disjoint-claim batches. This is a measured submission count, not a
 wall-clock RTT benchmark;
 fallback paths are intentionally not assigned a latency claim.
+On D1, the family-scoped bind budgets admit 14 pure same-kind uniqueness
+claims, seven pure disjointness claims, or seven claimed members when both
+families occur in one batch. Larger batches retain the portable behavior.
 
 Direct `edges.bulkInsert()` and `edges.bulkCreate()` calls on those same roots
 use one schema-fenced native program when history and revision capture are

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -323,23 +323,24 @@ for plain schema-managed `nodes.bulkInsert()` and `nodes.bulkCreate()` calls
 when the node has no claims, Operational Identity, history, revision, or
 projections. Session-capable PostgreSQL executes that program on one pinned
 transaction; Neon HTTP, D1, and libSQL submit one transport batch. If any batch
-member has a claim, every
-claimed member must have exactly one `unique` constraint whose scope is the
-literal `kind`, every input ID must be generated, and the backend's
-claimed-member budget must accommodate the batch. Claim-free kinds may
-participate in that generated-ID batch. IDs may otherwise be generated,
-caller-supplied, or mixed only for the wholly claim-free shape, and
+member has a claim, every claimed member must owe exactly one advertised claim
+family: either a `unique` constraint whose scope is the literal `kind` on a
+generated ID, or one `disjointWith` reservation on a generated or
+caller-supplied ID. The backend's claim-support budget must accommodate the
+batch, and claim-free members may participate alongside either family. IDs may
+otherwise be generated, caller-supplied, or mixed, and
 `bulkCreate()` returns rows in input order. This is an internal optimization,
 not a general Store batch API. A
-caller-supplied or mixed ID in a claimed batch, multiple unique constraints,
-non-kind uniqueness scope, disjointness, projected or identity-enabled nodes,
+caller-supplied ID with uniqueness work, multiple claims per member, non-kind
+uniqueness scope, projected or identity-enabled nodes,
 history/revision tracking, missing schema-fence support, and other unsupported
 shapes fail closed to the existing transaction or fallback behavior.
 
 The transport inventory for the supported libSQL root records one client
 `batch` submission and zero client `execute` calls for both generated-ID
-claim-free batches and generated-ID batches with one same-kind uniqueness
-claim. This is a measured submission count, not a wall-clock RTT benchmark;
+claim-free batches, generated-ID batches with one same-kind uniqueness claim,
+and single-disjoint-claim batches. This is a measured submission count, not a
+wall-clock RTT benchmark;
 fallback paths are intentionally not assigned a latency claim.
 
 Direct `edges.bulkInsert()` and `edges.bulkCreate()` calls on those same roots
@@ -352,10 +353,10 @@ semantic registration, and dynamic get-or-create convergence retain the
 interactive path.
 
 Direct edge `bulkDelete()` calls use the same exact-root exchange and refuse a
-foreign-kind ID atomically. Plain node `bulkDelete()` qualifies when no unique,
-disjointness, identity, projection, history, revision, cascade, or disconnect
-work is owed; the program enforces `restrict` against live connected edges in
-SQL. Other delete shapes retain their transaction path. `bulkUpsertById()`
+foreign-kind ID atomically. Restricted node `bulkDelete()` also releases every
+unique or disjoint claim owned by rows it tombstones in the same program, while
+enforcing live connected edges in SQL. Identity, projection, history,
+revision, cascade, and disconnect shapes retain their transaction path. `bulkUpsertById()`
 remains a resolved mutation set because it must read and schema-validate a
 database preimage before its writes are known. Bundled serverless roots can
 submit an eligible distinct-ID, live-row resolved set as one native exchange

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -205,23 +205,23 @@ results to input order.
 Eligible `bulkDelete()` calls use the same mutation-program boundary. Direct
 edge batches on bundled roots submit one schema-fenced atomic program; the
 statement refuses an ID owned by another edge collection and rolls back every
-chunk. Plain node batches also submit one exchange when the node has no unique
-or disjointness claims, Operational Identity, search projections, history, or
-revision capture and its delete behavior is `restrict` (or omitted). The node
+chunk. Restricted node batches also submit one exchange and release uniqueness
+and disjointness claims owned by the tombstoned rows in that program. The node
 statement rechecks connected live edges at the write boundary, so a restricted
 delete cannot race an earlier application-side probe. Cascade, disconnect,
-sidecar, captured, derived-backend, unregistered custom-backend, and
+projection, identity, captured, derived-backend, unregistered custom-backend, and
 caller-transaction shapes keep the interactive path.
 
 The same exact-root programs serve eligible singleton `update()` and
 `delete()` calls without changing their per-operation hook contract. On an
 interactive PostgreSQL root, the guarded mutation owns a short transaction;
 on the single-submission transports it remains one batch. A node
-update with no unique/disjoint/identity/projection sidecars, or a
+update with no unique/identity/projection sidecars (disjointness has no
+update-side transition), or a
 `cardinality: "many"` edge update with no durable match identity, performs one
 authoritative preimage read, validates and merges properties in TypeGraph, then
 submits one guarded atomic update. Every direct edge delete, and a restricted
-node delete owing none of those sidecars, performs its existing live-row gate
+node delete with supported claim cleanup, performs its existing live-row gate
 and then submits one guarded atomic delete. Missing or tombstoned deletes remain
 hook-free read-only no-ops. Temporal mutations, node cascade/disconnect,
 history/revision capture, ordinary derived backends, and unregistered custom

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -182,17 +182,21 @@ atomic convergence contract across multiple submissions.
 
 Bundled PostgreSQL roots using a recognized session-capable driver, Neon HTTP,
 Cloudflare D1, and libSQL also expose native write programs for eligible
-ingestion calls. Plain schema-managed `nodes.bulkInsert(items)` and
-`nodes.bulkCreate(items)` run one schema-fenced atomic program when the node has
-no claims, Operational Identity, history, revision, or projections. Neon HTTP,
-D1, and libSQL submit that program as one transport batch. Session-capable
+ingestion calls. Schema-managed `nodes.bulkInsert(items)` and
+`nodes.bulkCreate(items)` run one schema-fenced atomic program when each claimed
+member owes at most one advertised same-kind uniqueness or disjointness claim
+and the node has no Operational Identity, history, revision, or projections.
+Neon HTTP, D1, and libSQL submit that program as one transport batch. Session-capable
 PostgreSQL runs its statements on one pinned Drizzle transaction, with one SQL
 statement per bind-budget chunk. The batch may use generated IDs,
 caller-supplied IDs, or a mixture of both; `bulkCreate()` restores its rows to
-input order.
-Claimed, projected, identity-enabled, history/revision-tracked, constrained,
-and other unsupported node shapes retain their existing transaction or
-fallback path.
+input order. Cloudflare D1's 100-parameter budget admits 14 pure same-kind
+uniqueness claims, seven pure disjointness claims, or seven claimed members in
+a mixed-family batch. Multiple claims per member, wider uniqueness scopes,
+projected, identity-enabled, history/revision-tracked, and other unsupported
+node shapes retain their existing transaction or fallback path. These ceilings
+are distinct from the seven unique durable edge identities admitted by the
+convergence program above.
 
 Both `edges.bulkInsert(items)` and `edges.bulkCreate(items)` use the same
 schema-fenced atomic program when the store has no history or revision capture.

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -726,16 +726,18 @@ generated, caller-supplied, or mixed IDs can run as one schema-fenced atomic
 program when there are no claims, Operational Identity, history, revision, or
 projections. Session-capable PostgreSQL pins the program to one transaction;
 Neon HTTP, D1, and libSQL submit one transport batch. `bulkCreate()` restores
-rows to input order. This is an internal implementation detail, not a general
-Store batch surface. Constrained, projected, identity-enabled,
-history/revision-tracked, and other unsupported shapes keep the existing
-transaction or fallback path.
+rows to input order. The same program accepts one advertised same-kind
+uniqueness or disjointness claim per member; multiple claims, wider uniqueness
+scopes, projections, identity, and history/revision capture keep the existing
+transaction or fallback path. This is an internal implementation detail, not a
+general Store batch surface.
 
 The same bundled roots execute eligible node and edge `bulkDelete()` calls as
 closed schema-fenced mutation programs. Edge collection identity and node
-`restrict` behavior are rechecked by the write statement itself. Nodes with
-unique, disjointness, search, identity, or capture sidecars, or with cascade or
-disconnect behavior, retain the interactive path, as do derived/custom
+`restrict` behavior are rechecked by the write statement itself. Restricted
+node programs release owner-side uniqueness and disjointness claims in the
+same exchange. Nodes with search, identity, or capture sidecars, or with cascade
+or disconnect behavior, retain the interactive path, as do derived/custom
 backends and caller-owned transactions. On a portable backend, edge bulk
 deletion still resolves all IDs in one batched read and applies them through a
 set-based delete port when available, replacing the former per-ID loop.
@@ -1223,10 +1225,10 @@ store.nodes.Person.bulkDelete(
 ): Promise<void>;
 ```
 
-On eligible bundled roots, a plain restricted node kind runs this call as one
-schema-fenced atomic exchange. Kinds that owe unique, disjointness, search,
-identity, or capture cleanup, or cascade/disconnect work, use the transactional
-path instead.
+On eligible bundled roots, a restricted node kind runs this call as one
+schema-fenced atomic exchange, including owner-side uniqueness and disjointness
+claim cleanup. Kinds that owe search, identity, or capture cleanup, or
+cascade/disconnect work, use the transactional path instead.
 
 #### `getOrCreateByConstraint(constraintName, props, options?)`
 

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -295,11 +295,9 @@ export type AtomicNodeClaimSupport = Readonly<{
 }>;
 
 // @public
-export interface AtomicNodeDeleteBatchExecutor {
-    // (undocumented)
-    (input: AtomicNodeDeleteBatchInput): Promise<AtomicDeleteBatchResult>;
-    readonly releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
-}
+export type AtomicNodeDeleteBatchExecutor = Readonly<{
+    releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
+}> & ((input: AtomicNodeDeleteBatchInput) => Promise<AtomicDeleteBatchResult>);
 
 // @public
 export type AtomicNodeDeleteBatchInput = Readonly<{

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -269,7 +269,7 @@ export interface AtomicNodeBatchExecutor {
     (input: AtomicNodeBatchInput & Readonly<{
         resultMode: "rows";
     }>): Promise<readonly NodeRow[]>;
-    readonly maxClaimedEntries?: number;
+    readonly claimSupport?: AtomicNodeClaimSupport;
 }
 
 // @public
@@ -286,7 +286,20 @@ export type AtomicNodeBatchInput = Readonly<{
 export type AtomicNodeBatchResultMode = "count" | "rows";
 
 // @public
-export type AtomicNodeDeleteBatchExecutor = (input: AtomicNodeDeleteBatchInput) => Promise<AtomicDeleteBatchResult>;
+export type AtomicNodeClaimFamily = "disjointness" | "uniqueness";
+
+// @public
+export type AtomicNodeClaimSupport = Readonly<{
+    families: readonly AtomicNodeClaimFamily[];
+    maxEntries: number;
+}>;
+
+// @public
+export interface AtomicNodeDeleteBatchExecutor {
+    // (undocumented)
+    (input: AtomicNodeDeleteBatchInput): Promise<AtomicDeleteBatchResult>;
+    readonly releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
+}
 
 // @public
 export type AtomicNodeDeleteBatchInput = Readonly<{

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -290,8 +290,8 @@ export type AtomicNodeClaimFamily = "disjointness" | "uniqueness";
 
 // @public
 export type AtomicNodeClaimSupport = Readonly<{
-    families: readonly AtomicNodeClaimFamily[];
-    maxEntries: number;
+    maxEntriesByFamily: Readonly<Partial<Record<AtomicNodeClaimFamily, number>>>;
+    maxMixedEntries?: number;
 }>;
 
 // @public

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -280,12 +280,18 @@ export type AtomicNodeDeleteBatchInput = Readonly<{
   schemaFence: SchemaWriteFenceParams;
 }>;
 
-/** Executes complete eligible direct node deletes for one exact root. */
-export interface AtomicNodeDeleteBatchExecutor {
+/**
+ * Executes complete eligible direct node deletes for one exact root.
+ *
+ * Keep the callable as a function type intersected with its metadata. The API
+ * compatibility inventory follows function aliases into their input types;
+ * changing this to a callable interface would hide that contravariant edge.
+ */
+export type AtomicNodeDeleteBatchExecutor = Readonly<{
   /** Claim families whose owned sidecars this program releases. */
-  readonly releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
-  (input: AtomicNodeDeleteBatchInput): Promise<AtomicDeleteBatchResult>;
-}
+  releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
+}> &
+  ((input: AtomicNodeDeleteBatchInput) => Promise<AtomicDeleteBatchResult>);
 
 /** One authoritative node preimage and replacement used by a resolved set. */
 export type AtomicNodeResolvedUpdateEntry = Readonly<{

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -37,9 +37,10 @@ export type AtomicNodeClaimFamily = "disjointness" | "uniqueness";
 
 /** Closed claim envelope advertised by one node mutation executor. */
 export type AtomicNodeClaimSupport = Readonly<{
-  families: readonly AtomicNodeClaimFamily[];
-  /** Maximum members carrying one supported claim in a single program. */
-  maxEntries: number;
+  /** Pure-family member ceilings; an omitted family is unsupported. */
+  maxEntriesByFamily: Readonly<Partial<Record<AtomicNodeClaimFamily, number>>>;
+  /** Total claimed-member ceiling when more than one family is present. */
+  maxMixedEntries?: number;
 }>;
 
 function isAtomicNodeClaimFamily(
@@ -55,7 +56,6 @@ function assertAtomicNodeClaimFamilies(
 ): void {
   if (
     Array.isArray(value) &&
-    value.length > 0 &&
     new Set(value).size === value.length &&
     value.every((claimFamily) => isAtomicNodeClaimFamily(claimFamily))
   ) {
@@ -89,16 +89,59 @@ function assertAtomicNodeClaimSupport(
     );
   }
   const support = value as Readonly<Record<PropertyKey, unknown>>;
-  assertNonnegativeIntegerLimit(
-    family,
-    "claimSupport.maxEntries",
-    support["maxEntries"],
-  );
-  assertAtomicNodeClaimFamilies(
-    family,
-    "claimSupport.families",
-    support["families"],
-  );
+  const maxEntriesByFamily = support["maxEntriesByFamily"];
+  if (
+    typeof maxEntriesByFamily !== "object" ||
+    maxEntriesByFamily === null ||
+    Array.isArray(maxEntriesByFamily)
+  ) {
+    throw new ConfigurationError(
+      `Atomic mutation program family ${family} requires family-scoped claim limits.`,
+      {
+        code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+        family,
+        limit: "claimSupport.maxEntriesByFamily",
+        value: maxEntriesByFamily,
+      },
+    );
+  }
+  const familyLimits = Object.entries(maxEntriesByFamily);
+  for (const [claimFamily, limit] of familyLimits) {
+    if (!isAtomicNodeClaimFamily(claimFamily)) {
+      throw new ConfigurationError(
+        `Atomic mutation program family ${family} received an unknown claim family.`,
+        {
+          code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+          family,
+          limit: "claimSupport.maxEntriesByFamily",
+          value: claimFamily,
+        },
+      );
+    }
+    assertNonnegativeIntegerLimit(
+      family,
+      `claimSupport.maxEntriesByFamily.${claimFamily}`,
+      limit,
+    );
+  }
+  if (support["maxMixedEntries"] !== undefined) {
+    if (familyLimits.length < 2) {
+      throw new ConfigurationError(
+        `Atomic mutation program family ${family} cannot advertise mixed claims without two claim families.`,
+        {
+          code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+          family,
+          limit: "claimSupport.maxMixedEntries",
+          value: support["maxMixedEntries"],
+        },
+      );
+    }
+    assertNonnegativeIntegerLimit(
+      family,
+      "claimSupport.maxMixedEntries",
+      support["maxMixedEntries"],
+    );
+  }
 }
 
 /** The one owner of claim-verdict to advertised-family correlation. */
@@ -112,13 +155,34 @@ export function supportsAtomicNodeClaims(
   claims: readonly NodeInsertClaim[],
 ): boolean {
   if (claims.length === 0) return true;
-  return (
-    support !== undefined &&
-    claims.length <= support.maxEntries &&
-    claims.every((claim) =>
-      support.families.includes(atomicNodeClaimFamily(claim)),
+  if (support === undefined) return false;
+  const families = new Set(claims.map((claim) => atomicNodeClaimFamily(claim)));
+  if (
+    [...families].some(
+      (family) => support.maxEntriesByFamily[family] === undefined,
     )
+  ) {
+    return false;
+  }
+  if (families.size > 1) {
+    return (
+      support.maxMixedEntries !== undefined &&
+      claims.length <= support.maxMixedEntries
+    );
+  }
+  const family = families.values().next().value;
+  return (
+    family !== undefined &&
+    claims.length <= (support.maxEntriesByFamily[family] ?? 0)
   );
+}
+
+/** Whether an executor can admit at least one member of a claim family. */
+export function supportsAtomicNodeClaimFamily(
+  support: AtomicNodeClaimSupport | undefined,
+  family: AtomicNodeClaimFamily,
+): boolean {
+  return (support?.maxEntriesByFamily[family] ?? 0) > 0;
 }
 
 /** One normalized node-create member supplied to a semantic executor. */

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -32,6 +32,95 @@ export type AtomicNodeBatchIdSource = "generated" | "caller";
 /** Whether a node batch returns only its count or its ordered postimages. */
 export type AtomicNodeBatchResultMode = "count" | "rows";
 
+/** Independently provable claim semantics accepted by a node mutation family. */
+export type AtomicNodeClaimFamily = "disjointness" | "uniqueness";
+
+/** Closed claim envelope advertised by one node mutation executor. */
+export type AtomicNodeClaimSupport = Readonly<{
+  families: readonly AtomicNodeClaimFamily[];
+  /** Maximum members carrying one supported claim in a single program. */
+  maxEntries: number;
+}>;
+
+function isAtomicNodeClaimFamily(
+  value: unknown,
+): value is AtomicNodeClaimFamily {
+  return value === "disjointness" || value === "uniqueness";
+}
+
+function assertAtomicNodeClaimFamilies(
+  family: keyof AtomicMutationProgramRegistration,
+  name: string,
+  value: unknown,
+): void {
+  if (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    new Set(value).size === value.length &&
+    value.every((claimFamily) => isAtomicNodeClaimFamily(claimFamily))
+  ) {
+    return;
+  }
+  throw new ConfigurationError(
+    `Atomic mutation program family ${family} requires distinct ${name}.`,
+    {
+      code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+      family,
+      limit: name,
+      value,
+    },
+  );
+}
+
+function assertAtomicNodeClaimSupport(
+  family: "createNodes" | "mutateNodes",
+  value: unknown,
+): void {
+  if (value === undefined) return;
+  if (typeof value !== "object" || value === null) {
+    throw new ConfigurationError(
+      `Atomic mutation program family ${family} requires claimSupport metadata.`,
+      {
+        code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+        family,
+        limit: "claimSupport",
+        value,
+      },
+    );
+  }
+  const support = value as Readonly<Record<PropertyKey, unknown>>;
+  assertNonnegativeIntegerLimit(
+    family,
+    "claimSupport.maxEntries",
+    support["maxEntries"],
+  );
+  assertAtomicNodeClaimFamilies(
+    family,
+    "claimSupport.families",
+    support["families"],
+  );
+}
+
+/** The one owner of claim-verdict to advertised-family correlation. */
+function atomicNodeClaimFamily(claim: NodeInsertClaim): AtomicNodeClaimFamily {
+  return claim.verdict.kind;
+}
+
+/** Whether one executor explicitly accepts every normalized claimed member. */
+export function supportsAtomicNodeClaims(
+  support: AtomicNodeClaimSupport | undefined,
+  claims: readonly NodeInsertClaim[],
+): boolean {
+  if (claims.length === 0) return true;
+  return (
+    support !== undefined &&
+    claims.length <= support.maxEntries &&
+    claims.every((claim) =>
+      support.families.includes(atomicNodeClaimFamily(claim)),
+    )
+  );
+}
+
 /** One normalized node-create member supplied to a semantic executor. */
 export type AtomicNodeBatchEntry = Readonly<{
   idSource: AtomicNodeBatchIdSource;
@@ -49,8 +138,8 @@ export type AtomicNodeBatchInput = Readonly<{
 
 /** Executes the complete eligible node-create family for one exact root. */
 export interface AtomicNodeBatchExecutor {
-  /** Maximum constrained members the backend can gate in one statement. */
-  readonly maxClaimedEntries?: number;
+  /** Claim semantics this executor can prove, omitted for plain rows only. */
+  readonly claimSupport?: AtomicNodeClaimSupport;
   (
     input: AtomicNodeBatchInput & Readonly<{ resultMode: "count" }>,
   ): Promise<number>;
@@ -128,9 +217,11 @@ export type AtomicNodeDeleteBatchInput = Readonly<{
 }>;
 
 /** Executes complete eligible direct node deletes for one exact root. */
-export type AtomicNodeDeleteBatchExecutor = (
-  input: AtomicNodeDeleteBatchInput,
-) => Promise<AtomicDeleteBatchResult>;
+export interface AtomicNodeDeleteBatchExecutor {
+  /** Claim families whose owned sidecars this program releases. */
+  readonly releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
+  (input: AtomicNodeDeleteBatchInput): Promise<AtomicDeleteBatchResult>;
+}
 
 /** One authoritative node preimage and replacement used by a resolved set. */
 export type AtomicNodeResolvedUpdateEntry = Readonly<{
@@ -510,13 +601,21 @@ function assertAtomicMutationProgramLimits(
 ): void {
   if (executor === undefined) return;
   if (family === "createNodes") {
-    const maxClaimedEntries = (executor as AtomicNodeBatchExecutor)
-      .maxClaimedEntries;
-    if (maxClaimedEntries !== undefined) {
-      assertNonnegativeIntegerLimit(
+    assertAtomicNodeClaimSupport(
+      family,
+      (executor as AtomicNodeBatchExecutor).claimSupport,
+    );
+    return;
+  }
+  if (family === "deleteNodes") {
+    const releasedClaimFamilies: unknown = (
+      executor as AtomicNodeDeleteBatchExecutor
+    ).releasedClaimFamilies;
+    if (releasedClaimFamilies !== undefined) {
+      assertAtomicNodeClaimFamilies(
         family,
-        "maxClaimedEntries",
-        maxClaimedEntries,
+        "releasedClaimFamilies",
+        releasedClaimFamilies,
       );
     }
     return;

--- a/packages/typegraph/src/backend/capabilities/node-insert-projections.ts
+++ b/packages/typegraph/src/backend/capabilities/node-insert-projections.ts
@@ -5,6 +5,10 @@ import type {
   NodeInsertClaim,
   NodeInsertProjection,
 } from "../types";
+import {
+  type AtomicNodeClaimSupport,
+  supportsAtomicNodeClaims,
+} from "./atomic-mutation-program";
 
 export type NodeProjectionInsertTarget = BackendIdentity &
   Pick<GraphBackend, "commands">;
@@ -104,6 +108,45 @@ export function rephaseNonTransactionalNodeClaimPlan(
       ...claim,
       placement: "pre-insert",
     })),
+  };
+}
+
+/**
+ * Normalizes the one-claim envelope accepted by an atomic node program.
+ *
+ * Unlike the ordinary root insert seam, a closed program can also prove a
+ * disjoint claim because it carries the legacy live-node probe and cleanup in
+ * the same atomic transport submission. The executor's advertised support is
+ * authoritative; an omitted family remains on the portable path.
+ */
+export function rephaseAtomicNodeClaimPlan(
+  plan: ManagedNodeCreatePlan,
+  support: AtomicNodeClaimSupport | undefined,
+): ManagedNodeCreatePlan | undefined {
+  if (
+    plan.mode.kind !== "ordinary" ||
+    plan.projections.length > 0 ||
+    plan.claims.length !== 1 ||
+    !supportsAtomicNodeClaims(support, plan.claims)
+  ) {
+    return;
+  }
+  const claim = plan.claims[0];
+  if (claim === undefined) return;
+  const uniquenessSupported =
+    plan.idGenerated &&
+    claim.verdict.kind === "uniqueness" &&
+    claim.axis === plan.params.kind &&
+    claim.verdict.probeAxes.length === 1 &&
+    claim.verdict.probeAxes[0] === claim.axis;
+  const disjointnessSupported =
+    claim.verdict.kind === "disjointness" &&
+    claim.key === plan.params.id &&
+    claim.verdict.conflictingKinds.length === 1;
+  if (!uniquenessSupported && !disjointnessSupported) return;
+  return {
+    ...plan,
+    claims: [{ ...claim, placement: "pre-insert" }],
   };
 }
 

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -4,6 +4,7 @@ import {
   CompilerInvariantError,
   ConfigurationError,
   DatabaseOperationError,
+  DisjointError,
   EdgeMatchIdentityConflictError,
   MigrationError,
   SchemaContentConflictError,
@@ -148,6 +149,7 @@ import { type CompiledSqlQuery, type ExecutableSql } from "./execution/types";
 import type {
   AtomicNodeClaimEntry,
   AtomicNodeClaimOwnerRow,
+  AtomicNodeDisjointConflictRow,
 } from "./operations/atomic-node-claims";
 import {
   type CommonOperationStrategy,
@@ -767,6 +769,7 @@ async function withAtomicNodeDeleteRestrictionClassification<T>(
 
 type AtomicDeleteSlotResult =
   | Readonly<{ kind: "affected"; count: number }>
+  | Readonly<{ kind: "claim-release" }>
   | Readonly<{ kind: "fence"; matched: boolean }>;
 
 function assembleAtomicDeleteBatchResult(
@@ -779,6 +782,7 @@ function assembleAtomicDeleteBatchResult(
       affectedCount += result.count;
       continue;
     }
+    if (result.kind === "claim-release") continue;
     if (fenceResult !== undefined) {
       throw new CompilerInvariantError(
         "Atomic delete program returned more than one schema-fence result.",
@@ -1447,8 +1451,12 @@ export function createCommonOperationBackend(
     : (() => {
         const maxClaimedEntries = Math.max(
           0,
-          Math.floor((options.maxBindParameters - 13) / 6),
+          Math.floor((options.maxBindParameters - 13) / 14),
         );
+        const claimSupport = Object.freeze({
+          families: ["disjointness", "uniqueness"] as const,
+          maxEntries: maxClaimedEntries,
+        });
 
         function orderedAtomicNodeClaims(
           entries: readonly AtomicNodeBatchEntry[],
@@ -1493,6 +1501,10 @@ export function createCommonOperationBackend(
               entries: readonly AtomicNodeClaimEntry[];
               rows: readonly AtomicNodeClaimOwnerRow[];
             }>
+          | Readonly<{
+              kind: "disjoint-conflicts";
+              rows: readonly AtomicNodeDisjointConflictRow[];
+            }>
           | Readonly<{ kind: "cleanup" }>
           | Readonly<{
               kind: "counts";
@@ -1508,7 +1520,7 @@ export function createCommonOperationBackend(
         function classifyAtomicNodeClaimResults(
           claimEntries: readonly AtomicNodeClaimEntry[],
           results: readonly AtomicNodeProgramSlot[],
-        ): "stale" | "owned" | UniquenessError {
+        ): "stale" | "owned" | DisjointError | UniquenessError {
           const ownerByTarget = new Map<string, ClaimOwner>();
           let returnedClaims = 0;
           for (const result of results) {
@@ -1529,6 +1541,20 @@ export function createCommonOperationBackend(
             );
           }
 
+          const disjointConflicts = results
+            .flatMap((result) =>
+              result.kind === "disjoint-conflicts" ? result.rows : [],
+            )
+            .toSorted((left, right) => left.ordinal - right.ordinal);
+          const firstDisjointConflict = disjointConflicts[0];
+          if (firstDisjointConflict !== undefined) {
+            return new DisjointError({
+              nodeId: firstDisjointConflict.node_id,
+              attemptedKind: firstDisjointConflict.attempted_kind,
+              conflictingKind: firstDisjointConflict.conflicting_kind,
+            });
+          }
+
           for (const item of claimEntries.toSorted(
             (left, right) => left.ordinal - right.ordinal,
           )) {
@@ -1545,11 +1571,12 @@ export function createCommonOperationBackend(
               nodeId: item.entry.params.id,
             };
             if (!isSameClaimOwner(owner, proposedOwner)) {
-              if (claim.verdict.kind !== "uniqueness") {
-                throw new CompilerInvariantError(
-                  "Atomic node claim program received an unsupported claim verdict.",
-                  { ordinal: item.ordinal },
-                );
+              if (claim.verdict.kind === "disjointness") {
+                return new DisjointError({
+                  nodeId: item.entry.params.id,
+                  attemptedKind: item.entry.params.kind,
+                  conflictingKind: owner.concreteKind,
+                });
               }
               return new UniquenessError({
                 constraintName: claim.constraintName,
@@ -1578,7 +1605,12 @@ export function createCommonOperationBackend(
               : "A refused atomic node claim program still inserted nodes.",
             );
           }
-          if (verdict instanceof UniquenessError) throw verdict;
+          if (
+            verdict instanceof UniquenessError ||
+            verdict instanceof DisjointError
+          ) {
+            throw verdict;
+          }
           return verdict;
         }
 
@@ -1629,7 +1661,10 @@ export function createCommonOperationBackend(
             const nodeChunkSize = Math.max(
               1,
               Math.floor(
-                (options.maxBindParameters - 4 - 6 * claimEntries.length) / 9,
+                (options.maxBindParameters -
+                  4 -
+                  14 * claimEntries.length) /
+                  9,
               ),
             );
             const nodeChunks = chunkArray(input.entries, nodeChunkSize);
@@ -1658,6 +1693,36 @@ export function createCommonOperationBackend(
                 })),
               }),
             }));
+            const disjointEntries = claimEntries.filter(
+              (item) => item.entry.claim?.verdict.kind === "disjointness",
+            );
+            const disjointSlots: AtomicSqlProgram<
+              AtomicNodeProgramSlot,
+              unknown
+            >["slots"] =
+              disjointEntries.length === 0 ?
+                []
+              : [
+                  {
+                    statement: execution.compile(
+                      operationStrategy.buildAtomicNodeDisjointConflictsWithSchemaFence(
+                        disjointEntries,
+                        input.schemaFence,
+                        atomicSchemaFenceLockClause,
+                      ),
+                    ),
+                    cardinality: "many" as const,
+                    decode: (rows) => ({
+                      kind: "disjoint-conflicts" as const,
+                      rows: rows.map((row) => ({
+                        ordinal: Number(row["ordinal"]),
+                        attempted_kind: String(row["attempted_kind"]),
+                        node_id: String(row["node_id"]),
+                        conflicting_kind: String(row["conflicting_kind"]),
+                      })),
+                    }),
+                  },
+                ];
             const writeGate =
               operationStrategy.buildAtomicNodeClaimGatePredicateWithSchemaFence(
                 claimEntries,
@@ -1702,7 +1767,12 @@ export function createCommonOperationBackend(
                 }),
               }));
               const program = {
-                slots: [...claimSlots, ...nodeSlots, ...cleanupSlots],
+                slots: [
+                  ...claimSlots,
+                  ...disjointSlots,
+                  ...nodeSlots,
+                  ...cleanupSlots,
+                ],
                 assemble(results: readonly AtomicNodeProgramSlot[]): number {
                   const counts = results.flatMap((result) =>
                     result.kind === "counts" ? [result.count] : [],
@@ -1750,7 +1820,12 @@ export function createCommonOperationBackend(
               }),
             }));
             const program = {
-              slots: [...claimSlots, ...nodeSlots, ...cleanupSlots],
+              slots: [
+                ...claimSlots,
+                ...disjointSlots,
+                ...nodeSlots,
+                ...cleanupSlots,
+              ],
               assemble(
                 results: readonly AtomicNodeProgramSlot[],
               ): readonly NodeRow[] {
@@ -1880,7 +1955,7 @@ export function createCommonOperationBackend(
 
         const boundedExecuteAtomicNodeBatch = Object.assign(
           executeAtomicNodeBatch,
-          { maxClaimedEntries },
+          { claimSupport },
         );
         return {
           executeAtomicNodeBatch: boundedExecuteAtomicNodeBatch,
@@ -2319,9 +2394,9 @@ export function createCommonOperationBackend(
         const atomicSchemaFenceLockClause = requireDefined(
           schemaFenceLockClause,
         );
-        // Fence graph/version, timestamp, graph id and kind are the five
-        // fixed binds repeated beside each id chunk.
-        const chunkSize = Math.max(1, maxBindParameters - 5);
+        // Claim release is widest: fence graph/version, graph, kind, and the
+        // timestamp in both SET and owner-postimage predicates beside each id.
+        const chunkSize = Math.max(1, maxBindParameters - 6);
 
         async function executeAtomicNodeDeleteBatch(
           input: AtomicNodeDeleteBatchInput,
@@ -2351,9 +2426,28 @@ export function createCommonOperationBackend(
             decode: (rows: readonly Readonly<Record<string, unknown>>[]) =>
               ({ kind: "affected", count: rows.length }) as const,
           }));
+          const claimReleaseSlots = chunkArray(input.ids, chunkSize).map(
+            (ids) => ({
+              statement: execution.compile(
+                operationStrategy.buildAtomicDeletedNodeClaimReleaseWithSchemaFence(
+                  {
+                    graphId: input.graphId,
+                    kind: input.kind,
+                    ids,
+                    timestamp,
+                  },
+                  input.schemaFence,
+                  atomicSchemaFenceLockClause,
+                ),
+              ),
+              cardinality: "none" as const,
+              decode: () => ({ kind: "claim-release" as const }),
+            }),
+          );
           const program = {
             slots: [
               ...deleteSlots,
+              ...claimReleaseSlots,
               {
                 statement: execution.compile(
                   operationStrategy.buildSchemaFenceProbe(
@@ -2379,7 +2473,19 @@ export function createCommonOperationBackend(
           );
         }
 
-        return { executeAtomicNodeDeleteBatch } satisfies Readonly<{
+        const executeAtomicNodeDeleteBatchWithClaimCleanup = Object.assign(
+          executeAtomicNodeDeleteBatch,
+          {
+            releasedClaimFamilies: [
+              "disjointness",
+              "uniqueness",
+            ] as const,
+          },
+        );
+        return {
+          executeAtomicNodeDeleteBatch:
+            executeAtomicNodeDeleteBatchWithClaimCleanup,
+        } satisfies Readonly<{
           executeAtomicNodeDeleteBatch: AtomicNodeDeleteBatchExecutor;
         }>;
       })();

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -61,12 +61,14 @@ import {
   type AtomicNodeBatchEntry,
   type AtomicNodeBatchExecutor,
   type AtomicNodeBatchInput,
+  type AtomicNodeClaimSupport,
   type AtomicNodeDeleteBatchExecutor,
   type AtomicNodeDeleteBatchInput,
   AtomicNodeDeleteRestrictedRefusalError,
   type AtomicNodeResolvedMutationSetExecutor,
   type AtomicNodeResolvedUpdateBatchExecutor,
   type AtomicNodeResolvedUpdateEntry,
+  supportsAtomicNodeClaims,
 } from "../capabilities/atomic-mutation-program";
 import type {
   AtomicSqlProgram,
@@ -165,6 +167,22 @@ import {
 const ATOMIC_EDGE_CLAIM_PARAM_COUNT = 18;
 const ATOMIC_EDGE_CONVERGENCE_PARAM_COUNT = 14;
 const ATOMIC_EDGE_CONVERGENCE_FIXED_PARAM_COUNT = 2;
+const ATOMIC_NODE_CLAIM_INPUT_PARAM_COUNT = 6;
+const ATOMIC_NODE_DISJOINT_INPUT_PARAM_COUNT = 6;
+const ATOMIC_NODE_INSERT_PARAM_COUNT = 9;
+const ATOMIC_NODE_WRITE_FIXED_PARAM_COUNT = 4;
+
+function chunkAtomicNodeEntriesByIdSource(
+  entries: readonly AtomicNodeBatchEntry[],
+  chunkSize: number,
+): readonly (readonly AtomicNodeBatchEntry[])[] {
+  return (["generated", "caller"] as const).flatMap((idSource) =>
+    chunkArray(
+      entries.filter((entry) => entry.idSource === idSource),
+      chunkSize,
+    ),
+  );
+}
 
 function assertMatchingFusedEdgeClaim(
   params: InsertEdgeParams,
@@ -1449,14 +1467,32 @@ export function createCommonOperationBackend(
     ) ?
       {}
     : (() => {
-        const maxClaimedEntries = Math.max(
+        const maxPureUniquenessEntries = Math.max(
           0,
-          Math.floor((options.maxBindParameters - 13) / 14),
+          Math.floor(
+            (options.maxBindParameters -
+              ATOMIC_NODE_WRITE_FIXED_PARAM_COUNT -
+              ATOMIC_NODE_INSERT_PARAM_COUNT) /
+              ATOMIC_NODE_CLAIM_INPUT_PARAM_COUNT,
+          ),
+        );
+        const maxDisjointOrMixedEntries = Math.max(
+          0,
+          Math.floor(
+            (options.maxBindParameters -
+              ATOMIC_NODE_WRITE_FIXED_PARAM_COUNT -
+              ATOMIC_NODE_INSERT_PARAM_COUNT) /
+              (ATOMIC_NODE_CLAIM_INPUT_PARAM_COUNT +
+                ATOMIC_NODE_DISJOINT_INPUT_PARAM_COUNT),
+          ),
         );
         const claimSupport = Object.freeze({
-          families: ["disjointness", "uniqueness"] as const,
-          maxEntries: maxClaimedEntries,
-        });
+          maxEntriesByFamily: Object.freeze({
+            disjointness: maxDisjointOrMixedEntries,
+            uniqueness: maxPureUniquenessEntries,
+          }),
+          maxMixedEntries: maxDisjointOrMixedEntries,
+        } satisfies AtomicNodeClaimSupport);
 
         function orderedAtomicNodeClaims(
           entries: readonly AtomicNodeBatchEntry[],
@@ -1632,12 +1668,9 @@ export function createCommonOperationBackend(
           );
 
           const timestamp = nowIso();
-          const sourceGroups = ["generated", "caller"] as const;
-          const chunks = sourceGroups.flatMap((idSource) =>
-            chunkArray(
-              input.entries.filter((entry) => entry.idSource === idSource),
-              batchConfig.nodeSchemaFencedInsertBatchSize,
-            ),
+          const chunks = chunkAtomicNodeEntriesByIdSource(
+            input.entries,
+            batchConfig.nodeSchemaFencedInsertBatchSize,
           );
           const atomicExecutor = requireDefined(atomicSqlProgramExecutor);
           const atomicSchemaFenceLockClause = requireDefined(
@@ -1645,29 +1678,45 @@ export function createCommonOperationBackend(
           );
           const claimEntries = orderedAtomicNodeClaims(input.entries);
           if (claimEntries.length > 0) {
-            if (claimEntries.length > maxClaimedEntries) {
+            const claims = claimEntries.map((item) =>
+              requireDefined(item.entry.claim),
+            );
+            if (!supportsAtomicNodeClaims(claimSupport, claims)) {
               throw new CompilerInvariantError(
                 "Atomic node claim program exceeded its declared member budget.",
                 {
                   claimedEntries: claimEntries.length,
-                  maxClaimedEntries,
+                  claimSupport,
                 },
               );
             }
+            const disjointEntries = claimEntries.filter(
+              (item) => item.entry.claim?.verdict.kind === "disjointness",
+            );
             const claimChunkSize = Math.max(
               1,
-              Math.floor((options.maxBindParameters - 2) / 6),
+              Math.floor(
+                (options.maxBindParameters - 2) /
+                  ATOMIC_NODE_CLAIM_INPUT_PARAM_COUNT,
+              ),
             );
+            const gateParameterCount =
+              ATOMIC_NODE_CLAIM_INPUT_PARAM_COUNT * claimEntries.length +
+              ATOMIC_NODE_DISJOINT_INPUT_PARAM_COUNT *
+                disjointEntries.length;
             const nodeChunkSize = Math.max(
               1,
               Math.floor(
                 (options.maxBindParameters -
-                  4 -
-                  14 * claimEntries.length) /
-                  9,
+                  ATOMIC_NODE_WRITE_FIXED_PARAM_COUNT -
+                  gateParameterCount) /
+                  ATOMIC_NODE_INSERT_PARAM_COUNT,
               ),
             );
-            const nodeChunks = chunkArray(input.entries, nodeChunkSize);
+            const nodeChunks = chunkAtomicNodeEntriesByIdSource(
+              input.entries,
+              nodeChunkSize,
+            );
             const claimChunks = chunkArray(claimEntries, claimChunkSize);
             const claimSlots: AtomicSqlProgram<
               AtomicNodeProgramSlot,
@@ -1693,9 +1742,6 @@ export function createCommonOperationBackend(
                 })),
               }),
             }));
-            const disjointEntries = claimEntries.filter(
-              (item) => item.entry.claim?.verdict.kind === "disjointness",
-            );
             const disjointSlots: AtomicSqlProgram<
               AtomicNodeProgramSlot,
               unknown

--- a/packages/typegraph/src/backend/drizzle/operations/atomic-node-claims.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/atomic-node-claims.ts
@@ -34,6 +34,14 @@ export type AtomicNodeClaimOwnerRow = Readonly<{
   concrete_kind: string;
 }>;
 
+/** Legacy live-node evidence returned for one disjoint proposal. */
+export type AtomicNodeDisjointConflictRow = Readonly<{
+  ordinal: number;
+  attempted_kind: string;
+  node_id: string;
+  conflicting_kind: string;
+}>;
+
 const CLAIM_INPUT_ALIAS = "atomic_node_claim_input";
 const SCHEMA_FENCE_ALIAS = "atomic_node_claim_schema_fence";
 
@@ -44,6 +52,16 @@ const CLAIM_INPUT_COLUMNS = [
   "key",
   "node_id",
   "concrete_kind",
+] as const;
+const DISJOINT_INPUT_COLUMNS = [
+  "ordinal",
+  "graph_id",
+  "axis",
+  "constraint_name",
+  "key",
+  "node_id",
+  "attempted_kind",
+  "conflicting_kind",
 ] as const;
 
 function drizzleSqlTag(
@@ -111,17 +129,23 @@ function assertClaimEntries(
   for (const item of entries) {
     const { entry } = item;
     const claim = entry.claim;
+    const uniquenessSupported =
+      entry.idSource === "generated" &&
+      claim?.verdict.kind === "uniqueness" &&
+      claim.axis === entry.params.kind &&
+      claim.verdict.probeAxes.length === 1 &&
+      claim.verdict.probeAxes[0] === claim.axis;
+    const disjointnessSupported =
+      claim?.verdict.kind === "disjointness" &&
+      claim.key === entry.params.id &&
+      claim.verdict.conflictingKinds.length === 1;
     if (
-      entry.idSource !== "generated" ||
-      claim?.verdict.kind !== "uniqueness" ||
-      claim.axis !== entry.params.kind ||
-      claim.placement !== "pre-insert" ||
-      claim.verdict.probeAxes.length !== 1 ||
-      claim.verdict.probeAxes[0] !== claim.axis ||
+      claim?.placement !== "pre-insert" ||
+      (!uniquenessSupported && !disjointnessSupported) ||
       entry.params.graphId !== schemaFence.graphId
     ) {
       throw new CompilerInvariantError(
-        "Atomic node claims require generated ids and exactly one own-kind uniqueness claim.",
+        "Atomic node claims require one supported pre-insert claim.",
         { ordinal: item.ordinal },
       );
     }
@@ -135,6 +159,98 @@ function assertClaimEntries(
       );
     }
   }
+}
+
+function disjointInputValues(
+  entries: readonly AtomicNodeClaimEntry[],
+): readonly SQL[] {
+  return entries.flatMap((item) => {
+    const claim = claimOf(item);
+    if (claim.verdict.kind !== "disjointness") return [];
+    return claim.verdict.conflictingKinds.map(
+      (conflictingKind) => sql`
+        (
+          ${item.ordinal},
+          ${item.entry.params.graphId},
+          ${claim.axis},
+          ${claim.constraintName},
+          ${claim.key},
+          ${item.entry.params.id},
+          ${item.entry.params.kind},
+          ${conflictingKind}
+        )
+      `,
+    );
+  });
+}
+
+function disjointInputCte(
+  entries: readonly AtomicNodeClaimEntry[],
+  alias: string,
+): SQL | undefined {
+  const values = disjointInputValues(entries);
+  if (values.length === 0) return;
+  const columns = sql.join(
+    DISJOINT_INPUT_COLUMNS.map((column) => sql.identifier(column)),
+    sql`, `,
+  );
+  return sql`${sql.identifier(alias)} (${columns}) AS (VALUES ${sql.join([...values], sql`, `)})`;
+}
+
+function disjointConflictPredicate(
+  tables: Tables,
+  entries: readonly AtomicNodeClaimEntry[],
+  inputAlias: string,
+): SQL | undefined {
+  const inputCte = disjointInputCte(entries, inputAlias);
+  if (inputCte === undefined) return;
+  const input = sql.identifier(inputAlias);
+  const inputColumn = (name: string): SQL =>
+    sql`${input}.${quotedColumn({ name })}`;
+  const candidate = sql.identifier("atomic_disjoint_candidate");
+  const candidateColumn = (column: Readonly<{ name: string }>): SQL =>
+    sql`${candidate}.${quotedColumn(column)}`;
+  return sql`
+    WITH ${inputCte}
+    SELECT
+      ${inputColumn("ordinal")} AS ordinal,
+      ${inputColumn("attempted_kind")} AS attempted_kind,
+      ${inputColumn("node_id")} AS node_id,
+      ${candidateColumn(tables.nodes.kind)} AS conflicting_kind
+    FROM ${input}
+    JOIN ${tables.nodes} AS ${candidate}
+      ON ${candidateColumn(tables.nodes.graphId)} = ${inputColumn("graph_id")}
+     AND ${candidateColumn(tables.nodes.kind)} = ${inputColumn("conflicting_kind")}
+     AND ${candidateColumn(tables.nodes.id)} = ${inputColumn("key")}
+     AND ${candidateColumn(tables.nodes.deletedAt)} IS NULL
+  `;
+}
+
+/** Reads legacy live disjoint rows under the same schema fence as the write. */
+export function buildAtomicNodeDisjointConflictsWithSchemaFence(
+  tables: Tables,
+  entries: readonly AtomicNodeClaimEntry[],
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  assertClaimEntries(entries, schemaFence);
+  const conflicts = disjointConflictPredicate(
+    tables,
+    entries,
+    "atomic_node_disjoint_input",
+  );
+  if (conflicts === undefined) {
+    throw new CompilerInvariantError(
+      "An atomic disjoint conflict read requires a disjoint claim.",
+    );
+  }
+  return sql`
+    WITH ${schemaFenceCte(tables, schemaFence, schemaLockClause)}
+    SELECT conflict.*
+    FROM (${conflicts}) AS conflict
+    CROSS JOIN ${sql.identifier(SCHEMA_FENCE_ALIAS)}
+    ORDER BY conflict.ordinal
+  `;
 }
 
 function claimOf(item: AtomicNodeClaimEntry): NodeInsertClaim {
@@ -307,6 +423,13 @@ export function buildAtomicNodeClaimGatePredicateWithSchemaFence(
   const target = sql.identifier("candidate_claim");
   const targetColumn = (column: Readonly<{ name: string }>): SQL =>
     sql`${target}.${quotedColumn(column)}`;
+  const disjointConflicts = disjointConflictPredicate(
+    tables,
+    entries,
+    "atomic_node_disjoint_gate_input",
+  );
+  const disjointGate =
+    disjointConflicts === undefined ? sql`` : sql`AND NOT EXISTS (${disjointConflicts})`;
 
   return sql`
     EXISTS (
@@ -330,6 +453,7 @@ export function buildAtomicNodeClaimGatePredicateWithSchemaFence(
             AND ${targetColumn(uniques.deletedAt)} IS NULL
         )
       )
+      ${disjointGate}
     )
   `;
 }
@@ -377,6 +501,52 @@ export function buildAtomicNodeClaimCleanupWithSchemaFence(
           AND ${nodes.kind} = ${targetColumn(uniques.concreteKind)}
           AND ${nodes.id} = ${targetColumn(uniques.nodeId)}
           AND ${nodes.deletedAt} IS NULL
+      )
+  `;
+}
+
+/**
+ * Releases every claim owned by nodes tombstoned by this exact atomic delete.
+ *
+ * Owner-based cleanup deliberately avoids reconstructing uniqueness keys from
+ * preimages. The timestamp predicate binds the side effect to rows changed by
+ * this program; a stale fence or an already-deleted input therefore removes no
+ * claim.
+ */
+export function buildAtomicDeletedNodeClaimReleaseWithSchemaFence(
+  tables: Tables,
+  input: Readonly<{
+    graphId: string;
+    kind: string;
+    ids: readonly string[];
+    timestamp: string;
+  }>,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { nodes, uniques } = tables;
+  const owner = sql.identifier("atomic_deleted_claim_owner");
+  const ownerColumn = (column: Readonly<{ name: string }>): SQL =>
+    sql`${owner}.${quotedColumn(column)}`;
+  return sql`
+    WITH ${schemaFenceCte(tables, schemaFence, schemaLockClause)}
+    UPDATE ${uniques} AS ${owner}
+    SET ${quotedColumn(uniques.deletedAt)} = ${input.timestamp}
+    WHERE EXISTS (SELECT 1 FROM ${sql.identifier(SCHEMA_FENCE_ALIAS)})
+      AND ${ownerColumn(uniques.graphId)} = ${input.graphId}
+      AND ${ownerColumn(uniques.concreteKind)} = ${input.kind}
+      AND ${ownerColumn(uniques.deletedAt)} IS NULL
+      AND ${ownerColumn(uniques.nodeId)} IN (${sql.join(
+        input.ids.map((id) => sql`${id}`),
+        sql`, `,
+      )})
+      AND EXISTS (
+        SELECT 1
+        FROM ${nodes}
+        WHERE ${nodes.graphId} = ${ownerColumn(uniques.graphId)}
+          AND ${nodes.kind} = ${ownerColumn(uniques.concreteKind)}
+          AND ${nodes.id} = ${ownerColumn(uniques.nodeId)}
+          AND ${nodes.deletedAt} = ${input.timestamp}
       )
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/operations/atomic-node-claims.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/atomic-node-claims.ts
@@ -56,8 +56,6 @@ const CLAIM_INPUT_COLUMNS = [
 const DISJOINT_INPUT_COLUMNS = [
   "ordinal",
   "graph_id",
-  "axis",
-  "constraint_name",
   "key",
   "node_id",
   "attempted_kind",
@@ -172,8 +170,6 @@ function disjointInputValues(
         (
           ${item.ordinal},
           ${item.entry.params.graphId},
-          ${claim.axis},
-          ${claim.constraintName},
           ${claim.key},
           ${item.entry.params.id},
           ${item.entry.params.kind},

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -61,9 +61,11 @@ import type { PostgresTables } from "../schema/postgres";
 import type { SqliteTables } from "../schema/sqlite";
 import {
   type AtomicNodeClaimEntry,
+  buildAtomicDeletedNodeClaimReleaseWithSchemaFence,
   buildAtomicNodeClaimCleanupWithSchemaFence,
   buildAtomicNodeClaimGatePredicateWithSchemaFence,
   buildAtomicNodeClaimUpsertWithSchemaFence,
+  buildAtomicNodeDisjointConflictsWithSchemaFence,
 } from "./atomic-node-claims";
 import { buildClearGraph, type ClearGraphStatement } from "./clear";
 import {
@@ -299,6 +301,21 @@ export type CommonOperationStrategy = Readonly<{
   ) => SQL;
   buildAtomicNodeClaimCleanupWithSchemaFence: (
     entries: readonly AtomicNodeClaimEntry[],
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
+  buildAtomicNodeDisjointConflictsWithSchemaFence: (
+    entries: readonly AtomicNodeClaimEntry[],
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
+  buildAtomicDeletedNodeClaimReleaseWithSchemaFence: (
+    input: Readonly<{
+      graphId: string;
+      kind: string;
+      ids: readonly string[];
+      timestamp: string;
+    }>,
     schemaFence: SchemaWriteFenceParams,
     schemaLockClause: SQL,
   ) => SQL;
@@ -1015,6 +1032,35 @@ function createCommonOperationStrategy(
       return buildAtomicNodeClaimCleanupWithSchemaFence(
         tables,
         entries,
+        schemaFence,
+        schemaLockClause,
+      );
+    },
+    buildAtomicNodeDisjointConflictsWithSchemaFence(
+      entries: readonly AtomicNodeClaimEntry[],
+      schemaFence: SchemaWriteFenceParams,
+      schemaLockClause: SQL,
+    ): SQL {
+      return buildAtomicNodeDisjointConflictsWithSchemaFence(
+        tables,
+        entries,
+        schemaFence,
+        schemaLockClause,
+      );
+    },
+    buildAtomicDeletedNodeClaimReleaseWithSchemaFence(
+      input: Readonly<{
+        graphId: string;
+        kind: string;
+        ids: readonly string[];
+        timestamp: string;
+      }>,
+      schemaFence: SchemaWriteFenceParams,
+      schemaLockClause: SQL,
+    ): SQL {
+      return buildAtomicDeletedNodeClaimReleaseWithSchemaFence(
+        tables,
+        input,
         schemaFence,
         schemaLockClause,
       );

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -154,6 +154,8 @@ export type {
   AtomicNodeBatchIdSource,
   AtomicNodeBatchInput,
   AtomicNodeBatchResultMode,
+  AtomicNodeClaimFamily,
+  AtomicNodeClaimSupport,
   AtomicNodeDeleteBatchExecutor,
   AtomicNodeDeleteBatchInput,
   AtomicNodeResolvedMutationSetExecutor,

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -11,6 +11,7 @@ import {
   type AtomicEdgeMutationProgramExecutor,
   type AtomicEdgeResolvedUpdateBatchExecutor,
   type AtomicNodeBatchExecutor as BackendAtomicNodeBatchExecutor,
+  type AtomicNodeClaimFamily,
   type AtomicNodeDeleteBatchExecutor,
   type AtomicNodeResolvedMutationSetExecutor,
   type AtomicNodeResolvedUpdateBatchExecutor,
@@ -82,12 +83,20 @@ export function resolveAtomicNodeBatchExecutor(
   if (input.inputs.length === 0 || input.identityEnabled) return;
   const profile = resolveAtomicMutationProfile(input);
   if (profile?.createNodes === undefined) return;
+  const supportedClaimFamilies = new Set<AtomicNodeClaimFamily>(
+    profile.createNodes.claimSupport?.families,
+  );
 
   const registrations = input.inputs.map((item) => {
     if (!hasOwnKey(input.graph.nodes, item.kind)) return false;
     const registration = input.graph.nodes[item.kind];
     if (registration === undefined) return false;
-    if (input.registry.getDisjointKinds(item.kind).length > 0) return false;
+    if (
+      input.registry.getDisjointKinds(item.kind).length > 0 &&
+      !supportedClaimFamilies.has("disjointness")
+    ) {
+      return false;
+    }
     if (getSearchableFields(registration.type.schema).length > 0) return false;
     if (getEmbeddingFields(registration.type.schema).length > 0) return false;
     return registration;
@@ -99,6 +108,7 @@ export function resolveAtomicNodeBatchExecutor(
       registration !== false && (registration.unique ?? []).length > 0,
   );
   if (hasDeclaredClaims) {
+    if (!supportedClaimFamilies.has("uniqueness")) return;
     if (input.inputs.some((item) => item.id !== undefined)) return;
     if (
       registrations.some(
@@ -228,8 +238,21 @@ export function resolveAtomicNodeDeleteBatchExecutor(
   if (!hasOwnKey(input.graph.nodes, input.kind)) return;
   const registration = input.graph.nodes[input.kind];
   if (registration === undefined) return;
-  if (input.registry.getDisjointKinds(input.kind).length > 0) return;
-  if ((registration.unique ?? []).length > 0) return;
+  const executor = resolveAtomicMutationProfile(input)?.deleteNodes;
+  if (executor === undefined) return;
+  const releasedClaimFamilies = new Set(executor.releasedClaimFamilies);
+  if (
+    input.registry.getDisjointKinds(input.kind).length > 0 &&
+    !releasedClaimFamilies.has("disjointness")
+  ) {
+    return;
+  }
+  if (
+    (registration.unique ?? []).length > 0 &&
+    !releasedClaimFamilies.has("uniqueness")
+  ) {
+    return;
+  }
   if (
     registration.onDelete !== undefined &&
     registration.onDelete !== "restrict"
@@ -238,7 +261,7 @@ export function resolveAtomicNodeDeleteBatchExecutor(
   }
   if (getSearchableFields(registration.type.schema).length > 0) return;
   if (getEmbeddingFields(registration.type.schema).length > 0) return;
-  return resolveAtomicMutationProfile(input)?.deleteNodes;
+  return executor;
 }
 
 export type AtomicNodeResolvedUpdateEligibilityInput =
@@ -266,7 +289,6 @@ function isAtomicResolvedNodeKindEligible(
   const registration = input.graph.nodes[input.kind];
   return (
     registration !== undefined &&
-    input.registry.getDisjointKinds(input.kind).length === 0 &&
     (registration.unique ?? []).length === 0 &&
     getSearchableFields(registration.type.schema).length === 0 &&
     getEmbeddingFields(registration.type.schema).length === 0
@@ -329,6 +351,10 @@ export function resolveAtomicNodeResolvedMutationSetExecutor(
 ): AtomicNodeResolvedMutationSetExecutor | undefined {
   const entryCount = input.creates.length + input.updateCount;
   if (entryCount === 0 || !isAtomicResolvedNodeKindEligible(input)) return;
+  // A mixed set may create rows, so its program must carry disjoint claim
+  // acquisition and refusal. Update-only sets owe no disjoint transition and
+  // are independently eligible through `updateNodes`.
+  if (input.registry.getDisjointKinds(input.kind).length > 0) return;
   if (
     input.creates.some(
       (item) => item.kind !== input.kind || item.id === undefined,

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -11,11 +11,11 @@ import {
   type AtomicEdgeMutationProgramExecutor,
   type AtomicEdgeResolvedUpdateBatchExecutor,
   type AtomicNodeBatchExecutor as BackendAtomicNodeBatchExecutor,
-  type AtomicNodeClaimFamily,
   type AtomicNodeDeleteBatchExecutor,
   type AtomicNodeResolvedMutationSetExecutor,
   type AtomicNodeResolvedUpdateBatchExecutor,
   resolveAtomicMutationPrograms,
+  supportsAtomicNodeClaimFamily,
 } from "../../backend/capabilities/atomic-mutation-program";
 import {
   type GraphBackend,
@@ -83,9 +83,7 @@ export function resolveAtomicNodeBatchExecutor(
   if (input.inputs.length === 0 || input.identityEnabled) return;
   const profile = resolveAtomicMutationProfile(input);
   if (profile?.createNodes === undefined) return;
-  const supportedClaimFamilies = new Set<AtomicNodeClaimFamily>(
-    profile.createNodes.claimSupport?.families,
-  );
+  const claimSupport = profile.createNodes.claimSupport;
 
   const registrations = input.inputs.map((item) => {
     if (!hasOwnKey(input.graph.nodes, item.kind)) return false;
@@ -93,7 +91,7 @@ export function resolveAtomicNodeBatchExecutor(
     if (registration === undefined) return false;
     if (
       input.registry.getDisjointKinds(item.kind).length > 0 &&
-      !supportedClaimFamilies.has("disjointness")
+      !supportsAtomicNodeClaimFamily(claimSupport, "disjointness")
     ) {
       return false;
     }
@@ -108,7 +106,7 @@ export function resolveAtomicNodeBatchExecutor(
       registration !== false && (registration.unique ?? []).length > 0,
   );
   if (hasDeclaredClaims) {
-    if (!supportedClaimFamilies.has("uniqueness")) return;
+    if (!supportsAtomicNodeClaimFamily(claimSupport, "uniqueness")) return;
     if (input.inputs.some((item) => item.id !== undefined)) return;
     if (
       registrations.some(

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -52,6 +52,7 @@ import {
   type AtomicNodeDeleteBatchExecutor,
   AtomicNodeDeleteRestrictedRefusalError,
   type AtomicNodeResolvedUpdateBatchExecutor,
+  supportsAtomicNodeClaims,
 } from "../../backend/capabilities/atomic-mutation-program";
 import { isBundledRootAutocommitEligible } from "../../backend/capabilities/autocommit-single-statement";
 import { bindExtraIfReachable } from "../../backend/capabilities/bind";
@@ -1709,12 +1710,10 @@ function atomicNodeBatchEntries(
       claim,
     });
   }
-  if (
-    entries.filter((entry) => entry.claim !== undefined).length >
-    (claimSupport?.maxEntries ?? 0)
-  ) {
-    return;
-  }
+  const claims = entries.flatMap((entry) =>
+    entry.claim === undefined ? [] : [entry.claim],
+  );
+  if (!supportsAtomicNodeClaims(claimSupport, claims)) return;
   return entries;
 }
 

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -48,6 +48,7 @@ import { type z } from "zod";
 
 import {
   type AtomicNodeBatchEntry,
+  type AtomicNodeClaimSupport,
   type AtomicNodeDeleteBatchExecutor,
   AtomicNodeDeleteRestrictedRefusalError,
   type AtomicNodeResolvedUpdateBatchExecutor,
@@ -59,7 +60,7 @@ import {
   UNIQUE_SIDECAR_BATCH,
 } from "../../backend/capabilities/bundle-registry";
 import {
-  rephaseNonTransactionalNodeClaimPlan,
+  rephaseAtomicNodeClaimPlan,
   supportsNodeCreatePlan,
   supportsNodeInsertProjections,
 } from "../../backend/capabilities/node-insert-projections";
@@ -145,6 +146,7 @@ import {
   type NodeClaimItem,
   type NodeCreateClaimPlan,
   planNodeCreateClaims,
+  refuseNodeCreateClaimError,
 } from "../claims/node-claims";
 import { type UpsertDirtyCheck } from "../collections/coalesce";
 import {
@@ -1649,7 +1651,7 @@ async function prepareAtomicBatchCreates<G extends GraphDef>(
 
 function atomicNodeBatchEntries(
   preparedCreates: readonly NodeCreatePrepared[],
-  maxClaimedEntries: number,
+  claimSupport: AtomicNodeClaimSupport | undefined,
 ): readonly AtomicNodeBatchEntry[] | undefined {
   const entries: AtomicNodeBatchEntry[] = [];
   const ownerByClaimTarget = new Map<
@@ -1665,14 +1667,17 @@ function atomicNodeBatchEntries(
       continue;
     }
 
-    const rephased = rephaseNonTransactionalNodeClaimPlan({
-      entity: "node",
-      params: prepared.insertParams,
-      idGenerated: !prepared.idProvided,
-      mode: { kind: "ordinary" },
-      claims: prepared.claimPlan.claims,
-      projections: [],
-    });
+    const rephased = rephaseAtomicNodeClaimPlan(
+      {
+        entity: "node",
+        params: prepared.insertParams,
+        idGenerated: !prepared.idProvided,
+        mode: { kind: "ordinary" },
+        claims: prepared.claimPlan.claims,
+        projections: [],
+      },
+      claimSupport,
+    );
     if (rephased?.claims.length !== 1) return;
     const claim = rephased.claims[0];
     if (claim === undefined) return;
@@ -1684,33 +1689,52 @@ function atomicNodeBatchEntries(
     ]);
     const existingOwner = ownerByClaimTarget.get(targetKey);
     if (existingOwner !== undefined) {
-      if (claim.verdict.kind !== "uniqueness") return;
-      throw new UniquenessError({
+      const error = new UniquenessError({
         constraintName: claim.constraintName,
         kind: existingOwner.kind,
         existingId: existingOwner.id,
         newId: prepared.id,
-        fields: claim.verdict.fields,
+        fields: claim.verdict.kind === "uniqueness" ? claim.verdict.fields : [],
         axis: claim.axis,
       });
+      refuseNodeCreateClaimError(error, prepared.claimPlan);
     }
     ownerByClaimTarget.set(targetKey, {
       kind: prepared.kind,
       id: prepared.id,
     });
     entries.push({
-      idSource: "generated",
+      idSource: prepared.idProvided ? "caller" : "generated",
       params: prepared.insertParams,
       claim,
     });
   }
   if (
     entries.filter((entry) => entry.claim !== undefined).length >
-    maxClaimedEntries
+    (claimSupport?.maxEntries ?? 0)
   ) {
     return;
   }
   return entries;
+}
+
+async function withAtomicNodeClaimTranslation<TResult>(
+  preparedCreates: readonly NodeCreatePrepared[],
+  execute: () => Promise<TResult>,
+): Promise<TResult> {
+  try {
+    return await execute();
+  } catch (error) {
+    refuseNodeCreateClaimError(error, {
+      entries: preparedCreates.flatMap(
+        (prepared) => prepared.claimPlan.entries,
+      ),
+      claims: preparedCreates.flatMap((prepared) => prepared.claimPlan.claims),
+      verdicts: preparedCreates.flatMap(
+        (prepared) => prepared.claimPlan.verdicts,
+      ),
+    });
+  }
 }
 
 /**
@@ -2341,15 +2365,19 @@ export async function executeNodeCreateNoReturnBatch<G extends GraphDef>(
     );
     const entries = atomicNodeBatchEntries(
       preparedCreates,
-      atomicExecutor.maxClaimedEntries ?? 0,
+      atomicExecutor.claimSupport,
     );
     if (entries !== undefined) {
       const schemaFence = {
         graphId: ctx.graphId,
         expectedVersion: requireDefined(ctx.schemaVersion),
       };
-      const insertedCount = await withAlreadyExistsTranslation("node", () =>
-        atomicExecutor({ entries, resultMode: "count", schemaFence }),
+      const insertedCount = await withAtomicNodeClaimTranslation(
+        preparedCreates,
+        () =>
+          withAlreadyExistsTranslation("node", () =>
+            atomicExecutor({ entries, resultMode: "count", schemaFence }),
+          ),
       );
       if (insertedCount === 0) {
         await diagnoseFusedSchemaFenceNoRow(ctx, backend);
@@ -2450,15 +2478,19 @@ export async function executeNodeCreateBatch<G extends GraphDef>(
     );
     const entries = atomicNodeBatchEntries(
       preparedCreates,
-      atomicExecutor.maxClaimedEntries ?? 0,
+      atomicExecutor.claimSupport,
     );
     if (entries !== undefined) {
       const schemaFence = {
         graphId: ctx.graphId,
         expectedVersion: requireDefined(ctx.schemaVersion),
       };
-      const returnedRows = await withAlreadyExistsTranslation("node", () =>
-        atomicExecutor({ entries, resultMode: "rows", schemaFence }),
+      const returnedRows = await withAtomicNodeClaimTranslation(
+        preparedCreates,
+        () =>
+          withAlreadyExistsTranslation("node", () =>
+            atomicExecutor({ entries, resultMode: "rows", schemaFence }),
+          ),
       );
       if (returnedRows.length === 0) {
         await diagnoseFusedSchemaFenceNoRow(ctx, backend);
@@ -2939,7 +2971,7 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
     creates,
     backend,
   );
-  const createEntries = atomicNodeBatchEntries(preparedCreates, 0);
+  const createEntries = atomicNodeBatchEntries(preparedCreates, undefined);
   if (createEntries === undefined) {
     throw new CompilerInvariantError(
       "An eligible resolved node mutation set produced unsupported create claims.",

--- a/packages/typegraph/tests/atomic-generated-node-batch-pglite.test.ts
+++ b/packages/typegraph/tests/atomic-generated-node-batch-pglite.test.ts
@@ -4,6 +4,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { resolveBundledRootAtomicMutationPrograms } from "../src/backend/capabilities/atomic-mutation-program";
 import {
   type AtomicNodeClaimEntry,
   buildAtomicNodeClaimCleanupWithSchemaFence,
@@ -17,7 +18,8 @@ import { createLocalPgliteBackend } from "../src/backend/postgres/pglite";
 import type { SchemaWriteFenceParams } from "../src/backend/types";
 import { computeUniqueKey } from "../src/constraints";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
-import { RestrictedDeleteError } from "../src/errors";
+import { DisjointError, RestrictedDeleteError } from "../src/errors";
+import { disjointWith } from "../src/ontology";
 import { createStoreWithSchema } from "../src/store";
 
 const UniquePerson = defineNode("UniquePerson", {
@@ -57,6 +59,13 @@ const deleteGraph = defineGraph({
       cardinality: "many",
     },
   },
+});
+const Rival = defineNode("Rival", { schema: z.object({ name: z.string() }) });
+const disjointGraph = defineGraph({
+  id: "atomic-node-disjoint-pglite",
+  nodes: { PlainPerson: { type: PlainPerson }, Rival: { type: Rival } },
+  edges: {},
+  ontology: [disjointWith(PlainPerson, Rival)],
 });
 
 const schemaFence = { graphId: graph.id, expectedVersion: 1 } as const;
@@ -227,6 +236,31 @@ describe("constrained generated-node atomic SQL on PGlite", () => {
     await expect(
       store.nodes.PlainPerson.getById(connected.id),
     ).resolves.toBeDefined();
+  });
+
+  it("refuses a legacy disjoint row through the PostgreSQL atomic program", async () => {
+    const directBackend = createPostgresBackend(backend.db, { vector: false });
+    const [store] = await createStoreWithSchema(disjointGraph, directBackend);
+    expect(
+      resolveBundledRootAtomicMutationPrograms(directBackend)?.createNodes
+        ?.claimSupport?.families,
+    ).toContain("disjointness");
+    await directBackend.insertNode({
+      graphId: disjointGraph.id,
+      kind: Rival.kind,
+      id: "shared-id",
+      props: { name: "Legacy rival" },
+    });
+
+    await expect(
+      store.nodes.PlainPerson.bulkInsert([
+        { id: "sibling", props: { name: "Sibling" } },
+        { id: "shared-id", props: { name: "Conflict" } },
+      ]),
+    ).rejects.toBeInstanceOf(DisjointError);
+
+    await expect(store.nodes.PlainPerson.count()).resolves.toBe(0);
+    await expect(store.nodes.Rival.count()).resolves.toBe(1);
   });
 
   it("returns the incumbent owner and gates a conflicting generated node", async () => {

--- a/packages/typegraph/tests/atomic-generated-node-batch-pglite.test.ts
+++ b/packages/typegraph/tests/atomic-generated-node-batch-pglite.test.ts
@@ -243,8 +243,8 @@ describe("constrained generated-node atomic SQL on PGlite", () => {
     const [store] = await createStoreWithSchema(disjointGraph, directBackend);
     expect(
       resolveBundledRootAtomicMutationPrograms(directBackend)?.createNodes
-        ?.claimSupport?.families,
-    ).toContain("disjointness");
+        ?.claimSupport?.maxEntriesByFamily.disjointness,
+    ).toBeGreaterThan(0);
     await directBackend.insertNode({
       graphId: disjointGraph.id,
       kind: Rival.kind,

--- a/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
@@ -18,6 +18,7 @@ import {
   registerAtomicMutationPrograms,
   resolveAtomicMutationPrograms,
   resolveBundledRootAtomicMutationPrograms,
+  supportsAtomicNodeClaims,
 } from "../src/backend/capabilities/atomic-mutation-program";
 import {
   type AtomicSqlBatchExecutor,
@@ -32,7 +33,7 @@ import {
 import { tables as postgresTables } from "../src/backend/drizzle/schema/postgres";
 import { tables as sqliteTables } from "../src/backend/drizzle/schema/sqlite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
-import type { GraphBackend } from "../src/backend/types";
+import type { GraphBackend, NodeInsertClaim } from "../src/backend/types";
 import { defineGraph, defineNode } from "../src/core";
 import { ConfigurationError } from "../src/errors";
 import {
@@ -46,6 +47,13 @@ type RefusalConstraints = Pick<
   CommonOperationStrategy,
   "atomicEdgeRefusalConstraints" | "atomicNodeRefusalConstraints"
 >;
+
+function repeatClaim(
+  claim: NodeInsertClaim,
+  count: number,
+): readonly NodeInsertClaim[] {
+  return Array.from({ length: count }, () => claim);
+}
 
 const CustomNode = defineNode("CustomNode", {
   schema: z.object({ name: z.string() }),
@@ -339,7 +347,7 @@ describe("atomic mutation program execution profile", () => {
       executeCustomNodeBatch.bind(undefined);
     Object.defineProperty(createNodes, "claimSupport", {
       configurable: true,
-      value: { families: ["uniqueness"], maxEntries: -1 },
+      value: { maxEntriesByFamily: { uniqueness: -1 } },
     });
 
     const error = captureThrown(() =>
@@ -350,7 +358,7 @@ describe("atomic mutation program execution profile", () => {
       details: {
         code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
         family: "createNodes",
-        limit: "claimSupport.maxEntries",
+        limit: "claimSupport.maxEntriesByFamily.uniqueness",
       },
     });
     expect(hasAtomicMutationProgramRegistration(backend)).toBe(false);
@@ -363,7 +371,7 @@ describe("atomic mutation program execution profile", () => {
       executeCustomNodeBatch.bind(undefined);
     Object.defineProperty(createNodes, "claimSupport", {
       configurable: true,
-      value: { families: ["unknown"], maxEntries: 1 },
+      value: { maxEntriesByFamily: { unknown: 1 } },
     });
 
     const error = captureThrown(() =>
@@ -374,10 +382,76 @@ describe("atomic mutation program execution profile", () => {
       details: {
         code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
         family: "createNodes",
-        limit: "claimSupport.families",
+        limit: "claimSupport.maxEntriesByFamily",
       },
     });
     expect(hasAtomicMutationProgramRegistration(backend)).toBe(false);
+  });
+
+  it("accepts an empty claim-support envelope as an honest opt-out", () => {
+    const backend = createCustomAtomicRoot();
+    registerAtomicSqlProgram(backend, emptyAtomicBatch);
+    const createNodes: AtomicNodeBatchExecutor =
+      executeCustomNodeBatch.bind(undefined);
+    Object.defineProperty(createNodes, "claimSupport", {
+      configurable: true,
+      value: { maxEntriesByFamily: {} },
+    });
+
+    expect(() =>
+      registerAtomicMutationPrograms(backend, { createNodes }),
+    ).not.toThrow();
+    expect(hasAtomicMutationProgramRegistration(backend)).toBe(true);
+  });
+
+  it("applies pure and mixed claim-family ceilings independently", () => {
+    const uniquenessClaim = {
+      axis: "Person",
+      constraintName: "person-name",
+      key: "name",
+      placement: "pre-insert",
+      verdict: {
+        kind: "uniqueness",
+        fields: ["name"],
+        probeAxes: ["Person"],
+      },
+    } as const satisfies NodeInsertClaim;
+    const disjointnessClaim = {
+      axis: "Person|Rival",
+      constraintName: "disjoint",
+      key: "id",
+      placement: "pre-insert",
+      verdict: { kind: "disjointness", conflictingKinds: ["Rival"] },
+    } as const satisfies NodeInsertClaim;
+    const support = {
+      maxEntriesByFamily: { uniqueness: 14, disjointness: 7 },
+      maxMixedEntries: 7,
+    } as const;
+
+    expect(
+      supportsAtomicNodeClaims(support, repeatClaim(uniquenessClaim, 14)),
+    ).toBe(true);
+    expect(
+      supportsAtomicNodeClaims(support, repeatClaim(uniquenessClaim, 15)),
+    ).toBe(false);
+    expect(
+      supportsAtomicNodeClaims(support, repeatClaim(disjointnessClaim, 7)),
+    ).toBe(true);
+    expect(
+      supportsAtomicNodeClaims(support, repeatClaim(disjointnessClaim, 8)),
+    ).toBe(false);
+    expect(
+      supportsAtomicNodeClaims(support, [
+        ...repeatClaim(uniquenessClaim, 6),
+        disjointnessClaim,
+      ]),
+    ).toBe(true);
+    expect(
+      supportsAtomicNodeClaims(support, [
+        ...repeatClaim(uniquenessClaim, 7),
+        disjointnessClaim,
+      ]),
+    ).toBe(false);
   });
 
   it("refuses infinite family limits before publishing the profile", () => {

--- a/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
@@ -337,9 +337,9 @@ describe("atomic mutation program execution profile", () => {
     registerAtomicSqlProgram(backend, emptyAtomicBatch);
     const createNodes: AtomicNodeBatchExecutor =
       executeCustomNodeBatch.bind(undefined);
-    Object.defineProperty(createNodes, "maxClaimedEntries", {
+    Object.defineProperty(createNodes, "claimSupport", {
       configurable: true,
-      value: -1,
+      value: { families: ["uniqueness"], maxEntries: -1 },
     });
 
     const error = captureThrown(() =>
@@ -350,7 +350,31 @@ describe("atomic mutation program execution profile", () => {
       details: {
         code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
         family: "createNodes",
-        limit: "maxClaimedEntries",
+        limit: "claimSupport.maxEntries",
+      },
+    });
+    expect(hasAtomicMutationProgramRegistration(backend)).toBe(false);
+  });
+
+  it("refuses malformed claim-family declarations", () => {
+    const backend = createCustomAtomicRoot();
+    registerAtomicSqlProgram(backend, emptyAtomicBatch);
+    const createNodes: AtomicNodeBatchExecutor =
+      executeCustomNodeBatch.bind(undefined);
+    Object.defineProperty(createNodes, "claimSupport", {
+      configurable: true,
+      value: { families: ["unknown"], maxEntries: 1 },
+    });
+
+    const error = captureThrown(() =>
+      registerAtomicMutationPrograms(backend, { createNodes }),
+    );
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect(error).toMatchObject({
+      details: {
+        code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+        family: "createNodes",
+        limit: "claimSupport.families",
       },
     });
     expect(hasAtomicMutationProgramRegistration(backend)).toBe(false);

--- a/packages/typegraph/tests/atomic-node-batch-backend.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch-backend.test.ts
@@ -72,17 +72,18 @@ function makeNeonDatabase(rows: NeonRows): Readonly<{
 
 describe("bundled root atomic node batch", () => {
   it("dispatches node-delete chunks through one Neon atomic exchange", async () => {
-    const { db, query, transaction } = makeNeonDatabase((sqlText, params) =>
-      sqlText.includes("UPDATE") ?
-        params
-          .filter(
-            (parameter): parameter is string =>
-              typeof parameter === "string" &&
-              parameter.startsWith("delete-person-"),
-          )
-          .map((id) => ({ id }))
-      : [{ version: 1 }],
-    );
+    const { db, query, transaction } = makeNeonDatabase((sqlText, params) => {
+      if (sqlText.includes("typegraph_node_uniques")) return [];
+      return sqlText.includes("UPDATE") ?
+          params
+            .filter(
+              (parameter): parameter is string =>
+                typeof parameter === "string" &&
+                parameter.startsWith("delete-person-"),
+            )
+            .map((id) => ({ id }))
+        : [{ version: 1 }];
+    });
     const backend = createPostgresBackend(db, {
       capabilities: { maxBindParameters: 7 },
       vector: false,
@@ -103,12 +104,17 @@ describe("bundled root atomic node batch", () => {
     ).resolves.toEqual({ affectedCount: 3, schemaFenceMatched: true });
 
     expect(transaction).toHaveBeenCalledOnce();
-    expect(query).toHaveBeenCalledTimes(3);
-    for (const [sqlText, params] of query.mock.calls.slice(0, 2)) {
+    expect(query).toHaveBeenCalledTimes(7);
+    for (const [sqlText, params] of query.mock.calls.slice(0, 3)) {
       expect(sqlText).toContain("UPDATE");
       expect(params.length).toBeLessThanOrEqual(7);
     }
-    expect(query.mock.calls[2]?.[0]).toContain("SELECT");
+    for (const [sqlText, params] of query.mock.calls.slice(3, 6)) {
+      expect(sqlText).toContain("UPDATE");
+      expect(sqlText).toContain("typegraph_node_uniques");
+      expect(params.length).toBeLessThanOrEqual(7);
+    }
+    expect(query.mock.calls[6]?.[0]).toContain("SELECT");
   });
 
   it.each([

--- a/packages/typegraph/tests/atomic-node-batch-eligibility.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch-eligibility.test.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { DatabaseOperationError, StaleVersionError } from "../src";
 import {
   type AtomicNodeBatchInput,
+  type AtomicNodeDeleteBatchInput,
   markBundledRootAtomicMutationPrograms,
   markBundledRootAtomicNodeBatch,
 } from "../src/backend/capabilities/atomic-mutation-program";
@@ -189,7 +190,12 @@ function createFakeAtomicNodeBatch(onCall?: () => void) {
       input.resultMode === "count" ? input.entries.length : [],
     );
   }
-  return execute;
+  return Object.assign(execute, {
+    claimSupport: {
+      families: ["disjointness", "uniqueness"] as const,
+      maxEntries: 6,
+    },
+  });
 }
 
 function markAtomicRoot(backend: GraphBackend): void {
@@ -202,11 +208,16 @@ function markAtomicDeleteRoot(backend: GraphBackend): void {
   declareAtomicBatchForTest(backend);
   markBundledRootAutocommitEligible(backend);
   markBundledRootAtomicMutationPrograms(backend, {
-    deleteNodes: (deleteInput) =>
-      Promise.resolve({
-        affectedCount: deleteInput.ids.length,
-        schemaFenceMatched: true,
-      }),
+    deleteNodes: Object.assign(
+      (deleteInput: AtomicNodeDeleteBatchInput) =>
+        Promise.resolve({
+          affectedCount: deleteInput.ids.length,
+          schemaFenceMatched: true,
+        }),
+      {
+        releasedClaimFamilies: ["disjointness", "uniqueness"] as const,
+      },
+    ),
   });
 }
 
@@ -229,7 +240,7 @@ describe("atomic node batch eligibility", () => {
     ).toBeDefined();
   });
 
-  it("accepts only generated ids for one same-kind unique constraint", () => {
+  it("accepts generated ids for one same-kind unique constraint", () => {
     const backend = rootBackend(false);
     markAtomicRoot(backend);
 
@@ -239,6 +250,24 @@ describe("atomic node batch eligibility", () => {
         graph: uniqueGraph,
         registry: buildKindRegistry(uniqueGraph),
         inputs: [input],
+        schemaVersion: 1,
+        identityEnabled: false,
+        historyEnabled: false,
+        revisionTrackingEnabled: false,
+      }),
+    ).toBeDefined();
+  });
+
+  it("accepts caller ids for an advertised disjoint claim family", () => {
+    const backend = rootBackend(false);
+    markAtomicRoot(backend);
+
+    expect(
+      resolveAtomicNodeBatchExecutor({
+        backend,
+        graph: disjointGraph,
+        registry: buildKindRegistry(disjointGraph),
+        inputs: [{ ...input, id: "shared-id" }],
         schemaVersion: 1,
         identityEnabled: false,
         historyEnabled: false,
@@ -387,7 +416,6 @@ describe("atomic node batch eligibility", () => {
       false,
       false,
     ],
-    ["disjointness", disjointGraph, input, false, false, false],
     [
       "search projection",
       searchableGraph,
@@ -452,7 +480,7 @@ describe("atomic node delete batch eligibility", () => {
     ).rejects.toBeInstanceOf(DatabaseOperationError);
   });
 
-  it("accepts only a sidecar-free exact bundled root", () => {
+  it("accepts an exact bundled root with complete claim cleanup", () => {
     const backend = rootBackend(true);
     markAtomicDeleteRoot(backend);
 
@@ -472,8 +500,6 @@ describe("atomic node delete batch eligibility", () => {
   });
 
   it.each([
-    ["unique claims", uniqueGraph, "Person", false, false, false],
-    ["disjointness claims", disjointGraph, "Person", false, false, false],
     [
       "search projections",
       searchableGraph,

--- a/packages/typegraph/tests/atomic-node-batch-eligibility.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch-eligibility.test.ts
@@ -192,8 +192,8 @@ function createFakeAtomicNodeBatch(onCall?: () => void) {
   }
   return Object.assign(execute, {
     claimSupport: {
-      families: ["disjointness", "uniqueness"] as const,
-      maxEntries: 6,
+      maxEntriesByFamily: { disjointness: 6, uniqueness: 6 },
+      maxMixedEntries: 6,
     },
   });
 }

--- a/packages/typegraph/tests/atomic-node-batch-sql.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch-sql.test.ts
@@ -47,9 +47,34 @@ function buildAtomicSql(
   );
 }
 
+function atomicNodeClaimGateParameterCount(
+  entries: readonly AtomicNodeClaimEntry[],
+  entryCount: number,
+): number {
+  const selected = entries.slice(0, entryCount);
+  const gate = buildAtomicNodeClaimGatePredicateWithSchemaFence(
+    sqliteTables,
+    selected,
+    schemaFence,
+    drizzleSql.empty(),
+  );
+  const first = selected[0];
+  if (first === undefined) throw new Error("Expected a claimed member");
+  const query = buildAtomicNodeBatchWithSchemaFence(
+    sqliteTables,
+    [first.entry],
+    "2026-08-25T00:00:00.000Z",
+    schemaFence,
+    drizzleSql.empty(),
+    "count",
+    gate,
+  );
+  return new SQLiteSyncDialect().sqlToQuery(query).params.length;
+}
+
 describe("schema-fenced atomic node batch SQL", () => {
-  it("pins the D1 disjoint-claim gate ceiling at six members", () => {
-    const entries = Array.from({ length: 7 }, (_value, index) => {
+  it("pins family-scoped D1 claim-gate ceilings", () => {
+    const disjointEntries = Array.from({ length: 8 }, (_value, index) => {
       const id = `person-${index}`;
       return {
         ordinal: index,
@@ -74,30 +99,45 @@ describe("schema-fenced atomic node batch SQL", () => {
         },
       } as const satisfies AtomicNodeClaimEntry;
     });
-    const parameterCounts = [6, 7].map((entryCount) => {
-      const selected = entries.slice(0, entryCount);
-      const gate = buildAtomicNodeClaimGatePredicateWithSchemaFence(
-        sqliteTables,
-        selected,
-        schemaFence,
-        drizzleSql.empty(),
-      );
-      const first = selected[0];
-      if (first === undefined) throw new Error("Expected a claimed member");
-      const query = buildAtomicNodeBatchWithSchemaFence(
-        sqliteTables,
-        [first.entry],
-        "2026-08-25T00:00:00.000Z",
-        schemaFence,
-        drizzleSql.empty(),
-        "count",
-        gate,
-      );
-      return new SQLiteSyncDialect().sqlToQuery(query).params.length;
+    const uniquenessEntries = Array.from({ length: 15 }, (_value, index) => {
+      const id = `unique-person-${index}`;
+      return {
+        ordinal: index,
+        entry: {
+          idSource: "generated",
+          params: {
+            graphId: schemaFence.graphId,
+            kind: "Person",
+            id,
+            props: { name: `Unique Person ${index}` },
+          },
+          claim: {
+            axis: "Person",
+            constraintName: "person-name",
+            key: `unique-name-${index}`,
+            placement: "pre-insert",
+            verdict: {
+              kind: "uniqueness",
+              fields: ["name"],
+              probeAxes: ["Person"],
+            },
+          },
+        },
+      } as const satisfies AtomicNodeClaimEntry;
     });
 
-    expect(parameterCounts[0]).toBeLessThanOrEqual(100);
-    expect(parameterCounts[1]).toBeGreaterThan(100);
+    expect(
+      atomicNodeClaimGateParameterCount(disjointEntries, 7),
+    ).toBeLessThanOrEqual(100);
+    expect(
+      atomicNodeClaimGateParameterCount(disjointEntries, 8),
+    ).toBeGreaterThan(100);
+    expect(
+      atomicNodeClaimGateParameterCount(uniquenessEntries, 14),
+    ).toBeLessThanOrEqual(100);
+    expect(
+      atomicNodeClaimGateParameterCount(uniquenessEntries, 15),
+    ).toBeGreaterThan(100);
   });
 
   it("refuses empty and mixed-source statement inputs", () => {

--- a/packages/typegraph/tests/atomic-node-batch-sql.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch-sql.test.ts
@@ -6,6 +6,10 @@ import { SQLiteSyncDialect } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 
 import {
+  type AtomicNodeClaimEntry,
+  buildAtomicNodeClaimGatePredicateWithSchemaFence,
+} from "../src/backend/drizzle/operations/atomic-node-claims";
+import {
   buildAtomicNodeBatchWithSchemaFence,
   buildInsertNodesBatchWithSchemaFence,
 } from "../src/backend/drizzle/operations/nodes";
@@ -44,6 +48,58 @@ function buildAtomicSql(
 }
 
 describe("schema-fenced atomic node batch SQL", () => {
+  it("pins the D1 disjoint-claim gate ceiling at six members", () => {
+    const entries = Array.from({ length: 7 }, (_value, index) => {
+      const id = `person-${index}`;
+      return {
+        ordinal: index,
+        entry: {
+          idSource: "caller",
+          params: {
+            graphId: schemaFence.graphId,
+            kind: "Person",
+            id,
+            props: { name: `Person ${index}` },
+          },
+          claim: {
+            axis: "disjoint-axis",
+            constraintName: "disjoint-constraint",
+            key: id,
+            placement: "pre-insert",
+            verdict: {
+              kind: "disjointness",
+              conflictingKinds: ["Rival"],
+            },
+          },
+        },
+      } as const satisfies AtomicNodeClaimEntry;
+    });
+    const parameterCounts = [6, 7].map((entryCount) => {
+      const selected = entries.slice(0, entryCount);
+      const gate = buildAtomicNodeClaimGatePredicateWithSchemaFence(
+        sqliteTables,
+        selected,
+        schemaFence,
+        drizzleSql.empty(),
+      );
+      const first = selected[0];
+      if (first === undefined) throw new Error("Expected a claimed member");
+      const query = buildAtomicNodeBatchWithSchemaFence(
+        sqliteTables,
+        [first.entry],
+        "2026-08-25T00:00:00.000Z",
+        schemaFence,
+        drizzleSql.empty(),
+        "count",
+        gate,
+      );
+      return new SQLiteSyncDialect().sqlToQuery(query).params.length;
+    });
+
+    expect(parameterCounts[0]).toBeLessThanOrEqual(100);
+    expect(parameterCounts[1]).toBeGreaterThan(100);
+  });
+
   it("refuses empty and mixed-source statement inputs", () => {
     expect(() => buildAtomicSql([])).toThrow(CompilerInvariantError);
     expect(() =>

--- a/packages/typegraph/tests/atomic-node-batch.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch.test.ts
@@ -321,6 +321,24 @@ describe("plain node batch store contract", () => {
     }
   });
 
+  it("keeps mixed-ID disjoint creates in one atomic submission", async () => {
+    const fixture = await createDisjointFixture();
+    try {
+      const batch = vi.spyOn(fixture.client, "batch");
+
+      const created = await fixture.store.nodes.Person.bulkCreate([
+        { id: "caller", props: { name: "Caller" } },
+        { props: { name: "Generated" } },
+      ]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(created.map((node) => node.name)).toEqual(["Caller", "Generated"]);
+      expect(created[0]?.id).toBe("caller");
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
   it("releases disjoint claims inside the native delete program", async () => {
     const fixture = await createDisjointFixture();
     try {

--- a/packages/typegraph/tests/atomic-node-batch.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import {
+  DisjointError,
   RestrictedDeleteError,
   StaleVersionError,
   UniquenessError,
@@ -16,6 +17,7 @@ import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { computeUniqueKey } from "../src/constraints";
 import { defineEdge, defineGraph, defineNode, searchable } from "../src/core";
+import { disjointWith } from "../src/ontology";
 import { migrateSchema } from "../src/schema";
 import { createStoreWithSchema } from "../src/store";
 
@@ -27,6 +29,16 @@ const graph = defineGraph({
   id: "atomic-node-batch-store",
   nodes: { Person: { type: Person } },
   edges: {},
+});
+
+const Rival = defineNode("Rival", {
+  schema: z.object({ name: z.string() }),
+});
+const disjointGraph = defineGraph({
+  id: "atomic-node-batch-disjoint-store",
+  nodes: { Person: { type: Person }, Rival: { type: Rival } },
+  edges: {},
+  ontology: [disjointWith(Person, Rival)],
 });
 
 const knows = defineEdge("knows", { schema: z.object({}) });
@@ -109,6 +121,18 @@ async function createFallbackFixture() {
   });
   const { backend } = await createLibsqlBackend(client);
   const [store] = await createStoreWithSchema(fallbackGraph, backend);
+  return { backend, client, store, temporaryDirectory };
+}
+
+async function createDisjointFixture() {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "typegraph-atomic-node-batch-disjoint-"),
+  );
+  const client = createClient({
+    url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+  });
+  const { backend } = await createLibsqlBackend(client);
+  const [store] = await createStoreWithSchema(disjointGraph, backend);
   return { backend, client, store, temporaryDirectory };
 }
 
@@ -257,6 +281,84 @@ describe("plain node batch store contract", () => {
       expect(batch).toHaveBeenCalledOnce();
       expect(execute).not.toHaveBeenCalled();
       await expect(fixture.store.nodes.Person.count()).resolves.toBe(2);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("refuses a legacy disjoint row without committing sibling creates", async () => {
+    const fixture = await createDisjointFixture();
+    try {
+      // Model a pre-claim database: the live row exists but no canonical
+      // disjoint reservation accompanies it.
+      await fixture.backend.insertNode({
+        graphId: disjointGraph.id,
+        kind: Rival.kind,
+        id: "shared-id",
+        props: { name: "Legacy rival" },
+      });
+      const batch = vi.spyOn(fixture.client, "batch");
+
+      await expect(
+        fixture.store.nodes.Person.bulkInsert([
+          { id: "sibling", props: { name: "Sibling" } },
+          { id: "shared-id", props: { name: "Conflict" } },
+        ]),
+      ).rejects.toMatchObject({
+        name: DisjointError.name,
+        details: {
+          attemptedKind: Person.kind,
+          conflictingKind: Rival.kind,
+          nodeId: "shared-id",
+        },
+      });
+
+      expect(batch).toHaveBeenCalledOnce();
+      await expect(fixture.store.nodes.Person.count()).resolves.toBe(0);
+      await expect(fixture.store.nodes.Rival.count()).resolves.toBe(1);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("releases disjoint claims inside the native delete program", async () => {
+    const fixture = await createDisjointFixture();
+    try {
+      const person = await fixture.store.nodes.Person.create(
+        { name: "Person" },
+        { id: "reusable-id" },
+      );
+      const batch = vi.spyOn(fixture.client, "batch");
+      const execute = vi.spyOn(fixture.client, "execute");
+
+      await fixture.store.nodes.Person.bulkDelete([person.id]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(execute).not.toHaveBeenCalled();
+      await expect(
+        fixture.store.nodes.Rival.create({ name: "Rival" }, { id: person.id }),
+      ).resolves.toMatchObject({ id: "reusable-id" });
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("releases uniqueness claims inside the native delete program", async () => {
+    const fixture = await createFallbackFixture();
+    try {
+      const original = await fixture.store.nodes.UniquePerson.create({
+        name: "Reusable name",
+      });
+      const batch = vi.spyOn(fixture.client, "batch");
+      const execute = vi.spyOn(fixture.client, "execute");
+
+      await fixture.store.nodes.UniquePerson.bulkDelete([original.id]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(execute).not.toHaveBeenCalled();
+      await expect(
+        fixture.store.nodes.UniquePerson.create({ name: "Reusable name" }),
+      ).resolves.toMatchObject({ name: "Reusable name" });
     } finally {
       await closeFixture(fixture);
     }

--- a/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
+++ b/packages/typegraph/tests/atomic-resolved-update-batch.test.ts
@@ -26,6 +26,7 @@ import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { rowPropsToObject } from "../src/backend/types";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
 import { CompilerInvariantError, DatabaseOperationError } from "../src/errors";
+import { disjointWith } from "../src/ontology";
 import { buildKindRegistry } from "../src/registry";
 import { createStoreWithSchema, createVerifiedStore } from "../src/store";
 import {
@@ -68,6 +69,15 @@ const durableGraph = defineGraph({
       matchIdentity: { name: "label", fields: ["label"] },
     },
   },
+});
+const Rival = defineNode("Rival", {
+  schema: z.object({ name: z.string(), score: z.number() }),
+});
+const disjointGraph = defineGraph({
+  id: "atomic-resolved-update-batch-disjoint",
+  nodes: { Person: { type: Person }, Rival: { type: Rival } },
+  edges: {},
+  ontology: [disjointWith(Person, Rival)],
 });
 
 describe("atomic resolved update batches", () => {
@@ -122,6 +132,45 @@ describe("atomic resolved update batches", () => {
     expect(rows.map((row) => rowPropsToObject(row.props)["score"])).toEqual([
       10, 10,
     ]);
+  });
+
+  it("routes update-only disjoint kinds through the atomic family", async () => {
+    const client = createClient({ url: "file::memory:" });
+    clients.push(client);
+    const installed = await createLibsqlBackend(client);
+    const [store] = await createStoreWithSchema(
+      disjointGraph,
+      installed.backend,
+    );
+    const person = await store.nodes.Person.create(
+      { name: "Before", score: 1 },
+      { id: "person" },
+    );
+    const transactionlessBackend = createSqliteBackend(installed.db, {
+      executionProfile: { isSync: false, transactionMode: "none" },
+    });
+    const [transactionlessStore] = await createVerifiedStore(
+      disjointGraph,
+      transactionlessBackend,
+    );
+    const profile = requireDefined(
+      resolveBundledRootAtomicMutationPrograms(transactionlessBackend),
+    );
+    const updateNodes = vi.fn(requireDefined(profile.updateNodes));
+    const observedUpdateNodes = Object.assign(updateNodes, {
+      maxEntries: requireDefined(profile.updateNodes).maxEntries,
+    });
+    markBundledRootAtomicMutationPrograms(transactionlessBackend, {
+      ...profile,
+      updateNodes: observedUpdateNodes,
+    });
+
+    const [updated] = await transactionlessStore.nodes.Person.bulkUpsertById([
+      { id: person.id, props: { name: "After", score: 2 } },
+    ]);
+
+    expect(updateNodes).toHaveBeenCalledOnce();
+    expect(updated).toMatchObject({ name: "After", score: 2 });
   });
 
   it("updates no node when one preimage moved", async () => {


### PR DESCRIPTION
Fold single-claim node sidecars into the existing atomic mutation-program architecture instead of adding a parallel write path.

- Extend direct node-create programs to acquire and validate one explicitly advertised same-kind uniqueness or disjointness claim, including a legacy live-row disjointness guard, deterministic typed refusal, cleanup, and input-order preservation.
- Extend restricted node-delete programs to soft-release every owned uniqueness or disjointness claim in the same schema-fenced program as the tombstone write.
- Allow update-only disjoint node sets to use the existing resolved-update family because they create no claim transition; mixed create/update sets remain on the complete portable path.
- Replace the generated-uniqueness-only executor limit with family-keyed `claimSupport.maxEntriesByFamily`, an explicit mixed-family ceiling, and `releasedClaimFamilies` metadata so custom backends opt into only the semantics and capacities they can prove. Empty claim support is an honest opt-out; malformed or unsupported declarations fail closed during registration.
- Preserve the existing portable fallback for multiple claims, wider uniqueness scopes, projections, identity, temporal capture, and other unsupported shapes.
- Document the new eligibility envelope, custom-backend contract, D1 bind ceiling, and transport-submission behavior.

## Performance impact

On Neon HTTP, Cloudflare D1, and libSQL, eligible `bulkInsert()` and `bulkCreate()` calls for disjoint kinds now execute as one native transport submission rather than a multi-round-trip transactional claim/read/write sequence. Eligible restricted deletes release claim sidecars in that same single submission. Update-only upserts on disjoint kinds use the established two-exchange resolved-update shape—one authoritative preimage read followed by one atomic write submission—instead of the portable transaction flow.

Session-capable PostgreSQL executes the same closed statement sequence on its pinned transaction session. On D1's 100-parameter budget the constrained-create ceiling is 14 pure same-kind uniqueness claims, seven pure disjointness claims, or seven claimed members in a mixed-family batch. Claimed chunks are partitioned by generated versus caller ID through the same owner as claim-free chunks, so mixed-ID disjoint batches retain the native path. Larger or unsupported shapes fail closed to the portable implementation.

The implementation includes real libSQL and PGlite refusal/rollback coverage, owner-scoped claim-lifecycle coverage, registration validation, bind-budget ratchets, transport inventory assertions, and a mutation check proving the legacy disjointness guard is load-bearing.
