### PR TITLE
perf: batch atomic claim refusal diagnosis

### DIFF
--- a/.changeset/batch-atomic-claim-diagnosis.md
+++ b/.changeset/batch-atomic-claim-diagnosis.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Batch committed-state diagnosis after a refused atomic node-claim program. Bundled backends now recover typed uniqueness and disjointness errors with set-oriented reads instead of sequential per-member probes, while custom scalar fallbacks retain complete input coverage with bounded concurrency and deterministic error selection.

--- a/.changeset/batch-atomic-claim-diagnosis.md
+++ b/.changeset/batch-atomic-claim-diagnosis.md
@@ -2,4 +2,4 @@
 "@nicia-ai/typegraph": minor
 ---
 
-Batch committed-state diagnosis after a refused atomic node-claim program. Bundled backends now recover typed uniqueness and disjointness errors with set-oriented reads instead of sequential per-member probes, while custom scalar fallbacks retain complete input coverage with bounded concurrency and deterministic error selection.
+Batch committed-state diagnosis after a refused atomic node-claim program. Bundled backends now recover typed uniqueness and disjointness errors with set-oriented reads instead of sequential per-member probes, while custom scalar fallbacks use bounded windows, stop once the earliest refusal is known, and retain deterministic error selection.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -205,8 +205,12 @@ existing transaction or fallback path. This per-member budget is distinct from
 the seven unique durable edge identities admitted by the convergence program
 above. A successful program needs no diagnostic reads. A refused claim first
 rolls the entire native batch back, then uses committed-state fence and claim
-reads to recover the same typed error as the portable path; those failure-only
-reads are not part of the successful-write RTT count.
+reads to recover the same typed error as the portable path. Bundled backends
+diagnose the complete refused input with set-oriented node and uniqueness reads
+rather than one probe per member; custom backends without those batch reads use
+32-member concurrency windows while still covering every input and selecting
+the error in input order. These failure-only reads are not part of the
+successful-write RTT count.
 
 Both `edges.bulkInsert(items)` and `edges.bulkCreate(items)` use the same
 schema-fenced atomic program when the store has no history or revision capture.

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -207,10 +207,11 @@ above. A successful program needs no diagnostic reads. A refused claim first
 rolls the entire native batch back, then uses committed-state fence and claim
 reads to recover the same typed error as the portable path. Bundled backends
 diagnose the complete refused input with set-oriented node and uniqueness reads
-rather than one probe per member; custom backends without those batch reads use
-32-member concurrency windows while still covering every input and selecting
-the error in input order. These failure-only reads are not part of the
-successful-write RTT count.
+rather than one probe per member. Custom backends without those batch reads
+advance through 32-member concurrency windows until the earliest refusal can be
+selected in input order; when no claim explains the rollback, every input is
+covered before the honest terminal error. These failure-only reads are not part
+of the successful-write RTT count.
 
 Both `edges.bulkInsert(items)` and `edges.bulkCreate(items)` use the same
 schema-fenced atomic program when the store has no history or revision capture.

--- a/packages/typegraph/src/store/claims/node-claims.ts
+++ b/packages/typegraph/src/store/claims/node-claims.ts
@@ -25,6 +25,7 @@ import {
   type NodeInsertClaim,
   type TransactionBackend,
   type UniqueConstraintBackend,
+  type UniqueRow,
 } from "../../backend/types";
 import { checkWherePredicate, computeUniqueKey } from "../../constraints";
 import { type UniqueConstraint } from "../../core/types";
@@ -35,6 +36,7 @@ import {
 } from "../../errors";
 import { type KindRegistry } from "../../registry/kind-registry";
 import { requireDefined } from "../../utils/presence";
+import { encodeTupleKey } from "../../utils/tuple-key";
 import { constraintFenceRefusal } from "../operations/write-transaction";
 import { type GraphWriteLock } from "../recorded-capture/clock";
 import {
@@ -369,6 +371,60 @@ export function isUniquenessClaimEntry(
   return entry.refusal.kind === "uniqueness";
 }
 
+/** One set-oriented uniqueness read shared by every batch probe consumer. */
+export type NodeUniquenessProbeGroup = Readonly<{
+  nodeKind: string;
+  constraintName: string;
+  keys: readonly string[];
+}>;
+
+/**
+ * THE owner of grouping node uniqueness entries into backend batch reads.
+ *
+ * Preparation-cache priming and post-rollback diagnosis consume the same
+ * groups, including every canonical and legacy axis covered by a scoped claim.
+ * Keeping the grouping here prevents one path from silently probing a narrower
+ * hierarchy than the other.
+ */
+export function groupNodeUniquenessProbes(
+  registry: KindRegistry,
+  items: readonly Readonly<{
+    kind: string;
+    entries: readonly NodeClaimEntry[];
+  }>[],
+): readonly NodeUniquenessProbeGroup[] {
+  type MutableProbeGroup = Readonly<{
+    nodeKind: string;
+    constraintName: string;
+    keys: Set<string>;
+  }>;
+  const groups = new Map<string, MutableProbeGroup>();
+  for (const item of items) {
+    for (const entry of item.entries) {
+      if (!isUniquenessClaimEntry(entry)) continue;
+      for (const nodeKind of uniquenessProbeKinds(
+        item.kind,
+        entry.refusal.constraint.scope,
+        registry,
+      )) {
+        const identity = encodeTupleKey([nodeKind, entry.constraintName]);
+        const group = groups.get(identity) ?? {
+          nodeKind,
+          constraintName: entry.constraintName,
+          keys: new Set<string>(),
+        };
+        group.keys.add(entry.key);
+        groups.set(identity, group);
+      }
+    }
+  }
+  return [...groups.values()].map((group) => ({
+    nodeKind: group.nodeKind,
+    constraintName: group.constraintName,
+    keys: [...group.keys],
+  }));
+}
+
 /**
  * Probes ONE entry's key across every kind its scope covers, the axis first.
  *
@@ -398,8 +454,6 @@ async function probeUniqueKey(
   id: string,
   entry: UniquenessClaimEntry,
 ): Promise<boolean> {
-  const mine: ClaimOwner = { concreteKind: kind, nodeId: id };
-
   // `let` earns its place: the loop must visit EVERY kind in scope to reach its
   // refusal, so the ownership reading cannot be an early return.
   let heldByThisNode = false;
@@ -416,23 +470,42 @@ async function probeUniqueKey(
     });
 
     if (existing === undefined) continue;
-    if (
-      !isSameClaimOwner(
-        { concreteKind: existing.concrete_kind, nodeId: existing.node_id },
-        mine,
-      )
-    ) {
-      throw new UniquenessError({
-        constraintName: entry.constraintName,
-        kind: existing.concrete_kind,
-        existingId: existing.node_id,
-        newId: id,
-        fields: entry.refusal.constraint.fields,
-      });
-    }
+    const refusal = uniquenessClaimRefusal(kind, id, entry, existing);
+    if (refusal !== undefined) throw refusal;
     if (kindToCheck === entry.axis) heldByThisNode = true;
   }
   return heldByThisNode;
+}
+
+/**
+ * THE owner of the conflict verdict for one uniqueness probe result.
+ *
+ * The scalar probe and post-rollback batch diagnosis both call this function,
+ * so owner-pair equality and the public error payload cannot drift between the
+ * portable preflight and the native program's exceptional diagnostic path.
+ */
+export function uniquenessClaimRefusal(
+  kind: string,
+  id: string,
+  entry: UniquenessClaimEntry,
+  existing: UniqueRow,
+): UniquenessError | undefined {
+  const proposedOwner: ClaimOwner = { concreteKind: kind, nodeId: id };
+  if (
+    isSameClaimOwner(
+      { concreteKind: existing.concrete_kind, nodeId: existing.node_id },
+      proposedOwner,
+    )
+  ) {
+    return;
+  }
+  return new UniquenessError({
+    constraintName: entry.constraintName,
+    kind: existing.concrete_kind,
+    existingId: existing.node_id,
+    newId: id,
+    fields: entry.refusal.constraint.fields,
+  });
 }
 
 /**

--- a/packages/typegraph/src/store/claims/node-claims.ts
+++ b/packages/typegraph/src/store/claims/node-claims.ts
@@ -448,11 +448,24 @@ export function groupNodeUniquenessProbes(
  * @throws UniquenessError when a DIFFERENT node holds the key under any kind in
  *   scope.
  */
-async function probeUniqueKey(
+export async function probeUniqueKey(
   ctx: UniquenessProbeContext,
   kind: string,
   id: string,
   entry: UniquenessClaimEntry,
+  lookup: (
+    nodeKind: string,
+    entry: UniquenessClaimEntry,
+  ) => UniqueRow | undefined | Promise<UniqueRow | undefined> = async (
+    nodeKind,
+    claimEntry,
+  ) =>
+    ctx.backend.checkUnique({
+      graphId: ctx.graphId,
+      nodeKind,
+      constraintName: claimEntry.constraintName,
+      key: claimEntry.key,
+    }),
 ): Promise<boolean> {
   // `let` earns its place: the loop must visit EVERY kind in scope to reach its
   // refusal, so the ownership reading cannot be an early return.
@@ -462,12 +475,7 @@ async function probeUniqueKey(
     entry.refusal.constraint.scope,
     ctx.registry,
   )) {
-    const existing = await ctx.backend.checkUnique({
-      graphId: ctx.graphId,
-      nodeKind: kindToCheck,
-      constraintName: entry.constraintName,
-      key: entry.key,
-    });
+    const existing = await lookup(kindToCheck, entry);
 
     if (existing === undefined) continue;
     const refusal = uniquenessClaimRefusal(kind, id, entry, existing);
@@ -484,7 +492,7 @@ async function probeUniqueKey(
  * so owner-pair equality and the public error payload cannot drift between the
  * portable preflight and the native program's exceptional diagnostic path.
  */
-export function uniquenessClaimRefusal(
+function uniquenessClaimRefusal(
   kind: string,
   id: string,
   entry: UniquenessClaimEntry,

--- a/packages/typegraph/src/store/constraints.ts
+++ b/packages/typegraph/src/store/constraints.ts
@@ -34,7 +34,7 @@
  * are what the write paths ask so they take that same per-graph lock whenever
  * one of these probes is in play, and only then.
  */
-import { type GraphEntityReadBackend } from "../backend/types";
+import { type GraphEntityReadBackend, isLiveNodeRow } from "../backend/types";
 import {
   checkCardinality,
   checkDisjointness,
@@ -196,7 +196,7 @@ export async function checkDisjointnessConstraint(
   // For each disjoint kind, check if a node with this ID exists
   for (const disjointKind of disjointKinds) {
     const existing = await ctx.backend.getNode(ctx.graphId, disjointKind, id);
-    if (existing && !existing.deleted_at) {
+    if (existing !== undefined && isLiveNodeRow(existing)) {
       const error = checkDisjointness(id, kind, [disjointKind], ctx.registry);
       if (error) throw error;
     }

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -84,7 +84,11 @@ import {
   type TransactionBackend,
   type UniqueRow,
 } from "../../backend/types";
-import { checkWherePredicate, computeUniqueKey } from "../../constraints";
+import {
+  checkDisjointness,
+  checkWherePredicate,
+  computeUniqueKey,
+} from "../../constraints";
 import { type GraphDef } from "../../core/define-graph";
 import { assertJsonValue } from "../../core/json-value";
 import {
@@ -128,6 +132,7 @@ import type { CompiledSelectSql } from "../../query/sql-intent";
 import { asCompiledRowsSql } from "../../query/sql-intent";
 import { type KindRegistry } from "../../registry/kind-registry";
 import { canonicalEqual } from "../../schema/canonical";
+import { chunk } from "../../utils/array";
 import {
   assertOrderedValidityWindow,
   assertWritableValidityWindow,
@@ -144,11 +149,14 @@ import { type ClaimOwner, uniquenessProbeKinds } from "../claims/axis";
 import {
   checkUniquenessConstraints,
   createUniquenessContext,
+  groupNodeUniquenessProbes,
+  isUniquenessClaimEntry,
   nodeClaimEntries,
   type NodeClaimItem,
   type NodeCreateClaimPlan,
   planNodeCreateClaims,
   refuseNodeCreateClaimError,
+  uniquenessClaimRefusal,
 } from "../claims/node-claims";
 import { type UpsertDirtyCheck } from "../collections/coalesce";
 import {
@@ -1504,58 +1512,29 @@ export async function primeBatchValidationCaches(
     UNIQUE_SIDECAR_BATCH.id,
   );
   if (boundCheckUniqueBatch !== undefined) {
-    interface ProbeGroup {
-      nodeKind: string;
-      constraintName: string;
-      keys: Set<string>;
-    }
-    const groups = new Map<string, ProbeGroup>();
-    for (const draft of drafts) {
-      for (const entry of nodeClaimEntries(
-        ctx.registry,
-        draft.kind,
-        draft.id,
-        draft.validatedProps,
-        draft.uniqueConstraints,
-        "create",
-      )) {
-        // Uniqueness entries only: this primes the reads the UNIQUENESS probe
-        // makes. A disjointness entry's verdict comes from the disjoint
-        // partner's node row, which no `checkUnique` read would supply.
-        if (entry.refusal.kind !== "uniqueness") continue;
-        const constraint = entry.refusal.constraint;
-        const key = entry.key;
-        // Seeded over exactly the kinds the per-row probe reads — the axis and
-        // the legacy kinds — so priming stays a batched substitute for those
-        // reads rather than a narrower set that sends them back to the
-        // database one row at a time.
-        const kindsToCheck = uniquenessProbeKinds(
-          draft.kind,
-          constraint.scope,
+    const groups = groupNodeUniquenessProbes(
+      ctx.registry,
+      drafts.map((draft) => ({
+        kind: draft.kind,
+        entries: nodeClaimEntries(
           ctx.registry,
-        );
-        for (const kindToCheck of kindsToCheck) {
-          const groupKey = encodeTupleKey([kindToCheck, constraint.name]);
-          const group = groups.get(groupKey) ?? {
-            nodeKind: kindToCheck,
-            constraintName: constraint.name,
-            keys: new Set<string>(),
-          };
-          group.keys.add(key);
-          groups.set(groupKey, group);
-        }
-      }
-    }
-    for (const group of groups.values()) {
-      const orderedKeys = [...group.keys];
+          draft.kind,
+          draft.id,
+          draft.validatedProps,
+          draft.uniqueConstraints,
+          "create",
+        ),
+      })),
+    );
+    for (const group of groups) {
       const rows = await boundCheckUniqueBatch.checkUniqueBatch({
         graphId: ctx.graphId,
         nodeKind: group.nodeKind,
         constraintName: group.constraintName,
-        keys: orderedKeys,
+        keys: group.keys,
       });
       const rowsByKey = new Map(rows.map((row) => [row.key, row]));
-      for (const key of orderedKeys) {
+      for (const key of group.keys) {
         seams.seedUniqueRow(
           group.nodeKind,
           group.constraintName,
@@ -1764,6 +1743,208 @@ async function withAtomicNodeClaimTranslation<TResult>(
   }
 }
 
+/** Bounds concurrent custom-backend reads on the exceptional diagnosis path. */
+const ATOMIC_NODE_CLAIM_DIAGNOSTIC_WINDOW_SIZE = 32;
+
+type AtomicNodeClaimDiagnosticVerdict =
+  Readonly<{ kind: "clear" }> | Readonly<{ kind: "refusal"; error: unknown }>;
+
+const ATOMIC_NODE_CLAIM_CLEAR = { kind: "clear" } as const;
+
+async function captureAtomicNodeClaimDiagnosticVerdicts(
+  preparedCreates: readonly NodeCreatePrepared[],
+  diagnose: (prepared: NodeCreatePrepared) => Promise<void>,
+): Promise<readonly AtomicNodeClaimDiagnosticVerdict[]> {
+  const verdicts: AtomicNodeClaimDiagnosticVerdict[] = [];
+  for (const window of chunk(
+    preparedCreates,
+    ATOMIC_NODE_CLAIM_DIAGNOSTIC_WINDOW_SIZE,
+  )) {
+    verdicts.push(
+      ...(await Promise.all(
+        window.map(async (prepared) => {
+          try {
+            await diagnose(prepared);
+            return ATOMIC_NODE_CLAIM_CLEAR;
+          } catch (error) {
+            return { kind: "refusal" as const, error };
+          }
+        }),
+      )),
+    );
+  }
+  return verdicts;
+}
+
+async function runAtomicNodeClaimDiagnosticGroups<T>(
+  groups: readonly T[],
+  read: (group: T) => Promise<void>,
+): Promise<void> {
+  for (const window of chunk(
+    groups,
+    ATOMIC_NODE_CLAIM_DIAGNOSTIC_WINDOW_SIZE,
+  )) {
+    await Promise.all(window.map(async (group) => read(group)));
+  }
+}
+
+async function diagnoseAtomicNodeDisjointness<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  backend: GraphBackend | TransactionBackend,
+  preparedCreates: readonly NodeCreatePrepared[],
+): Promise<readonly AtomicNodeClaimDiagnosticVerdict[]> {
+  const boundGetNodes = bindExtraIfReachable(
+    backend,
+    ctx.batchPointRead.extras.getNodes,
+    BATCH_POINT_READ.id,
+  );
+  const constraintContext: ConstraintContext = {
+    graphId: ctx.graphId,
+    registry: ctx.registry,
+    backend,
+  };
+  if (boundGetNodes === undefined) {
+    return captureAtomicNodeClaimDiagnosticVerdicts(
+      preparedCreates,
+      async (prepared) =>
+        checkDisjointnessConstraint(
+          constraintContext,
+          prepared.kind,
+          prepared.id,
+        ),
+    );
+  }
+
+  type DisjointReadGroup = Readonly<{ kind: string; ids: Set<string> }>;
+  const disjointKindsByInput = preparedCreates.map((prepared) =>
+    ctx.registry.getDisjointKinds(prepared.kind),
+  );
+  const groupsByKind = new Map<string, DisjointReadGroup>();
+  for (const [index, prepared] of preparedCreates.entries()) {
+    for (const kind of requireDefined(disjointKindsByInput[index])) {
+      const group = groupsByKind.get(kind) ?? { kind, ids: new Set<string>() };
+      group.ids.add(prepared.id);
+      groupsByKind.set(kind, group);
+    }
+  }
+
+  const rowsByReference = new Map<string, BackendNodeRow>();
+  await runAtomicNodeClaimDiagnosticGroups(
+    [...groupsByKind.values()],
+    async (group) => {
+      const rows = await boundGetNodes.getNodes(ctx.graphId, group.kind, [
+        ...group.ids,
+      ]);
+      for (const row of rows) {
+        rowsByReference.set(refKey({ kind: row.kind, id: row.id }), row);
+      }
+    },
+  );
+
+  return preparedCreates.map((prepared, index) => {
+    for (const conflictingKind of requireDefined(disjointKindsByInput[index])) {
+      const row = rowsByReference.get(
+        refKey({ kind: conflictingKind, id: prepared.id }),
+      );
+      if (row === undefined || !isLiveNodeRow(row)) continue;
+      const error = checkDisjointness(
+        prepared.id,
+        prepared.kind,
+        [conflictingKind],
+        ctx.registry,
+      );
+      if (error !== undefined) return { kind: "refusal" as const, error };
+    }
+    return ATOMIC_NODE_CLAIM_CLEAR;
+  });
+}
+
+async function diagnoseAtomicNodeUniqueness<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  backend: GraphBackend | TransactionBackend,
+  preparedCreates: readonly NodeCreatePrepared[],
+): Promise<readonly AtomicNodeClaimDiagnosticVerdict[]> {
+  const boundCheckUniqueBatch = bindExtraIfReachable(
+    backend,
+    ctx.uniqueSidecarBatch.extras.checkUniqueBatch,
+    UNIQUE_SIDECAR_BATCH.id,
+  );
+  const uniquenessContext = createUniquenessContext(
+    ctx.graphId,
+    ctx.registry,
+    backend,
+    ctx.uniqueSidecarBatch,
+  );
+  if (boundCheckUniqueBatch === undefined) {
+    return captureAtomicNodeClaimDiagnosticVerdicts(
+      preparedCreates,
+      async (prepared) =>
+        checkUniquenessConstraints(
+          uniquenessContext,
+          prepared.kind,
+          prepared.id,
+          prepared.validatedProps,
+          prepared.uniqueConstraints,
+        ),
+    );
+  }
+
+  const probeItems = preparedCreates.map((prepared) => ({
+    kind: prepared.kind,
+    entries: nodeClaimEntries(
+      ctx.registry,
+      prepared.kind,
+      prepared.id,
+      prepared.validatedProps,
+      prepared.uniqueConstraints,
+      "create",
+    ),
+  }));
+  const groups = groupNodeUniquenessProbes(ctx.registry, probeItems);
+
+  const rowsByTarget = new Map<string, UniqueRow>();
+  await runAtomicNodeClaimDiagnosticGroups(groups, async (group) => {
+    const rows = await boundCheckUniqueBatch.checkUniqueBatch({
+      graphId: ctx.graphId,
+      nodeKind: group.nodeKind,
+      constraintName: group.constraintName,
+      keys: group.keys,
+    });
+    for (const row of rows) {
+      rowsByTarget.set(
+        encodeTupleKey([group.nodeKind, group.constraintName, row.key]),
+        row,
+      );
+    }
+  });
+
+  return preparedCreates.map((prepared, index) => {
+    for (const entry of requireDefined(probeItems[index]).entries) {
+      if (!isUniquenessClaimEntry(entry)) continue;
+      for (const nodeKind of uniquenessProbeKinds(
+        prepared.kind,
+        entry.refusal.constraint.scope,
+        ctx.registry,
+      )) {
+        const existing = rowsByTarget.get(
+          encodeTupleKey([nodeKind, entry.constraintName, entry.key]),
+        );
+        if (existing === undefined) continue;
+        const refusal = uniquenessClaimRefusal(
+          prepared.kind,
+          prepared.id,
+          entry,
+          existing,
+        );
+        if (refusal !== undefined) {
+          return { kind: "refusal" as const, error: refusal };
+        }
+      }
+    }
+    return ATOMIC_NODE_CLAIM_CLEAR;
+  });
+}
+
 /**
  * Diagnoses a database-enforced all-or-nothing claim refusal after rollback.
  *
@@ -1777,33 +1958,31 @@ async function diagnoseAtomicNodeBatchNoRow<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
   backend: GraphBackend | TransactionBackend,
   preparedCreates: readonly NodeCreatePrepared[],
-): Promise<void> {
+): Promise<never> {
   await diagnoseFusedSchemaFenceNoRow(ctx, backend);
-  const constraintContext: ConstraintContext = {
-    graphId: ctx.graphId,
-    registry: ctx.registry,
-    backend,
-  };
-  const uniquenessContext = createUniquenessContext(
-    ctx.graphId,
-    ctx.registry,
-    backend,
-    ctx.uniqueSidecarBatch,
-  );
-  for (const prepared of preparedCreates) {
-    await checkDisjointnessConstraint(
-      constraintContext,
-      prepared.kind,
-      prepared.id,
-    );
-    await checkUniquenessConstraints(
-      uniquenessContext,
-      prepared.kind,
-      prepared.id,
-      prepared.validatedProps,
-      prepared.uniqueConstraints,
-    );
+  const [disjointnessVerdicts, uniquenessVerdicts] = await Promise.all([
+    diagnoseAtomicNodeDisjointness(ctx, backend, preparedCreates),
+    diagnoseAtomicNodeUniqueness(ctx, backend, preparedCreates),
+  ]);
+  for (const [index] of preparedCreates.entries()) {
+    const disjointness = requireDefined(disjointnessVerdicts[index]);
+    if (disjointness.kind === "refusal") throw disjointness.error;
+    const uniqueness = requireDefined(uniquenessVerdicts[index]);
+    if (uniqueness.kind === "refusal") throw uniqueness.error;
   }
+  throw new DatabaseOperationError(
+    "Atomic node batch returned no postimages, but current schema-fence and " +
+      "claim state do not explain the refusal. Database state may have " +
+      "changed after the atomic program rolled back.",
+    {
+      operation: "insert",
+      entity: "node",
+      attempted: preparedCreates.map((prepared) => ({
+        kind: prepared.kind,
+        id: prepared.id,
+      })),
+    },
+  );
 }
 
 /**

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -155,8 +155,8 @@ import {
   type NodeClaimItem,
   type NodeCreateClaimPlan,
   planNodeCreateClaims,
+  probeUniqueKey,
   refuseNodeCreateClaimError,
-  uniquenessClaimRefusal,
 } from "../claims/node-claims";
 import { type UpsertDirtyCheck } from "../collections/coalesce";
 import {
@@ -1755,25 +1755,16 @@ async function captureAtomicNodeClaimDiagnosticVerdicts(
   preparedCreates: readonly NodeCreatePrepared[],
   diagnose: (prepared: NodeCreatePrepared) => Promise<void>,
 ): Promise<readonly AtomicNodeClaimDiagnosticVerdict[]> {
-  const verdicts: AtomicNodeClaimDiagnosticVerdict[] = [];
-  for (const window of chunk(
-    preparedCreates,
-    ATOMIC_NODE_CLAIM_DIAGNOSTIC_WINDOW_SIZE,
-  )) {
-    verdicts.push(
-      ...(await Promise.all(
-        window.map(async (prepared) => {
-          try {
-            await diagnose(prepared);
-            return ATOMIC_NODE_CLAIM_CLEAR;
-          } catch (error) {
-            return { kind: "refusal" as const, error };
-          }
-        }),
-      )),
-    );
-  }
-  return verdicts;
+  return Promise.all(
+    preparedCreates.map(async (prepared) => {
+      try {
+        await diagnose(prepared);
+        return ATOMIC_NODE_CLAIM_CLEAR;
+      } catch (error) {
+        return { kind: "refusal" as const, error };
+      }
+    }),
+  );
 }
 
 async function runAtomicNodeClaimDiagnosticGroups<T>(
@@ -1918,31 +1909,32 @@ async function diagnoseAtomicNodeUniqueness<G extends GraphDef>(
     }
   });
 
-  return preparedCreates.map((prepared, index) => {
-    for (const entry of requireDefined(probeItems[index]).entries) {
-      if (!isUniquenessClaimEntry(entry)) continue;
-      for (const nodeKind of uniquenessProbeKinds(
-        prepared.kind,
-        entry.refusal.constraint.scope,
-        ctx.registry,
-      )) {
-        const existing = rowsByTarget.get(
-          encodeTupleKey([nodeKind, entry.constraintName, entry.key]),
-        );
-        if (existing === undefined) continue;
-        const refusal = uniquenessClaimRefusal(
-          prepared.kind,
-          prepared.id,
-          entry,
-          existing,
-        );
-        if (refusal !== undefined) {
-          return { kind: "refusal" as const, error: refusal };
+  return Promise.all(
+    preparedCreates.map(async (prepared, index) => {
+      for (const entry of requireDefined(probeItems[index]).entries) {
+        if (!isUniquenessClaimEntry(entry)) continue;
+        try {
+          await probeUniqueKey(
+            uniquenessContext,
+            prepared.kind,
+            prepared.id,
+            entry,
+            (nodeKind, claimEntry) =>
+              rowsByTarget.get(
+                encodeTupleKey([
+                  nodeKind,
+                  claimEntry.constraintName,
+                  claimEntry.key,
+                ]),
+              ),
+          );
+        } catch (error) {
+          return { kind: "refusal" as const, error };
         }
       }
-    }
-    return ATOMIC_NODE_CLAIM_CLEAR;
-  });
+      return ATOMIC_NODE_CLAIM_CLEAR;
+    }),
+  );
 }
 
 /**
@@ -1951,8 +1943,8 @@ async function diagnoseAtomicNodeUniqueness<G extends GraphDef>(
  * The atomic program deliberately reports only the rollback sentinel: claim
  * ownership is read again from committed state so a successful sibling chunk
  * can never be mistaken for permission to commit. These are the same portable
- * constraint probes used outside the native program, preserving their typed
- * errors and input order on the failure-only path.
+ * verdict owners used outside the native program, preserving their typed errors
+ * and input order on the failure-only path.
  */
 async function diagnoseAtomicNodeBatchNoRow<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
@@ -1960,15 +1952,38 @@ async function diagnoseAtomicNodeBatchNoRow<G extends GraphDef>(
   preparedCreates: readonly NodeCreatePrepared[],
 ): Promise<never> {
   await diagnoseFusedSchemaFenceNoRow(ctx, backend);
-  const [disjointnessVerdicts, uniquenessVerdicts] = await Promise.all([
-    diagnoseAtomicNodeDisjointness(ctx, backend, preparedCreates),
-    diagnoseAtomicNodeUniqueness(ctx, backend, preparedCreates),
-  ]);
-  for (const [index] of preparedCreates.entries()) {
-    const disjointness = requireDefined(disjointnessVerdicts[index]);
-    if (disjointness.kind === "refusal") throw disjointness.error;
-    const uniqueness = requireDefined(uniquenessVerdicts[index]);
-    if (uniqueness.kind === "refusal") throw uniqueness.error;
+  const hasSetOrientedDiagnosis =
+    bindExtraIfReachable(
+      backend,
+      ctx.batchPointRead.extras.getNodes,
+      BATCH_POINT_READ.id,
+    ) !== undefined &&
+    bindExtraIfReachable(
+      backend,
+      ctx.uniqueSidecarBatch.extras.checkUniqueBatch,
+      UNIQUE_SIDECAR_BATCH.id,
+    ) !== undefined;
+  const diagnosticWindows =
+    hasSetOrientedDiagnosis ?
+      [preparedCreates]
+    : chunk(preparedCreates, ATOMIC_NODE_CLAIM_DIAGNOSTIC_WINDOW_SIZE);
+  for (const window of diagnosticWindows) {
+    const [disjointnessVerdicts, uniquenessVerdicts] =
+      hasSetOrientedDiagnosis ?
+        await Promise.all([
+          diagnoseAtomicNodeDisjointness(ctx, backend, window),
+          diagnoseAtomicNodeUniqueness(ctx, backend, window),
+        ])
+      : [
+          await diagnoseAtomicNodeDisjointness(ctx, backend, window),
+          await diagnoseAtomicNodeUniqueness(ctx, backend, window),
+        ];
+    for (const [index] of window.entries()) {
+      const disjointness = requireDefined(disjointnessVerdicts[index]);
+      if (disjointness.kind === "refusal") throw disjointness.error;
+      const uniqueness = requireDefined(uniquenessVerdicts[index]);
+      if (uniqueness.kind === "refusal") throw uniqueness.error;
+    }
   }
   throw new DatabaseOperationError(
     "Atomic node batch returned no postimages, but current schema-fence and " +

--- a/packages/typegraph/tests/atomic-node-batch.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch.test.ts
@@ -490,6 +490,43 @@ describe("plain node batch store contract", () => {
     }
   });
 
+  it("uses the shared row-liveness verdict during scalar disjoint diagnosis", async () => {
+    const fixture = await createDisjointFixture();
+    try {
+      await fixture.backend.insertNode({
+        graphId: disjointGraph.id,
+        kind: Rival.kind,
+        id: "null-liveness",
+        props: { name: "Legacy rival" },
+      });
+      Object.defineProperty(fixture.backend, "getNodes", {
+        configurable: true,
+        value: undefined,
+      });
+      const getNode = fixture.backend.getNode;
+      vi.spyOn(fixture.backend, "getNode").mockImplementation(
+        async (...args) => {
+          const row = await getNode(...args);
+          if (row === undefined) return;
+          // Deliberately model a third-party backend that violates TypeGraph's
+          // timestamp normalization. Scalar and set reads must still classify
+          // the same row through the shared liveness predicate.
+          // eslint-disable-next-line unicorn/no-null -- null is the malformed transport value under test.
+          return { ...row, deleted_at: null } as never;
+        },
+      );
+
+      const insertion = fixture.store.nodes.Person.bulkInsert([
+        { id: "null-liveness", props: { name: "Proposed" } },
+      ]);
+      const rejection = await insertion.catch((error: unknown) => error);
+      expect(rejection).toBeInstanceOf(DatabaseOperationError);
+      expect(rejection).not.toBeInstanceOf(DisjointError);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
   it("releases disjoint claims inside the native delete program", async () => {
     const fixture = await createDisjointFixture();
     try {
@@ -823,6 +860,38 @@ describe("plain node batch store contract", () => {
 
       expect(scalarClaimProbe).toHaveBeenCalledTimes(65);
       expect(maximumActiveReads).toBe(32);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("stops scalar diagnosis after the earliest refusing window", async () => {
+    const fixture = await createFallbackFixture();
+    try {
+      await fixture.store.nodes.UniquePerson.bulkInsert([
+        { id: "early-incumbent", props: { name: "Held" } },
+      ]);
+      Object.defineProperty(fixture.backend, "checkUniqueBatch", {
+        configurable: true,
+        value: undefined,
+      });
+      const checkUnique = fixture.backend.checkUnique;
+      const scalarClaimProbe = vi
+        .spyOn(fixture.backend, "checkUnique")
+        .mockImplementation(async (params) => checkUnique(params));
+      const inputs = Array.from({ length: 65 }, (_value, index) => ({
+        id: `early-member-${index}`,
+        props: { name: index === 0 ? "Held" : `Fresh ${index}` },
+      }));
+
+      await expect(
+        fixture.store.nodes.UniquePerson.bulkInsert(inputs),
+      ).rejects.toMatchObject({
+        name: UniquenessError.name,
+        details: { newId: "early-member-0" },
+      });
+
+      expect(scalarClaimProbe).toHaveBeenCalledTimes(32);
     } finally {
       await closeFixture(fixture);
     }

--- a/packages/typegraph/tests/atomic-node-batch.test.ts
+++ b/packages/typegraph/tests/atomic-node-batch.test.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 import {
   ContributionUnavailableError,
+  DatabaseOperationError,
   DisjointError,
   RestrictedDeleteError,
   StaleVersionError,
@@ -413,6 +414,8 @@ describe("plain node batch store contract", () => {
         props: { name: "Legacy rival" },
       });
       const batch = vi.spyOn(fixture.client, "batch");
+      const batchNodeRead = vi.spyOn(fixture.backend, "getNodes");
+      const scalarNodeRead = vi.spyOn(fixture.backend, "getNode");
 
       await expect(
         fixture.store.nodes.Person.bulkInsert([
@@ -429,6 +432,8 @@ describe("plain node batch store contract", () => {
       });
 
       expect(batch).toHaveBeenCalledOnce();
+      expect(batchNodeRead).toHaveBeenCalledOnce();
+      expect(scalarNodeRead).not.toHaveBeenCalled();
       await expect(fixture.store.nodes.Person.count()).resolves.toBe(0);
       await expect(fixture.store.nodes.Rival.count()).resolves.toBe(1);
     } finally {
@@ -449,6 +454,37 @@ describe("plain node batch store contract", () => {
       expect(batch).toHaveBeenCalledOnce();
       expect(created.map((node) => node.name)).toEqual(["Caller", "Generated"]);
       expect(created[0]?.id).toBe("caller");
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("diagnoses a late disjoint refusal with one set-oriented node read", async () => {
+    const fixture = await createDisjointFixture();
+    try {
+      await fixture.backend.insertNode({
+        graphId: disjointGraph.id,
+        kind: Rival.kind,
+        id: "late-disjoint-64",
+        props: { name: "Legacy rival" },
+      });
+      const batchNodeRead = vi.spyOn(fixture.backend, "getNodes");
+      const scalarNodeRead = vi.spyOn(fixture.backend, "getNode");
+      const inputs = Array.from({ length: 65 }, (_value, index) => ({
+        id: `late-disjoint-${index}`,
+        props: { name: `Person ${index}` },
+      }));
+
+      await expect(
+        fixture.store.nodes.Person.bulkInsert(inputs),
+      ).rejects.toMatchObject({
+        name: DisjointError.name,
+        details: { nodeId: "late-disjoint-64" },
+      });
+
+      expect(batchNodeRead).toHaveBeenCalledOnce();
+      expect(scalarNodeRead).not.toHaveBeenCalled();
+      await expect(fixture.store.nodes.Person.count()).resolves.toBe(0);
     } finally {
       await closeFixture(fixture);
     }
@@ -713,6 +749,117 @@ describe("plain node batch store contract", () => {
       await expect(
         fixture.store.nodes.MultiClaimPerson.getById("sibling" as never),
       ).resolves.toBeUndefined();
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("diagnoses a late uniqueness refusal with one set-oriented probe", async () => {
+    const fixture = await createFallbackFixture();
+    try {
+      await fixture.store.nodes.UniquePerson.bulkInsert([
+        { id: "late-incumbent", props: { name: "Held" } },
+      ]);
+      const batchClaimProbe = vi.spyOn(fixture.backend, "checkUniqueBatch");
+      const scalarClaimProbe = vi.spyOn(fixture.backend, "checkUnique");
+      const inputs = Array.from({ length: 65 }, (_value, index) => ({
+        id: `late-member-${index}`,
+        props: { name: index === 64 ? "Held" : `Fresh ${index}` },
+      }));
+
+      await expect(
+        fixture.store.nodes.UniquePerson.bulkInsert(inputs),
+      ).rejects.toMatchObject({
+        name: UniquenessError.name,
+        details: {
+          existingId: "late-incumbent",
+          newId: "late-member-64",
+        },
+      });
+
+      expect(batchClaimProbe).toHaveBeenCalledOnce();
+      expect(scalarClaimProbe).not.toHaveBeenCalled();
+      await expect(fixture.store.nodes.UniquePerson.count()).resolves.toBe(1);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("bounds scalar diagnosis without truncating late inputs", async () => {
+    const fixture = await createFallbackFixture();
+    try {
+      await fixture.store.nodes.UniquePerson.bulkInsert([
+        { id: "scalar-incumbent", props: { name: "Held" } },
+      ]);
+      Object.defineProperty(fixture.backend, "checkUniqueBatch", {
+        configurable: true,
+        value: undefined,
+      });
+      const checkUnique = fixture.backend.checkUnique;
+      let activeReads = 0;
+      let maximumActiveReads = 0;
+      const scalarClaimProbe = vi
+        .spyOn(fixture.backend, "checkUnique")
+        .mockImplementation(async (params) => {
+          activeReads += 1;
+          maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+          try {
+            return await checkUnique(params);
+          } finally {
+            activeReads -= 1;
+          }
+        });
+      const inputs = Array.from({ length: 65 }, (_value, index) => ({
+        id: `scalar-member-${index}`,
+        props: { name: index === 64 ? "Held" : `Fresh ${index}` },
+      }));
+
+      await expect(
+        fixture.store.nodes.UniquePerson.bulkInsert(inputs),
+      ).rejects.toMatchObject({
+        name: UniquenessError.name,
+        details: { newId: "scalar-member-64" },
+      });
+
+      expect(scalarClaimProbe).toHaveBeenCalledTimes(65);
+      expect(maximumActiveReads).toBe(32);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("selects claim refusals in input order after batched diagnosis", async () => {
+    const fixture = await createFallbackFixture();
+    try {
+      await fixture.store.nodes.MultiClaimPerson.bulkInsert([
+        {
+          id: "handle-incumbent",
+          props: { email: "free@example.com", handle: "held-handle" },
+        },
+        {
+          id: "email-incumbent",
+          props: { email: "held@example.com", handle: "free-handle" },
+        },
+      ]);
+
+      await expect(
+        fixture.store.nodes.MultiClaimPerson.bulkInsert([
+          {
+            id: "first-refusal",
+            props: { email: "first@example.com", handle: "held-handle" },
+          },
+          {
+            id: "second-refusal",
+            props: { email: "held@example.com", handle: "second-handle" },
+          },
+        ]),
+      ).rejects.toMatchObject({
+        name: UniquenessError.name,
+        details: {
+          constraintName: "multi_claim_handle",
+          newId: "first-refusal",
+        },
+      });
     } finally {
       await closeFixture(fixture);
     }
@@ -1332,6 +1479,8 @@ describe("constrained node batch store contract", () => {
       });
       const batch = vi.spyOn(fixture.client, "batch");
       const execute = vi.spyOn(fixture.client, "execute");
+      const batchClaimProbe = vi.spyOn(fixture.backend, "checkUniqueBatch");
+      const scalarClaimProbe = vi.spyOn(fixture.backend, "checkUnique");
 
       const insertion = fixture.store.nodes.UniquePerson.bulkInsert([
         { props: { name: "Alice" } },
@@ -1349,6 +1498,8 @@ describe("constrained node batch store contract", () => {
       });
       expect(typeof rejection.details.newId).toBe("string");
       expect(batch).toHaveBeenCalledOnce();
+      expect(batchClaimProbe).toHaveBeenCalledOnce();
+      expect(scalarClaimProbe).not.toHaveBeenCalled();
       // The transport-level sentinel rolls every chunk back first. The two
       // failure-only reads then distinguish a current fence from the exact
       // committed claim holder without letting client-side diagnosis authorize
@@ -1362,6 +1513,29 @@ describe("constrained node batch store contract", () => {
         key: computeUniqueKey({ name: "Bob" }, ["name"], "binary"),
       });
       expect(claim).toBeUndefined();
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("reports an honest terminal when committed claim state changed", async () => {
+    const fixture = await createFallbackFixture();
+    try {
+      await fixture.store.nodes.UniquePerson.bulkInsert([
+        { id: "moving-incumbent", props: { name: "Moving" } },
+      ]);
+      vi.spyOn(fixture.backend, "checkUniqueBatch").mockResolvedValue([]);
+
+      const insertion = fixture.store.nodes.UniquePerson.bulkInsert([
+        { id: "refused", props: { name: "Moving" } },
+      ]);
+      await expect(insertion).rejects.toBeInstanceOf(DatabaseOperationError);
+      const rejection = await insertion.catch((error: unknown) => error);
+      if (!(rejection instanceof DatabaseOperationError)) throw rejection;
+      expect(rejection.message).toContain(
+        "current schema-fence and claim state do not explain",
+      );
+      await expect(fixture.store.nodes.UniquePerson.count()).resolves.toBe(1);
     } finally {
       await closeFixture(fixture);
     }


### PR DESCRIPTION
## Summary

Refused atomic node claim programs previously recovered typed uniqueness and disjointness errors with sequential committed-state probes, costing up to roughly two round trips per input after rollback. This change makes that exceptional path set-oriented without changing the successful write path.

## Architecture

Bundled backends now group disjoint-node reads by kind and uniqueness reads by probe kind plus constraint, execute the two diagnostic families concurrently, and select the final typed refusal in original input order. Custom backends without both batch ports advance through shared 32-member windows, stop once the earliest refusal can be selected, and cover every input before reporting an unexplained rollback.

The portable preflight and rollback diagnosis share groupNodeUniquenessProbes and probeUniqueKey as the owners of hierarchy coverage, probe ordering, ownership comparison, and public error payloads. Scalar and batched disjointness also share isLiveNodeRow, preventing third-party timestamp normalization from changing the typed verdict between paths. If the committed fence and claims no longer explain the rollback, the Store reports an honest DatabaseOperationError instead of implying a stable claim conflict.

## Performance

Successful atomic writes add no reads or exchanges. On a refused one-constraint batch, bundled diagnosis changes from N sequential uniqueness probes to one set-oriented uniqueness read; the analogous single-partner disjointness case changes from N node probes to one set-oriented node read. Custom scalar fallbacks bound concurrency at 32 and stop after the first window containing the deterministic refusal, avoiding full-batch work when an early member conflicts.

The load-bearing tests were mutation-checked by forcing each bundled path back to scalar reads, reversing the final verdict scan, restoring full-input scalar probing after an early conflict, and restoring the divergent scalar liveness spelling; each corresponding ratchet failed before restoration.