### PR TITLE
perf: add atomic bulk node replacement

### DIFF
--- a/.changeset/atomic-bulk-replace.md
+++ b/.changeset/atomic-bulk-replace.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add `nodes.<Kind>.bulkReplaceById()` for complete-document replacement by ID. Eligible bundled SQLite, D1, libSQL, Neon HTTP, and PostgreSQL transaction-session roots execute missing-row creation, live-row replacement, tombstone resurrection, claims, and search projections as one read-free atomic submission; unsupported shapes retain the complete portable path.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1530,11 +1530,13 @@ The profile is family-scoped:
 | Member                        | Store operations authorized                                                               |
 | ----------------------------- | ----------------------------------------------------------------------------------------- |
 | `createNodes` / `createEdges` | Eligible direct `bulkInsert()` and `bulkCreate()` programs                                |
+| `replaceNodes`                | Eligible complete-document `nodes.bulkReplaceById()` programs                            |
 | `deleteNodes` / `deleteEdges` | Eligible direct `bulkDelete()` programs                                                   |
 | `updateNodes` / `updateEdges` | Eligible resolved update-only sets                                                        |
 | `mutateNodes` / `mutateEdges` | Eligible mixed create/update sets; the edge family also owns durable endpoint convergence |
 
-Executor limits such as `maxEntries`,
+Executor limits such as `maxEntries`, `replaceNodes.maxEntries.plain`,
+`replaceNodes.maxEntries.claimed`,
 `createNodes.claimSupport.maxInputCostPerEntry`, and the two edge mutation
 ceilings are part of the registration contract and must be nonnegative
 integers; zero honestly declares that the backend's bind budget cannot admit
@@ -1546,7 +1548,10 @@ honestly opts out of all claim work. The Store calls the exported
 when its complete normalized claim set exceeds the executor's declared bound.
 Custom executors must use that same helper instead of reproducing its
 dialect-reviewed bind formula. `deleteNodes.releasedClaimFamilies` similarly
-declares which owner-side claim cleanup the delete program proves. Node
+declares which owner-side claim cleanup the delete program proves.
+`replaceNodes.releasedClaimFamilies` declares which previous owner claims the
+replacement releases before acquiring its complete postimage claims; the Store
+does not infer that proof from `claimSupport`. Node
 create/update/mutation executors advertise derived-storage support separately
 through `projectionSupport.families`; omission or an empty list honestly opts
 out, and the Store never infers projection safety from transport registration
@@ -1561,7 +1566,9 @@ does not follow; the root conformance inventory therefore excludes the mixed
 variants while continuing to require direct create, delete, update, and durable
 convergence evidence. Bundled PostgreSQL binds the same reviewed lowering to the
 exact transaction session and exercises the mixed node and edge variants against
-a real engine, including typed refusal rollback.
+a real engine, including typed refusal rollback. The same session profile
+registers `replaceNodes`, so a caller-owned PostgreSQL transaction keeps blind
+replacement inside its savepoint-backed atomic program.
 An exact `atomicBatch: "session"` conformance fixture includes those mixed
 variants even though `interactiveTransactions` is true; nested-transaction
 isolation is reported as inapplicable because the fixture resource is already

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1549,6 +1549,12 @@ when its complete normalized claim set exceeds the executor's declared bound.
 Custom executors must use that same helper instead of reproducing its
 dialect-reviewed bind formula. `deleteNodes.releasedClaimFamilies` similarly
 declares which owner-side claim cleanup the delete program proves.
+Bundled replacement executors also expose an `accepts(entries)` pre-dispatch
+proof. It packs prepared members with the same bind-weighted planner used by
+execution, so claimed batches are admitted by their actual work instead of an
+unrelated fixed 32-entry ceiling; `false` is an explicit no-SQL fallback
+verdict. Custom executors may provide the same exact admission seam when one
+claimed-member ceiling would be needlessly pessimistic.
 `replaceNodes.releasedClaimFamilies` declares which previous owner claims the
 replacement releases before acquiring its complete postimage claims; the Store
 does not infer that proof from `claimSupport`. Node

--- a/apps/docs/src/content/docs/data-sync.md
+++ b/apps/docs/src/content/docs/data-sync.md
@@ -186,6 +186,29 @@ already exist, then a second for the new ones. The interchange importer
 directly — it applies each row in document order regardless of batch size, at the
 cost of the per-row validation and reporting that a bulk write skips.
 
+### bulkReplaceById
+
+Use node `bulkReplaceById` when each source record is authoritative and should
+replace the stored document rather than merge with it:
+
+```typescript
+await store.nodes.Document.bulkReplaceById(
+  externalRecords.map((record) => ({
+    id: record.id,
+    props: {
+      title: record.title,
+      content: record.body,
+    },
+  }))
+);
+```
+
+Omitted optional fields are removed. IDs must be distinct within the call;
+replacement is a set of final documents, not an ordered patch stream. On an
+eligible serverless backend this is the read-free sync path: TypeGraph submits
+creation, replacement, resurrection, claims, and search sidecars as one atomic
+program instead of reading every stored document before writing.
+
 ### bulkDelete
 
 Deletes multiple nodes by ID. Silently ignores IDs that don't exist:

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -388,6 +388,15 @@ the Store never infers fallback safety from a missing result. Once a session
 program starts, a savepoint preserves the surrounding transaction for typed
 refusal diagnosis.
 
+Node `bulkReplaceById()` avoids that structural preimage read by accepting only
+complete replacement documents and distinct IDs. On an eligible bundled root,
+the complete call—including claim ownership changes and fulltext/vector
+sidecars—uses one atomic transport submission. Live rows retain their stored
+validity windows; tombstones receive a freshly stamped window. Operational
+Identity and history/revision capture use the portable path. Custom backends
+must register and semantically certify the independent `replaceNodes` family;
+transport registration or another node family is not evidence for replacement.
+
 Eligible singleton `update()` and `delete()` calls reuse those same registered
 families. Plain or projected node updates, unconstrained non-durable-identity edge updates,
 all direct edge deletes, and plain restricted node deletes remain two-exchange

--- a/apps/docs/src/content/docs/performance/overview.md
+++ b/apps/docs/src/content/docs/performance/overview.md
@@ -252,9 +252,17 @@ resolved batches retain their two-attempt budget to bound retry cost.
 
 These operations are registered through an exact-resource mutation execution
 profile. Create and delete are **closed programs**: validation and arbitration
-can be expressed by the submitted SQL itself. `bulkUpsertById()` is deliberately
-different. It first reads authoritative stored properties, then merges and
-validates them before its write set is known. On bundled serverless roots, a
+can be expressed by the submitted SQL itself. Node `bulkReplaceById()` is also
+a closed program: every item supplies a complete document, so eligible bundled
+roots submit missing-row creation, live replacement, tombstone resurrection,
+claim release/acquisition, and fulltext/vector transitions in one read-free
+atomic exchange. Live rows preserve their validity windows; resurrected rows
+receive a fresh stamped window. Operational Identity and history/revision
+capture retain the portable path.
+
+`bulkUpsertById()` is deliberately different. It first reads authoritative
+stored properties, then merges and validates them before its write set is
+known. On bundled serverless roots, a
 distinct-ID batch with no claims, Operational Identity, durable
 edge match identity, temporal mutation, history, or revision capture submits
 its resolved mutation set, including node fulltext/vector replacements, as one
@@ -285,7 +293,9 @@ from 8 transport submissions to 1 atomic exchange. Eligible one-chunk node and
 edge `bulkDelete()` calls likewise submit 1 atomic exchange instead of a
 transaction plus per-row probes/writes. On the portable edge path, one batched
 authoritative read plus one set-based soft delete replaces the former two
-statements per input. Eligible update-only and mixed create/update node and edge
+statements per input. Eligible `nodes.bulkReplaceById()` calls submit 1 atomic
+exchange with no preimage read, including claim and projection sidecars.
+Eligible update-only and mixed create/update node and edge
 `bulkUpsertById()` calls whose preimages fit one bind-budget read submit 2
 exchanges: one batched preimage read and one atomic mutation exchange. Mixed
 sets previously required separate create and update submissions after the read,
@@ -338,6 +348,7 @@ internally.
 | `bulkCreate(items)`                       | Yes             | Need created nodes back                              |
 | `bulkInsert(items)`                       | No              | Maximum throughput ingestion                         |
 | `bulkUpsertById(items)`                   | Yes             | Idempotent import (create or update by ID)           |
+| `bulkReplaceById(items)`                  | Yes             | Idempotent complete-document replacement by ID       |
 | `bulkDelete(ids)`                         | No              | Mass soft-delete                                     |
 | `trustedImportGraphStream(store, chunks)` | No              | Fastest initial load into a fresh dedicated database |
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -1217,6 +1217,27 @@ dirty-check is applied per item: value-identical items are skipped from the
 write batch but still appear in the returned array (the existing node, in input
 order). See [`upsertById`](#upsertbyidid-props-options).
 
+#### `bulkReplaceById(items)`
+
+Creates or completely replaces multiple node documents by distinct IDs:
+
+```typescript
+store.nodes.Person.bulkReplaceById(
+  items: readonly {
+    id: string;
+    props: { name: string; email?: string };
+  }[]
+): Promise<Node<Person>[]>;
+```
+
+Unlike `bulkUpsertById`, replacement does not merge with stored properties.
+An omitted optional field is removed. Missing IDs are created, live rows keep
+their stored validity window, and tombstones are resurrected with a freshly
+stamped validity window. The method deliberately accepts no temporal mutation
+options: its complete postimage is knowable before dispatch, which lets eligible
+serverless backends execute the call without a preimage read. Duplicate IDs are
+refused rather than interpreted as an ordered script.
+
 #### `bulkDelete(ids)`
 
 Soft-deletes multiple nodes.

--- a/packages/typegraph/etc/api-surface-exceptions.json
+++ b/packages/typegraph/etc/api-surface-exceptions.json
@@ -384,6 +384,62 @@
     "issue": "#533"
   },
   {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "NodeCollection",
+    "member": "bulkReplaceById",
+    "kind": "required-member-added",
+    "reason": "Pre-1.0 clean break: expose complete-document replacement as a distinct operation instead of weakening bulkUpsertById with a mode flag; every Store-produced collection implements it.",
+    "issue": "#533"
+  },
+  {
     "entrypoint": "typegraph-backend.api.md",
     "declaration": "AtomicNodeDeleteBatchInput",
     "member": "schemaFence",

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -361,6 +361,7 @@ export interface AtomicNodeReplacementBatchExecutor {
         releaseClaims: boolean;
         schemaFence: SchemaWriteFenceParams;
     }>): Promise<readonly NodeRow[]>;
+    readonly accepts?: (entries: readonly AtomicNodeReplacementEntry[]) => boolean;
     readonly claimSupport?: AtomicNodeClaimSupport;
     readonly maxEntries: Readonly<{
         plain: number;

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -49,7 +49,7 @@ export const ATOMIC_EDGE_MUTATION_VARIANT_BY_KIND: {
 };
 
 // @public
-export const ATOMIC_MUTATION_PROGRAM_VARIANTS: readonly ["createNodes", "createEdges", "deleteNodes", "deleteEdges", "updateNodes", "updateEdges", "mutateNodes", "mutateEdges.resolvedSet", "mutateEdges.durableConvergence"];
+export const ATOMIC_MUTATION_PROGRAM_VARIANTS: readonly ["createNodes", "replaceNodes", "createEdges", "deleteNodes", "deleteEdges", "updateNodes", "updateEdges", "mutateNodes", "mutateEdges.resolvedSet", "mutateEdges.durableConvergence"];
 
 // @public
 export type AtomicDeleteBatchResult = Readonly<{
@@ -232,6 +232,7 @@ export type AtomicMutationProgramRefusalPreparation = Readonly<{
 // @public
 export type AtomicMutationProgramRegistration = Readonly<{
     createNodes?: AtomicNodeBatchExecutor | undefined;
+    replaceNodes?: AtomicNodeReplacementBatchExecutor | undefined;
     createEdges?: AtomicEdgeBatchExecutor | undefined;
     deleteNodes?: AtomicNodeDeleteBatchExecutor | undefined;
     deleteEdges?: AtomicEdgeDeleteBatchExecutor | undefined;
@@ -350,6 +351,30 @@ export type AtomicNodeProjectionFamily = "embedding" | "fulltext";
 // @public
 export type AtomicNodeProjectionSupport = Readonly<{
     families: readonly AtomicNodeProjectionFamily[];
+}>;
+
+// @public
+export interface AtomicNodeReplacementBatchExecutor {
+    // (undocumented)
+    (input: Readonly<{
+        entries: readonly AtomicNodeReplacementEntry[];
+        releaseClaims: boolean;
+        schemaFence: SchemaWriteFenceParams;
+    }>): Promise<readonly NodeRow[]>;
+    readonly claimSupport?: AtomicNodeClaimSupport;
+    readonly maxEntries: Readonly<{
+        plain: number;
+        claimed: number;
+    }>;
+    readonly projectionSupport?: AtomicNodeProjectionSupport;
+    readonly releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
+}
+
+// @public
+export type AtomicNodeReplacementEntry = Readonly<{
+    params: InsertNodeParams;
+    claims?: readonly NodeInsertClaim[];
+    projections?: readonly AtomicNodeProjection[];
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -3881,6 +3881,10 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -3451,6 +3451,10 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -3065,6 +3065,10 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -3005,6 +3005,10 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -3011,6 +3011,10 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -3092,6 +3092,10 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -4523,7 +4523,7 @@ const NODE_TEMPORAL_READ_NAMES: readonly ["getById", "getByIds", "find", "count"
 const NODE_TYPE_BRAND: "__nodeType";
 
 // @public
-const NODE_WRITE_NAMES: readonly ["create", "createFromRecord", "update", "updateWhere", "delete", "hardDelete", "upsertById", "upsertByIdFromRecord", "bulkCreate", "bulkUpsertById", "bulkInsert", "bulkDelete", "getOrCreateByConstraint", "bulkGetOrCreateByConstraint"];
+const NODE_WRITE_NAMES: readonly ["create", "createFromRecord", "update", "updateWhere", "delete", "hardDelete", "upsertById", "upsertByIdFromRecord", "bulkCreate", "bulkReplaceById", "bulkUpsertById", "bulkInsert", "bulkDelete", "getOrCreateByConstraint", "bulkGetOrCreateByConstraint"];
 
 // @public
 export type NodeAccessor<N extends NodeType> = IsDynamicNodeType<N> extends true ? DynamicNodeAccessor : Readonly<{
@@ -4611,6 +4611,10 @@ export type NodeCollection<N extends NodeType, CN extends string = string> = Rea
         validFrom?: string;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
+    bulkReplaceById: (items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+    }>[]) => Promise<Node<N>[]>;
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -122,7 +122,7 @@ function assertAtomicNodeClaimFamilies(
 }
 
 function assertAtomicNodeClaimSupport(
-  family: "createNodes" | "mutateNodes",
+  family: "createNodes" | "mutateNodes" | "replaceNodes",
   value: unknown,
 ): void {
   if (value === undefined) return;
@@ -157,7 +157,7 @@ function isAtomicNodeProjectionFamily(
 }
 
 function assertAtomicNodeProjectionSupport(
-  family: "createNodes" | "mutateNodes" | "updateNodes",
+  family: "createNodes" | "mutateNodes" | "replaceNodes" | "updateNodes",
   value: unknown,
 ): void {
   if (value === undefined) return;
@@ -289,6 +289,39 @@ export interface AtomicNodeBatchExecutor {
   ): Promise<number>;
   (
     input: AtomicNodeBatchInput & Readonly<{ resultMode: "rows" }>,
+  ): Promise<readonly NodeRow[]>;
+}
+
+/** One complete, preimage-free replacement supplied to a semantic executor. */
+export type AtomicNodeReplacementEntry = Readonly<{
+  params: InsertNodeParams;
+  /** Complete canonically ordered claims the replacement postimage owes. */
+  claims?: readonly NodeInsertClaim[];
+  /** Complete derived-storage transitions owed by the replacement postimage. */
+  projections?: readonly AtomicNodeProjection[];
+}>;
+
+/** Any node entry whose complete postimage drives projections/assertions. */
+export type AtomicNodePostimageEntry =
+  AtomicNodeBatchEntry | AtomicNodeReplacementEntry;
+
+/** Executes complete blind node replacements for one exact resource. */
+export interface AtomicNodeReplacementBatchExecutor {
+  /** Maximum members accepted by one atomic submission, including internal chunks. */
+  readonly maxEntries: Readonly<{ plain: number; claimed: number }>;
+  /** Claim semantics this executor can prove, omitted for plain rows only. */
+  readonly claimSupport?: AtomicNodeClaimSupport;
+  /** Claim families whose earlier owner rows this program releases. */
+  readonly releasedClaimFamilies?: readonly AtomicNodeClaimFamily[];
+  /** Derived-storage families this executor carries inside its program. */
+  readonly projectionSupport?: AtomicNodeProjectionSupport;
+  (
+    input: Readonly<{
+      entries: readonly AtomicNodeReplacementEntry[];
+      /** Whether earlier owner claims must be released before acquisition. */
+      releaseClaims: boolean;
+      schemaFence: SchemaWriteFenceParams;
+    }>,
   ): Promise<readonly NodeRow[]>;
 }
 
@@ -511,6 +544,7 @@ export class AtomicNodeDeleteRestrictedRefusalError extends Error {
  */
 export type AtomicMutationProgramExecutor = Readonly<{
   createNodes?: AtomicNodeBatchExecutor;
+  replaceNodes?: AtomicNodeReplacementBatchExecutor;
   createEdges?: AtomicEdgeBatchExecutor;
   deleteNodes?: AtomicNodeDeleteBatchExecutor;
   deleteEdges?: AtomicEdgeDeleteBatchExecutor;
@@ -523,6 +557,7 @@ export type AtomicMutationProgramExecutor = Readonly<{
 /** Every independently enabled semantic variant in a mutation profile. */
 export const ATOMIC_MUTATION_PROGRAM_VARIANTS = [
   "createNodes",
+  "replaceNodes",
   "createEdges",
   "deleteNodes",
   "deleteEdges",
@@ -570,6 +605,12 @@ export function reachableAtomicMutationProgramVariants(
   const resolvedMutationSetsReachable =
     !execution.interactiveTransactions || execution.atomicBatch === "session";
   if (profile.createNodes !== undefined) variants.push("createNodes");
+  if (
+    (profile.replaceNodes?.maxEntries.plain ?? 0) > 0 ||
+    (profile.replaceNodes?.maxEntries.claimed ?? 0) > 0
+  ) {
+    variants.push("replaceNodes");
+  }
   if (profile.createEdges !== undefined) variants.push("createEdges");
   if (profile.deleteNodes !== undefined) variants.push("deleteNodes");
   if (profile.deleteEdges !== undefined) variants.push("deleteEdges");
@@ -606,6 +647,7 @@ export function reachableAtomicMutationProgramVariants(
  */
 export type AtomicMutationProgramRegistration = Readonly<{
   createNodes?: AtomicNodeBatchExecutor | undefined;
+  replaceNodes?: AtomicNodeReplacementBatchExecutor | undefined;
   createEdges?: AtomicEdgeBatchExecutor | undefined;
   deleteNodes?: AtomicNodeDeleteBatchExecutor | undefined;
   deleteEdges?: AtomicEdgeDeleteBatchExecutor | undefined;
@@ -650,6 +692,7 @@ function instrumentAtomicMutationProgramExecutors(
   const descriptors = {
     createEdges: { variant: () => "createEdges" },
     createNodes: { variant: () => "createNodes" },
+    replaceNodes: { variant: () => "replaceNodes" },
     deleteEdges: { variant: () => "deleteEdges" },
     deleteNodes: { variant: () => "deleteNodes" },
     mutateEdges: {
@@ -725,6 +768,7 @@ export async function withAtomicMutationProgramDispatchObserver<TResult>(
 
 const ATOMIC_MUTATION_PROGRAM_FAMILIES = [
   "createNodes",
+  "replaceNodes",
   "createEdges",
   "deleteNodes",
   "deleteEdges",
@@ -758,10 +802,48 @@ function assertAtomicMutationProgramLimits(
   executor: AtomicMutationProgramRegistration[typeof family],
 ): void {
   if (executor === undefined) return;
-  if (family === "createNodes") {
-    const nodeExecutor = executor as AtomicNodeBatchExecutor;
+  if (family === "createNodes" || family === "replaceNodes") {
+    const nodeExecutor = executor as
+      AtomicNodeBatchExecutor | AtomicNodeReplacementBatchExecutor;
     assertAtomicNodeClaimSupport(family, nodeExecutor.claimSupport);
     assertAtomicNodeProjectionSupport(family, nodeExecutor.projectionSupport);
+    if (family === "replaceNodes") {
+      const replacementExecutor =
+        nodeExecutor as AtomicNodeReplacementBatchExecutor;
+      const releasedClaimFamilies = replacementExecutor.releasedClaimFamilies;
+      if (releasedClaimFamilies !== undefined) {
+        assertAtomicNodeClaimFamilies(
+          family,
+          "releasedClaimFamilies",
+          releasedClaimFamilies,
+        );
+      }
+      const maxEntries = (
+        replacementExecutor as unknown as Readonly<Record<string, unknown>>
+      )["maxEntries"];
+      if (typeof maxEntries !== "object" || maxEntries === null) {
+        throw new ConfigurationError(
+          "Atomic mutation program family replaceNodes requires maxEntries metadata.",
+          {
+            code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+            family,
+            limit: "maxEntries",
+            value: maxEntries,
+          },
+        );
+      }
+      const limits = maxEntries as Readonly<Record<string, unknown>>;
+      assertNonnegativeIntegerLimit(
+        family,
+        "maxEntries.plain",
+        limits["plain"],
+      );
+      assertNonnegativeIntegerLimit(
+        family,
+        "maxEntries.claimed",
+        limits["claimed"],
+      );
+    }
     return;
   }
   if (family === "deleteNodes") {
@@ -973,6 +1055,7 @@ export function markBundledRootAtomicMutationPrograms<T extends object>(
   target: T,
   executor: Readonly<{
     createNodes?: AtomicNodeBatchExecutor | undefined;
+    replaceNodes?: AtomicNodeReplacementBatchExecutor | undefined;
     createEdges?: AtomicEdgeBatchExecutor | undefined;
     deleteNodes?: AtomicNodeDeleteBatchExecutor | undefined;
     deleteEdges?: AtomicEdgeDeleteBatchExecutor | undefined;

--- a/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
+++ b/packages/typegraph/src/backend/capabilities/atomic-mutation-program.ts
@@ -309,6 +309,10 @@ export type AtomicNodePostimageEntry =
 export interface AtomicNodeReplacementBatchExecutor {
   /** Maximum members accepted by one atomic submission, including internal chunks. */
   readonly maxEntries: Readonly<{ plain: number; claimed: number }>;
+  /** Exact no-SQL admission proof for the prepared replacement work. */
+  readonly accepts?: (
+    entries: readonly AtomicNodeReplacementEntry[],
+  ) => boolean;
   /** Claim semantics this executor can prove, omitted for plain rows only. */
   readonly claimSupport?: AtomicNodeClaimSupport;
   /** Claim families whose earlier owner rows this program releases. */
@@ -843,6 +847,18 @@ function assertAtomicMutationProgramLimits(
         "maxEntries.claimed",
         limits["claimed"],
       );
+      const accepts = (executor as AtomicNodeReplacementBatchExecutor).accepts;
+      if (accepts !== undefined && typeof accepts !== "function") {
+        throw new ConfigurationError(
+          "Atomic mutation program family replaceNodes requires a callable accepts predicate.",
+          {
+            code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+            family,
+            limit: "accepts",
+            value: accepts,
+          },
+        );
+      }
     }
     return;
   }

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -66,7 +66,10 @@ import {
   type AtomicNodeDeleteBatchExecutor,
   type AtomicNodeDeleteBatchInput,
   AtomicNodeDeleteRestrictedRefusalError,
+  type AtomicNodePostimageEntry,
   type AtomicNodeProjectionSupport,
+  type AtomicNodeReplacementBatchExecutor,
+  type AtomicNodeReplacementEntry,
   type AtomicNodeResolvedMutationSetExecutor,
   type AtomicNodeResolvedUpdateBatchExecutor,
   type AtomicNodeResolvedUpdateEntry,
@@ -235,6 +238,20 @@ function chunkAtomicNodeEntriesByClaimWork(
         ATOMIC_NODE_INSERT_PARAM_COUNT +
         atomicNodeClaimInputCost(entry.claims ?? []),
     ),
+  );
+}
+
+function chunkAtomicNodeReplacementEntriesByClaimWork(
+  entries: readonly AtomicNodeReplacementEntry[],
+  maxBindParameters: number,
+): readonly (readonly AtomicNodeReplacementEntry[])[] {
+  const available = maxBindParameters - ATOMIC_NODE_WRITE_FIXED_PARAM_COUNT;
+  return chunkByWeight(
+    entries,
+    available,
+    (entry) =>
+      ATOMIC_NODE_INSERT_PARAM_COUNT +
+      atomicNodeClaimInputCost(entry.claims ?? []),
   );
 }
 
@@ -558,6 +575,7 @@ export type CommonOperationBackend = Pick<
 > &
   Readonly<{
     executeAtomicNodeBatch?: AtomicNodeBatchExecutor;
+    executeAtomicNodeReplacementBatch?: AtomicNodeReplacementBatchExecutor;
     executeAtomicNodeDeleteBatch?: AtomicNodeDeleteBatchExecutor;
     executeAtomicNodeResolvedUpdateBatch?: AtomicNodeResolvedUpdateBatchExecutor;
     executeAtomicNodeResolvedMutationSet?: AtomicNodeResolvedMutationSetExecutor;
@@ -685,21 +703,21 @@ type CreateCommonOperationBackendOptions = Readonly<{
   /** Local signature evidence compiled into an atomic projection program. */
   resolveAtomicNodeProjectionEvidence?:
     | ((
-        creates: readonly AtomicNodeBatchEntry[],
+        creates: readonly AtomicNodePostimageEntry[],
         updates: readonly AtomicNodeResolvedUpdateEntry[],
       ) => Promise<readonly AtomicContributionEvidence[]>)
     | undefined;
   /** Failure-only durable marker diagnosis after an atomic refusal rolls back. */
   diagnoseAtomicNodeProjectionEvidence?:
     | ((
-        creates: readonly AtomicNodeBatchEntry[],
+        creates: readonly AtomicNodePostimageEntry[],
         updates: readonly AtomicNodeResolvedUpdateEntry[],
       ) => Promise<void>)
     | undefined;
   /** Maps physical projection failures without weakening row classifications. */
   refuseAtomicNodeProjectionError?:
     | ((
-        creates: readonly AtomicNodeBatchEntry[],
+        creates: readonly AtomicNodePostimageEntry[],
         updates: readonly AtomicNodeResolvedUpdateEntry[],
         error: unknown,
       ) => Promise<never>)
@@ -909,7 +927,7 @@ type AtomicResolvedMutationSlot<TRow> =
 // can never exceed K mutation statements. The absolute member ceiling keeps a
 // high-bind PostgreSQL backend from turning the same contract into an enormous
 // HTTP request merely because one SQL statement can carry many parameters.
-const ATOMIC_RESOLVED_MUTATION_MAX_MUTATION_STATEMENTS = 32;
+const ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS = 32;
 const ATOMIC_RESOLVED_MUTATION_MAX_MEMBERS = 512;
 const ATOMIC_RESOLVED_MUTATION_FIXED_PARAM_COUNT = 12;
 const ATOMIC_NODE_RESOLVED_MUTATION_PARAMS_PER_ENTRY = 5;
@@ -933,9 +951,7 @@ function atomicResolvedMutationSubmissionMaxEntries(
 ): number {
   return Math.min(
     ATOMIC_RESOLVED_MUTATION_MAX_MEMBERS,
-    statementChunkSize *
-      (ATOMIC_RESOLVED_MUTATION_MAX_MUTATION_STATEMENTS - 1) +
-      1,
+    statementChunkSize * (ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS - 1) + 1,
   );
 }
 
@@ -1106,7 +1122,7 @@ type AtomicNodeProjectionSlot = Readonly<{ kind: "projection" }>;
 function compileAtomicNodeProjectionSlots(
   operationStrategy: CommonOperationStrategy,
   execution: OperationBackendExecution,
-  creates: readonly AtomicNodeBatchEntry[],
+  creates: readonly AtomicNodePostimageEntry[],
   updates: readonly AtomicNodeResolvedUpdateEntry[],
   timestamp: string,
   maxBindParameters: number,
@@ -1161,13 +1177,13 @@ function compileAtomicNodeProjectionSlots(
 async function compileAtomicNodeProjectionEvidenceSlots(
   operationStrategy: CommonOperationStrategy,
   execution: OperationBackendExecution,
-  creates: readonly AtomicNodeBatchEntry[],
+  creates: readonly AtomicNodePostimageEntry[],
   updates: readonly AtomicNodeResolvedUpdateEntry[],
   timestamp: string,
   maxBindParameters: number,
   resolveEvidence:
     | ((
-        creates: readonly AtomicNodeBatchEntry[],
+        creates: readonly AtomicNodePostimageEntry[],
         updates: readonly AtomicNodeResolvedUpdateEntry[],
       ) => Promise<readonly AtomicContributionEvidence[]>)
     | undefined,
@@ -1548,7 +1564,7 @@ export function createCommonOperationBackend(
 
   async function runAtomicNodeSidecarProgram<TResult>(
     input: Readonly<{
-      creates: readonly AtomicNodeBatchEntry[];
+      creates: readonly AtomicNodePostimageEntry[];
       updates: readonly AtomicNodeResolvedUpdateEntry[];
       operation: "insert" | "update" | "upsert";
       hasProjections: boolean;
@@ -1833,9 +1849,9 @@ export function createCommonOperationBackend(
           families: operationStrategy.atomicNodeProjectionFamilies,
         } satisfies AtomicNodeProjectionSupport);
 
-        function orderedAtomicNodeClaims(
-          entries: readonly AtomicNodeBatchEntry[],
-        ): readonly AtomicNodeClaimEntry[] {
+        function orderedAtomicNodeClaims<
+          TEntry extends AtomicNodePostimageEntry,
+        >(entries: readonly TEntry[]): readonly AtomicNodeClaimEntry<TEntry>[] {
           return entries
             .flatMap((entry, memberOrdinal) =>
               (entry.claims ?? []).map((claim, claimOrdinal) => ({
@@ -1865,7 +1881,9 @@ export function createCommonOperationBackend(
             });
         }
 
-        function atomicNodeClaimTargetKey(entry: AtomicNodeClaimEntry): string {
+        function atomicNodeClaimTargetKey(
+          entry: AtomicNodeClaimEntry<AtomicNodePostimageEntry>,
+        ): string {
           return encodeTupleKey([
             entry.claim.axis,
             entry.claim.constraintName,
@@ -1880,7 +1898,7 @@ export function createCommonOperationBackend(
         type AtomicNodeProgramSlot =
           | Readonly<{
               kind: "claims";
-              entries: readonly AtomicNodeClaimEntry[];
+              entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[];
               rows: readonly AtomicNodeClaimOwnerRow[];
             }>
           | Readonly<{ kind: "cleanup" }>
@@ -1888,17 +1906,17 @@ export function createCommonOperationBackend(
           | Readonly<{ kind: "assertion" }>
           | Readonly<{
               kind: "counts";
-              chunk: readonly AtomicNodeBatchEntry[];
+              chunk: readonly AtomicNodePostimageEntry[];
               count: number;
             }>
           | Readonly<{
               kind: "rows";
-              chunk: readonly AtomicNodeBatchEntry[];
+              chunk: readonly AtomicNodePostimageEntry[];
               rows: readonly NodeRow[];
             }>;
 
         function classifyAtomicNodeClaimResults(
-          claimEntries: readonly AtomicNodeClaimEntry[],
+          claimEntries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
           results: readonly AtomicNodeProgramSlot[],
         ): "stale" | "owned" | DisjointError | UniquenessError {
           const ownerByTarget = new Map<string, ClaimOwner>();
@@ -1963,7 +1981,7 @@ export function createCommonOperationBackend(
         }
 
         function requireAtomicNodeClaimWrite(
-          claimEntries: readonly AtomicNodeClaimEntry[],
+          claimEntries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
           results: readonly AtomicNodeProgramSlot[],
           insertedCount: number,
         ): "stale" | "owned" {
@@ -2038,7 +2056,7 @@ export function createCommonOperationBackend(
               options.maxBindParameters,
             );
             function claimGateForChunk(chunk: readonly AtomicNodeBatchEntry[]) {
-              const members = new Set(chunk);
+              const members = new Set<AtomicNodePostimageEntry>(chunk);
               const chunkClaims = claimEntries.filter((item) =>
                 members.has(item.entry),
               );
@@ -2471,14 +2489,288 @@ export function createCommonOperationBackend(
           });
         }
 
+        async function executeAtomicNodeReplacementBatch(
+          input: Parameters<AtomicNodeReplacementBatchExecutor>[0],
+        ): Promise<readonly NodeRow[]> {
+          if (input.entries.length === 0) return [];
+          assertMatchingNodeSchemaFences(
+            input.entries.map((entry) => entry.params),
+            input.schemaFence,
+          );
+          const firstEntry = requireDefined(input.entries[0]);
+          const identities = new Set<string>();
+          for (const entry of input.entries) {
+            if (
+              entry.params.graphId !== firstEntry.params.graphId ||
+              entry.params.kind !== firstEntry.params.kind
+            ) {
+              throw new CompilerInvariantError(
+                "An atomic node replacement requires one graph and node kind.",
+                {
+                  expectedGraphId: firstEntry.params.graphId,
+                  expectedKind: firstEntry.params.kind,
+                  actualGraphId: entry.params.graphId,
+                  actualKind: entry.params.kind,
+                },
+              );
+            }
+            const identity = encodeTupleKey([
+              entry.params.graphId,
+              entry.params.kind,
+              entry.params.id,
+            ]);
+            if (identities.has(identity)) {
+              throw new CompilerInvariantError(
+                "An atomic node replacement requires distinct identities.",
+              );
+            }
+            identities.add(identity);
+            if (!supportsAtomicNodeClaims(claimSupport, entry.claims ?? [])) {
+              throw new CompilerInvariantError(
+                "Atomic node replacement exceeded its declared per-member claim budget.",
+                { claimSupport },
+              );
+            }
+          }
+
+          const timestamp = nowIso();
+          const atomicExecutor = requireDefined(atomicSqlProgramExecutor);
+          const atomicSchemaFenceLockClause = requireDefined(
+            schemaFenceLockClause,
+          );
+          const claimEntries = orderedAtomicNodeClaims(input.entries);
+          const nodeChunks = chunkAtomicNodeReplacementEntriesByClaimWork(
+            input.entries,
+            options.maxBindParameters,
+          );
+          if (nodeChunks.length > ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS) {
+            throw new CompilerInvariantError(
+              "Atomic node replacement exceeded its declared submission statement budget.",
+              {
+                actual: nodeChunks.length,
+                maximum: ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS,
+              },
+            );
+          }
+
+          const claimChunkSize = Math.max(
+            1,
+            Math.floor(
+              (options.maxBindParameters - 2) /
+                ATOMIC_NODE_CLAIM_INPUT_PARAM_COUNT,
+            ),
+          );
+          const claimChunks = chunkArray(claimEntries, claimChunkSize);
+          const claimSlots: AtomicSqlProgram<
+            AtomicNodeProgramSlot,
+            unknown
+          >["slots"] = claimChunks.map((chunk) => ({
+            statement: execution.compile(
+              operationStrategy.buildAtomicNodeClaimUpsertWithSchemaFence(
+                chunk,
+                input.schemaFence,
+                atomicSchemaFenceLockClause,
+              ),
+            ),
+            cardinality: "many" as const,
+            decode: (rows: readonly Readonly<Record<string, unknown>>[]) => ({
+              kind: "claims" as const,
+              entries: chunk,
+              rows: rows.map((row) => ({
+                node_kind: String(row["node_kind"]),
+                constraint_name: String(row["constraint_name"]),
+                key: String(row["key"]),
+                node_id: String(row["node_id"]),
+                concrete_kind: String(row["concrete_kind"]),
+              })),
+            }),
+          }));
+          const releaseChunkSize = Math.max(1, options.maxBindParameters - 5);
+          const releaseSlots: AtomicSqlProgram<
+            AtomicNodeProgramSlot,
+            unknown
+          >["slots"] =
+            input.releaseClaims ?
+              chunkArray(input.entries, releaseChunkSize).map((chunk) => ({
+                statement: execution.compile(
+                  operationStrategy.buildAtomicNodeReplacementClaimReleaseWithSchemaFence(
+                    {
+                      graphId: requireDefined(chunk[0]).params.graphId,
+                      kind: requireDefined(chunk[0]).params.kind,
+                      ids: chunk.map((entry) => entry.params.id),
+                      timestamp,
+                    },
+                    input.schemaFence,
+                    atomicSchemaFenceLockClause,
+                  ),
+                ),
+                cardinality: "none" as const,
+                decode: () => ({ kind: "cleanup" as const }),
+              }))
+            : [];
+          function claimGateForChunk(
+            chunk: readonly AtomicNodeReplacementEntry[],
+          ): SQL | undefined {
+            const members = new Set<AtomicNodePostimageEntry>(chunk);
+            const chunkClaims = claimEntries.filter((item) =>
+              members.has(item.entry),
+            );
+            return chunkClaims.length === 0 ?
+                undefined
+              : operationStrategy.buildAtomicNodeClaimGatePredicateWithSchemaFence(
+                  chunkClaims,
+                  input.schemaFence,
+                  atomicSchemaFenceLockClause,
+                );
+          }
+          const nodeSlots: AtomicSqlProgram<
+            AtomicNodeProgramSlot,
+            unknown
+          >["slots"] = nodeChunks.map((chunk) => ({
+            statement: execution.compile(
+              operationStrategy.buildAtomicNodeReplacementBatchWithSchemaFence(
+                chunk,
+                timestamp,
+                input.schemaFence,
+                atomicSchemaFenceLockClause,
+                claimGateForChunk(chunk),
+              ),
+            ),
+            cardinality: "many" as const,
+            decode: (rows: readonly Readonly<Record<string, unknown>>[]) => ({
+              kind: "rows" as const,
+              chunk,
+              rows: rows.map((row) => rowMappers.toNodeRow(row)),
+            }),
+          }));
+          const projectionSlots = compileAtomicNodeProjectionSlots(
+            operationStrategy,
+            execution,
+            input.entries,
+            [],
+            timestamp,
+            options.maxBindParameters,
+          );
+          const projectionEvidenceSlots =
+            await compileAtomicNodeProjectionEvidenceSlots(
+              operationStrategy,
+              execution,
+              input.entries,
+              [],
+              timestamp,
+              options.maxBindParameters,
+              options.resolveAtomicNodeProjectionEvidence,
+            );
+          const assertionSlots: AtomicSqlProgram<
+            AtomicNodeProgramSlot,
+            unknown
+          >["slots"] = nodeChunks.map((chunk) => ({
+            statement: execution.compile(
+              operationStrategy.buildAssertAtomicNodeMutationPostimages(
+                chunk,
+                [],
+                timestamp,
+                input.schemaFence,
+              ),
+            ),
+            cardinality: "none" as const,
+            decode: () => ({ kind: "assertion" as const }),
+          }));
+          const program = {
+            slots: [
+              ...releaseSlots,
+              ...claimSlots,
+              ...nodeSlots,
+              ...projectionSlots,
+              ...projectionEvidenceSlots,
+              ...assertionSlots,
+            ],
+            assemble(
+              results: readonly AtomicNodeProgramSlot[],
+            ): readonly NodeRow[] {
+              const rows = results.flatMap((result) =>
+                result.kind === "rows" ? result.rows : [],
+              );
+              if (claimEntries.length > 0) {
+                const claimVerdict = requireAtomicNodeClaimWrite(
+                  claimEntries,
+                  results,
+                  rows.length,
+                );
+                if (claimVerdict === "stale") return [];
+              }
+              if (rows.length !== input.entries.length) {
+                throw new CompilerInvariantError(
+                  "Atomic node replacement returned a partial result.",
+                  { expected: input.entries.length, actual: rows.length },
+                );
+              }
+              const byIdentity = new Map(
+                rows.map((row) => [
+                  encodeTupleKey([row.graph_id, row.kind, row.id]),
+                  row,
+                ]),
+              );
+              if (byIdentity.size !== rows.length) {
+                throw new CompilerInvariantError(
+                  "Atomic node replacement returned duplicate result rows.",
+                );
+              }
+              return input.entries.map((entry) =>
+                requireDefined(
+                  byIdentity.get(
+                    encodeTupleKey([
+                      entry.params.graphId,
+                      entry.params.kind,
+                      entry.params.id,
+                    ]),
+                  ),
+                  "Atomic node replacement omitted an input row.",
+                ),
+              );
+            },
+          } satisfies AtomicSqlProgram<
+            AtomicNodeProgramSlot,
+            readonly NodeRow[]
+          >;
+          return runAtomicNodeSidecarProgram({
+            creates: input.entries,
+            updates: [],
+            operation: "upsert",
+            hasProjections: projectionSlots.length > 0,
+            hasPostimageAssertion: true,
+            run: () => atomicExecutor.execute(program),
+            postimageRefusal: () => [],
+          });
+        }
+
         const boundedExecuteAtomicNodeBatch = Object.assign(
           executeAtomicNodeBatch,
           { claimSupport, projectionSupport },
         );
+        const executeAtomicNodeReplacement = Object.assign(
+          executeAtomicNodeReplacementBatch,
+          {
+            claimSupport,
+            maxEntries: Object.freeze({
+              plain: Math.min(
+                ATOMIC_RESOLVED_MUTATION_MAX_MEMBERS,
+                atomicResolvedMutationSubmissionMaxEntries(
+                  batchConfig.nodeSchemaFencedInsertBatchSize,
+                ),
+              ),
+              claimed: ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS,
+            }),
+            projectionSupport,
+            releasedClaimFamilies: claimSupport.families,
+          },
+        );
         return {
           executeAtomicNodeBatch: boundedExecuteAtomicNodeBatch,
+          executeAtomicNodeReplacementBatch: executeAtomicNodeReplacement,
         } satisfies Readonly<{
           executeAtomicNodeBatch: AtomicNodeBatchExecutor;
+          executeAtomicNodeReplacementBatch: AtomicNodeReplacementBatchExecutor;
         }>;
       })();
 

--- a/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
+++ b/packages/typegraph/src/backend/drizzle/operation-backend-core.ts
@@ -255,6 +255,23 @@ function chunkAtomicNodeReplacementEntriesByClaimWork(
   );
 }
 
+/** Maximum plain replacement members whose chunks fit one atomic submission. */
+export function atomicNodeReplacementSubmissionMaxEntries(
+  maxBindParameters: number,
+): number {
+  const entriesPerStatement = Math.max(
+    1,
+    Math.floor(
+      (maxBindParameters - ATOMIC_NODE_WRITE_FIXED_PARAM_COUNT) /
+        ATOMIC_NODE_INSERT_PARAM_COUNT,
+    ),
+  );
+  return Math.min(
+    ATOMIC_RESOLVED_MUTATION_MAX_MEMBERS,
+    atomicResolvedMutationSubmissionMaxEntries(entriesPerStatement),
+  );
+}
+
 function assertMatchingFusedEdgeClaim(
   params: InsertEdgeParams,
   claim: ClaimEdgeCardinalityParams,
@@ -2489,6 +2506,17 @@ export function createCommonOperationBackend(
           });
         }
 
+        function acceptsAtomicNodeReplacementEntries(
+          entries: readonly AtomicNodeReplacementEntry[],
+        ): boolean {
+          return (
+            chunkAtomicNodeReplacementEntriesByClaimWork(
+              entries,
+              options.maxBindParameters,
+            ).length <= ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS
+          );
+        }
+
         async function executeAtomicNodeReplacementBatch(
           input: Parameters<AtomicNodeReplacementBatchExecutor>[0],
         ): Promise<readonly NodeRow[]> {
@@ -2543,7 +2571,7 @@ export function createCommonOperationBackend(
             input.entries,
             options.maxBindParameters,
           );
-          if (nodeChunks.length > ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS) {
+          if (!acceptsAtomicNodeReplacementEntries(input.entries)) {
             throw new CompilerInvariantError(
               "Atomic node replacement exceeded its declared submission statement budget.",
               {
@@ -2751,15 +2779,13 @@ export function createCommonOperationBackend(
         const executeAtomicNodeReplacement = Object.assign(
           executeAtomicNodeReplacementBatch,
           {
+            accepts: acceptsAtomicNodeReplacementEntries,
             claimSupport,
             maxEntries: Object.freeze({
-              plain: Math.min(
-                ATOMIC_RESOLVED_MUTATION_MAX_MEMBERS,
-                atomicResolvedMutationSubmissionMaxEntries(
-                  batchConfig.nodeSchemaFencedInsertBatchSize,
-                ),
+              plain: atomicNodeReplacementSubmissionMaxEntries(
+                options.maxBindParameters,
               ),
-              claimed: ATOMIC_MUTATION_MAX_MUTATION_STATEMENTS,
+              claimed: ATOMIC_RESOLVED_MUTATION_MAX_MEMBERS,
             }),
             projectionSupport,
             releasedClaimFamilies: claimSupport.families,

--- a/packages/typegraph/src/backend/drizzle/operations/atomic-node-claims.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/atomic-node-claims.ts
@@ -5,7 +5,10 @@ import {
   type ClaimOwnerColumnNames,
   claimOwnerMatchesSql,
 } from "../../../store/claims/axis";
-import type { AtomicNodeBatchEntry } from "../../capabilities/atomic-mutation-program";
+import type {
+  AtomicNodeBatchEntry,
+  AtomicNodePostimageEntry,
+} from "../../capabilities/atomic-mutation-program";
 import type {
   InsertNodeParams,
   NodeInsertClaim,
@@ -20,10 +23,12 @@ import {
 } from "./shared";
 
 /** One node batch member, carrying its stable ordinal into claim SQL. */
-export type AtomicNodeClaimEntry = Readonly<{
+export type AtomicNodeClaimEntry<
+  TEntry extends AtomicNodePostimageEntry = AtomicNodeBatchEntry,
+> = Readonly<{
   memberOrdinal: number;
   claimOrdinal: number;
-  entry: AtomicNodeBatchEntry;
+  entry: TEntry;
   claim: NodeInsertClaim;
 }>;
 
@@ -90,7 +95,7 @@ function excludedColumn(columnName: string): SQL {
 }
 
 function assertClaimEntries(
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
   schemaFence: SchemaWriteFenceParams,
 ): void {
   if (entries.length === 0) {
@@ -164,7 +169,7 @@ function ordinalLiteral(value: number): SQL {
 /** Complete legacy-storage conflict reads for one normalized claim set. */
 function claimConflictQueries(
   tables: Tables,
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
   schemaFence: SchemaWriteFenceParams,
 ): readonly SQL[] {
   return entries.flatMap((item) => {
@@ -221,17 +226,21 @@ function claimConflictQueries(
   });
 }
 
-function claimOf(item: AtomicNodeClaimEntry): NodeInsertClaim {
+function claimOf(
+  item: AtomicNodeClaimEntry<AtomicNodePostimageEntry>,
+): NodeInsertClaim {
   return item.claim;
 }
 
-function paramsOf(item: AtomicNodeClaimEntry): InsertNodeParams {
+function paramsOf(
+  item: AtomicNodeClaimEntry<AtomicNodePostimageEntry>,
+): InsertNodeParams {
   return item.entry.params;
 }
 
 function claimInputValues(
   tables: Tables,
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
 ): SQL {
   const { uniques } = tables;
   return sql.join(
@@ -255,7 +264,7 @@ function claimInputValues(
 
 function claimInputCte(
   tables: Tables,
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
   alias: string,
 ): SQL {
   const columns = sql.join(
@@ -304,7 +313,7 @@ function claimOwnerMatches(tables: Tables, dialect: SqlDialect): SQL {
 export function buildAtomicNodeClaimUpsertWithSchemaFence(
   tables: Tables,
   dialect: SqlDialect,
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
   schemaFence: SchemaWriteFenceParams,
   schemaLockClause: SQL,
 ): SQL {
@@ -372,7 +381,7 @@ export function buildAtomicNodeClaimUpsertWithSchemaFence(
  */
 export function buildAtomicNodeClaimGatePredicateWithSchemaFence(
   tables: Tables,
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
   schemaFence: SchemaWriteFenceParams,
   schemaLockClause: SQL,
 ): SQL {
@@ -424,7 +433,7 @@ export function buildAtomicNodeClaimGatePredicateWithSchemaFence(
  */
 export function buildAtomicNodeClaimCleanupWithSchemaFence(
   tables: Tables,
-  entries: readonly AtomicNodeClaimEntry[],
+  entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
   schemaFence: SchemaWriteFenceParams,
   schemaLockClause: SQL,
 ): SQL {
@@ -507,5 +516,41 @@ export function buildAtomicDeletedNodeClaimReleaseWithSchemaFence(
           AND ${nodes.id} = ${ownerColumn(uniques.nodeId)}
           AND ${nodes.deletedAt} = ${input.timestamp}
       )
+  `;
+}
+
+/**
+ * Soft-releases every live claim owned by a blind-replacement member.
+ *
+ * Replacement has no preimage by contract, so it cannot diff old and new
+ * claim keys. Releasing by exact owner before acquiring the postimage claims
+ * makes omission and key changes complete without an extra read. The later
+ * claim gate and terminal postimage assertion keep this cleanup in the same
+ * all-or-nothing submission as the row replacement.
+ */
+export function buildAtomicNodeReplacementClaimReleaseWithSchemaFence(
+  tables: Tables,
+  input: Readonly<{
+    graphId: string;
+    kind: string;
+    ids: readonly string[];
+    timestamp: string;
+  }>,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+): SQL {
+  const { uniques } = tables;
+  return sql`
+    WITH ${schemaFenceCte(tables, schemaFence, schemaLockClause)}
+    UPDATE ${uniques}
+    SET ${quotedColumn(uniques.deletedAt)} = ${input.timestamp}
+    WHERE EXISTS (SELECT 1 FROM ${sql.identifier(SCHEMA_FENCE_ALIAS)})
+      AND ${uniques.graphId} = ${input.graphId}
+      AND ${uniques.concreteKind} = ${input.kind}
+      AND ${uniques.deletedAt} IS NULL
+      AND ${uniques.nodeId} IN (${sql.join(
+        input.ids.map((id) => sql`${id}`),
+        sql`, `,
+      )})
   `;
 }

--- a/packages/typegraph/src/backend/drizzle/operations/node-projections.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/node-projections.ts
@@ -11,7 +11,7 @@ import { chunk as chunkArray } from "../../../utils/array";
 import { resolveStampedValidityLowerBound } from "../../../utils/date";
 import { encodeTupleKey } from "../../../utils/tuple-key";
 import type {
-  AtomicNodeBatchEntry,
+  AtomicNodePostimageEntry,
   AtomicNodeProjection,
   AtomicNodeResolvedUpdateEntry,
 } from "../../capabilities/atomic-mutation-program";
@@ -42,7 +42,7 @@ type AtomicNodeProjectionEntry = Readonly<{
 }>;
 
 function atomicProjectionEntries(
-  creates: readonly AtomicNodeBatchEntry[],
+  creates: readonly AtomicNodePostimageEntry[],
   updates: readonly AtomicNodeResolvedUpdateEntry[],
 ): readonly AtomicNodeProjectionEntry[] {
   return [
@@ -69,7 +69,7 @@ export type AtomicNodeProjectionRequirements = Readonly<{
 
 /** One owner for the physical derived-storage requirements of a node program. */
 export function resolveAtomicNodeProjectionRequirements(
-  creates: readonly AtomicNodeBatchEntry[],
+  creates: readonly AtomicNodePostimageEntry[],
   updates: readonly AtomicNodeResolvedUpdateEntry[],
 ): AtomicNodeProjectionRequirements | undefined {
   const entries = atomicProjectionEntries(creates, updates);
@@ -123,7 +123,7 @@ export function resolveAtomicNodeProjectionRequirements(
  * work deliberately aborts the submission and rolls these transitions back.
  */
 export function buildAtomicNodeProjectionStatements(
-  creates: readonly AtomicNodeBatchEntry[],
+  creates: readonly AtomicNodePostimageEntry[],
   updates: readonly AtomicNodeResolvedUpdateEntry[],
   timestamp: string,
   dialect: SqlDialect,

--- a/packages/typegraph/src/backend/drizzle/operations/nodes.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/nodes.ts
@@ -8,6 +8,8 @@ import type {
   AtomicNodeBatchEntry,
   AtomicNodeBatchResultMode,
   AtomicNodeDeleteBatchInput,
+  AtomicNodePostimageEntry,
+  AtomicNodeReplacementEntry,
   AtomicNodeResolvedUpdateEntry,
 } from "../../capabilities/atomic-mutation-program";
 import type {
@@ -40,7 +42,7 @@ const INITIAL_NODE_VERSION = 1;
 const NODE_VERSION_INCREMENT = 1;
 
 function atomicNodeCreatePostimage(
-  entry: AtomicNodeBatchEntry,
+  entry: Pick<AtomicNodePostimageEntry, "params">,
   timestamp: string,
 ) {
   const params = entry.params;
@@ -71,6 +73,12 @@ function atomicNodeUpdatePostimage(
     version: entry.expectedVersion + NODE_VERSION_INCREMENT,
     updatedAt: timestamp,
   } as const;
+}
+
+function isAtomicNodeBatchEntry(
+  entry: AtomicNodePostimageEntry,
+): entry is AtomicNodeBatchEntry {
+  return "idSource" in entry;
 }
 
 /**
@@ -360,13 +368,14 @@ export function buildInsertNodesBatchWithSchemaFence(
  * engine refusal is classified by the backend as a duplicate node identity,
  * and the native batch rolls back every earlier statement.
  */
-export function buildAtomicNodeBatchWithSchemaFence(
+function buildAtomicNodeWriteBatchWithSchemaFence(
   tables: Tables,
-  entries: readonly AtomicNodeBatchEntry[],
+  entries: readonly AtomicNodePostimageEntry[],
   timestamp: string,
   schemaFence: SchemaWriteFenceParams,
   schemaLockClause: SQL,
   resultMode: AtomicNodeBatchResultMode,
+  writeMode: "create" | "replace",
   writeGate?: SQL,
 ): SQL {
   const firstEntry = entries[0];
@@ -375,12 +384,23 @@ export function buildAtomicNodeBatchWithSchemaFence(
       "An atomic node batch statement needs at least one entry.",
     );
   }
-  if (!entries.every((entry) => entry.idSource === firstEntry.idSource)) {
+  if (
+    writeMode === "create" &&
+    (!isAtomicNodeBatchEntry(firstEntry) ||
+      !entries.every(
+        (entry) =>
+          isAtomicNodeBatchEntry(entry) &&
+          entry.idSource === firstEntry.idSource,
+      ))
+  ) {
     throw new CompilerInvariantError(
       "An atomic node batch statement cannot mix identity sources.",
     );
   }
-  const generated = firstEntry.idSource === "generated";
+  const generated =
+    writeMode === "create" &&
+    isAtomicNodeBatchEntry(firstEntry) &&
+    firstEntry.idSource === "generated";
   const { nodes, schemaVersions } = tables;
   const columns = nodeColumnList(nodes);
   const inputColumns = [
@@ -464,6 +484,21 @@ export function buildAtomicNodeBatchWithSchemaFence(
         ELSE ${excluded(nodes.updatedAt)}
       END
   `;
+  const replacement = sql`
+    ON CONFLICT (${conflictColumns}) DO UPDATE SET
+      ${quotedColumn(nodes.props)} = ${excluded(nodes.props)},
+      ${quotedColumn(nodes.version)} = ${currentVersion} + 1,
+      ${quotedColumn(nodes.validFrom)} = CASE
+        WHEN ${currentDeletedAt} IS NULL THEN ${currentValidFrom}
+        ELSE ${excluded(nodes.validFrom)}
+      END,
+      ${quotedColumn(nodes.validTo)} = CASE
+        WHEN ${currentDeletedAt} IS NULL THEN ${currentValidTo}
+        ELSE ${excluded(nodes.validTo)}
+      END,
+      ${quotedColumn(nodes.deletedAt)} = NULL,
+      ${quotedColumn(nodes.updatedAt)} = ${excluded(nodes.updatedAt)}
+  `;
 
   return sql`
     WITH "schema_fence" AS (
@@ -488,9 +523,56 @@ export function buildAtomicNodeBatchWithSchemaFence(
         : sql`WHERE TRUE`
       : sql`WHERE ${writeGate}`
     }
-    ${generated ? sql.empty() : resurrection}
+    ${
+      writeMode === "replace" ? replacement
+      : generated ? sql.empty()
+      : resurrection
+    }
     ${resultClause}
   `;
+}
+
+/** Schema-fenced create batch with caller-id resurrection semantics. */
+export function buildAtomicNodeBatchWithSchemaFence(
+  tables: Tables,
+  entries: readonly AtomicNodeBatchEntry[],
+  timestamp: string,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+  resultMode: AtomicNodeBatchResultMode,
+  writeGate?: SQL,
+): SQL {
+  return buildAtomicNodeWriteBatchWithSchemaFence(
+    tables,
+    entries,
+    timestamp,
+    schemaFence,
+    schemaLockClause,
+    resultMode,
+    "create",
+    writeGate,
+  );
+}
+
+/** Schema-fenced blind replacement: create missing, replace live, revive tombstones. */
+export function buildAtomicNodeReplacementBatchWithSchemaFence(
+  tables: Tables,
+  entries: readonly AtomicNodeReplacementEntry[],
+  timestamp: string,
+  schemaFence: SchemaWriteFenceParams,
+  schemaLockClause: SQL,
+  writeGate?: SQL,
+): SQL {
+  return buildAtomicNodeWriteBatchWithSchemaFence(
+    tables,
+    entries,
+    timestamp,
+    schemaFence,
+    schemaLockClause,
+    "rows",
+    "replace",
+    writeGate,
+  );
 }
 
 /**
@@ -700,7 +782,7 @@ export function buildAtomicNodeResolvedUpdateBatch(
  */
 export function buildAssertAtomicNodeMutationPostimages(
   tables: Tables,
-  creates: readonly AtomicNodeBatchEntry[],
+  creates: readonly AtomicNodePostimageEntry[],
   updates: readonly AtomicNodeResolvedUpdateEntry[],
   timestamp: string,
   schemaFence: SchemaWriteFenceParams,

--- a/packages/typegraph/src/backend/drizzle/operations/strategy.ts
+++ b/packages/typegraph/src/backend/drizzle/operations/strategy.ts
@@ -12,7 +12,9 @@ import type {
   AtomicNodeBatchEntry,
   AtomicNodeBatchResultMode,
   AtomicNodeDeleteBatchInput,
+  AtomicNodePostimageEntry,
   AtomicNodeProjectionFamily,
+  AtomicNodeReplacementEntry,
   AtomicNodeResolvedUpdateEntry,
 } from "../../capabilities/atomic-mutation-program";
 import { nowIso } from "../../row-mappers";
@@ -66,6 +68,7 @@ import {
   buildAtomicNodeClaimCleanupWithSchemaFence,
   buildAtomicNodeClaimGatePredicateWithSchemaFence,
   buildAtomicNodeClaimUpsertWithSchemaFence,
+  buildAtomicNodeReplacementClaimReleaseWithSchemaFence,
 } from "./atomic-node-claims";
 import { buildClearGraph, type ClearGraphStatement } from "./clear";
 import {
@@ -137,6 +140,7 @@ import {
   buildAssertAtomicNodeProjectionEvidence,
   buildAtomicNodeBatchWithSchemaFence,
   buildAtomicNodeDeleteBatchWithSchemaFence,
+  buildAtomicNodeReplacementBatchWithSchemaFence,
   buildAtomicNodeResolvedUpdateBatch,
   buildDeleteNode,
   buildGetNode,
@@ -274,7 +278,7 @@ export type CommonOperationStrategy = Readonly<{
     schemaLockClause?: SQL,
   ) => SQL | undefined;
   buildAtomicNodeProjectionStatements: (
-    creates: readonly AtomicNodeBatchEntry[],
+    creates: readonly AtomicNodePostimageEntry[],
     updates: readonly AtomicNodeResolvedUpdateEntry[],
     timestamp: string,
     chunkSize: number,
@@ -302,22 +306,39 @@ export type CommonOperationStrategy = Readonly<{
     resultMode: AtomicNodeBatchResultMode,
     writeGate?: SQL,
   ) => SQL;
+  buildAtomicNodeReplacementBatchWithSchemaFence: (
+    entries: readonly AtomicNodeReplacementEntry[],
+    timestamp: string,
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+    writeGate?: SQL,
+  ) => SQL;
   buildAtomicNodeClaimUpsertWithSchemaFence: (
-    entries: readonly AtomicNodeClaimEntry[],
+    entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
     schemaFence: SchemaWriteFenceParams,
     schemaLockClause: SQL,
   ) => SQL;
   buildAtomicNodeClaimGatePredicateWithSchemaFence: (
-    entries: readonly AtomicNodeClaimEntry[],
+    entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
     schemaFence: SchemaWriteFenceParams,
     schemaLockClause: SQL,
   ) => SQL;
   buildAtomicNodeClaimCleanupWithSchemaFence: (
-    entries: readonly AtomicNodeClaimEntry[],
+    entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
     schemaFence: SchemaWriteFenceParams,
     schemaLockClause: SQL,
   ) => SQL;
   buildAtomicDeletedNodeClaimReleaseWithSchemaFence: (
+    input: Readonly<{
+      graphId: string;
+      kind: string;
+      ids: readonly string[];
+      timestamp: string;
+    }>,
+    schemaFence: SchemaWriteFenceParams,
+    schemaLockClause: SQL,
+  ) => SQL;
+  buildAtomicNodeReplacementClaimReleaseWithSchemaFence: (
     input: Readonly<{
       graphId: string;
       kind: string;
@@ -337,7 +358,7 @@ export type CommonOperationStrategy = Readonly<{
     schemaLockClause: SQL,
   ) => SQL;
   buildAssertAtomicNodeMutationPostimages: (
-    creates: readonly AtomicNodeBatchEntry[],
+    creates: readonly AtomicNodePostimageEntry[],
     updates: readonly AtomicNodeResolvedUpdateEntry[],
     timestamp: string,
     schemaFence: SchemaWriteFenceParams,
@@ -631,6 +652,7 @@ const COMMON_TABLE_OPERATION_BUILDERS = {
   buildInsertNodesBatchReturning,
   buildInsertNodesBatchWithSchemaFence,
   buildAtomicNodeBatchWithSchemaFence,
+  buildAtomicNodeReplacementBatchWithSchemaFence,
   buildGetNode,
   buildGetNodes,
   buildUpdateNode,
@@ -694,7 +716,7 @@ function createCommonOperationStrategy(
   // just the read-side fragments.
   const fulltextBuilders = {
     buildAtomicNodeProjectionStatements: (
-      creates: readonly AtomicNodeBatchEntry[],
+      creates: readonly AtomicNodePostimageEntry[],
       updates: readonly AtomicNodeResolvedUpdateEntry[],
       timestamp: string,
       chunkSize: number,
@@ -1036,7 +1058,7 @@ function createCommonOperationStrategy(
       return buildInsertUniqueBatch(tables, dialect, entries);
     },
     buildAtomicNodeClaimUpsertWithSchemaFence(
-      entries: readonly AtomicNodeClaimEntry[],
+      entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
       schemaFence: SchemaWriteFenceParams,
       schemaLockClause: SQL,
     ): SQL {
@@ -1049,7 +1071,7 @@ function createCommonOperationStrategy(
       );
     },
     buildAtomicNodeClaimGatePredicateWithSchemaFence(
-      entries: readonly AtomicNodeClaimEntry[],
+      entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
       schemaFence: SchemaWriteFenceParams,
       schemaLockClause: SQL,
     ): SQL {
@@ -1061,7 +1083,7 @@ function createCommonOperationStrategy(
       );
     },
     buildAtomicNodeClaimCleanupWithSchemaFence(
-      entries: readonly AtomicNodeClaimEntry[],
+      entries: readonly AtomicNodeClaimEntry<AtomicNodePostimageEntry>[],
       schemaFence: SchemaWriteFenceParams,
       schemaLockClause: SQL,
     ): SQL {
@@ -1083,6 +1105,23 @@ function createCommonOperationStrategy(
       schemaLockClause: SQL,
     ): SQL {
       return buildAtomicDeletedNodeClaimReleaseWithSchemaFence(
+        tables,
+        input,
+        schemaFence,
+        schemaLockClause,
+      );
+    },
+    buildAtomicNodeReplacementClaimReleaseWithSchemaFence(
+      input: Readonly<{
+        graphId: string;
+        kind: string;
+        ids: readonly string[];
+        timestamp: string;
+      }>,
+      schemaFence: SchemaWriteFenceParams,
+      schemaLockClause: SQL,
+    ): SQL {
+      return buildAtomicNodeReplacementClaimReleaseWithSchemaFence(
         tables,
         input,
         schemaFence,

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -2130,6 +2130,7 @@ export function createPostgresBackend(
     registerAtomicSqlProgram(backend, executionAdapter);
     registerAtomicMutationPrograms(backend, {
       createNodes: operations.executeAtomicNodeBatch,
+      replaceNodes: operations.executeAtomicNodeReplacementBatch,
       createEdges: operations.executeAtomicEdgeBatch,
       deleteNodes: operations.executeAtomicNodeDeleteBatch,
       deleteEdges: operations.executeAtomicEdgeDeleteBatch,
@@ -3416,6 +3417,7 @@ function createTransactionBackend(
     registerAtomicMutationPrograms(backend, {
       mutateNodes: requireDefined(backend.executeAtomicNodeResolvedMutationSet),
       mutateEdges: resolvedSetOnlyEdgeMutationProgram(mutateEdges),
+      replaceNodes: requireDefined(backend.executeAtomicNodeReplacementBatch),
     });
   }
 

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -2685,6 +2685,7 @@ export function createSqliteBackend(
     registerAtomicSqlProgram(backend, executionAdapter);
     registerAtomicMutationPrograms(backend, {
       createNodes: operations.executeAtomicNodeBatch,
+      replaceNodes: operations.executeAtomicNodeReplacementBatch,
       createEdges: operations.executeAtomicEdgeBatch,
       deleteNodes: operations.executeAtomicNodeDeleteBatch,
       deleteEdges: operations.executeAtomicEdgeDeleteBatch,

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -161,6 +161,8 @@ export type {
   AtomicNodeProjection,
   AtomicNodeProjectionFamily,
   AtomicNodeProjectionSupport,
+  AtomicNodeReplacementBatchExecutor,
+  AtomicNodeReplacementEntry,
   AtomicNodeResolvedMutationSetExecutor,
   AtomicNodeResolvedMutationSetResult,
   AtomicNodeResolvedUpdateBatchExecutor,

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -56,6 +56,7 @@ export type NodeOperations = Readonly<{
   executeCreateBatch: (
     inputs: readonly CreateNodeInput[],
     backend: GraphBackend | TransactionBackend,
+    options?: Readonly<{ propsPreValidated?: true }>,
   ) => Promise<readonly Node[]>;
   executeCreateNoReturnBatch: (
     inputs: readonly CreateNodeInput[],
@@ -86,6 +87,18 @@ export type NodeOperations = Readonly<{
       Readonly<{ created: readonly Node[]; updated: readonly Node[] }>
     >
   >;
+  prepareReplacement: (
+    kind: string,
+    props: Record<string, unknown>,
+  ) => Record<string, unknown>;
+  executeReplacementBatch: (
+    kind: string,
+    items: readonly Readonly<{
+      id: string;
+      props: Record<string, unknown>;
+    }>[],
+    backend: GraphBackend | TransactionBackend,
+  ) => Promise<ResolvedMutationSetAttempt<readonly Node[]>>;
   /**
    * Coalesce dirty-check for `upsertById` / `bulkUpsertById`. Present only when
    * the store was created with `coalesceUnchangedUpserts: true`; its absence is

--- a/packages/typegraph/src/store/collection-surface.ts
+++ b/packages/typegraph/src/store/collection-surface.ts
@@ -51,6 +51,7 @@ export const NODE_WRITE_NAMES = [
   "upsertById",
   "upsertByIdFromRecord",
   "bulkCreate",
+  "bulkReplaceById",
   "bulkUpsertById",
   "bulkInsert",
   "bulkDelete",

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -21,7 +21,7 @@ import {
   type NodeType,
   type TemporalMode,
 } from "../../core/types";
-import { ConfigurationError } from "../../errors";
+import { ConfigurationError, ValidationError } from "../../errors";
 import type { DynamicNodeAccessor, NodeAccessor } from "../../query/builder";
 import { type QueryBuilder } from "../../query/builder";
 import { type Predicate } from "../../query/predicates";
@@ -174,6 +174,8 @@ export type NodeUpsertUpdateBatchEntry = Readonly<{
   input: UpsertUpdateNodeInput;
   clearDeleted: boolean;
   existing?: BackendNodeRow;
+  /** Complete props already validated by the replacement API owner. */
+  replacementProps?: Record<string, unknown>;
 }>;
 
 /**
@@ -201,6 +203,7 @@ export type NodeCollectionConfig = Readonly<{
   executeCreateBatch: (
     inputs: readonly CreateNodeInput[],
     backend: GraphBackend | TransactionBackend,
+    options?: Readonly<{ propsPreValidated?: true }>,
   ) => Promise<readonly Node[]>;
   executeUpdate: (
     input: UpsertUpdateNodeInput,
@@ -227,6 +230,18 @@ export type NodeCollectionConfig = Readonly<{
       Readonly<{ created: readonly Node[]; updated: readonly Node[] }>
     >
   >;
+  prepareReplacement: (
+    kind: string,
+    props: Record<string, unknown>,
+  ) => Record<string, unknown>;
+  executeReplacementBatch: (
+    kind: string,
+    items: readonly Readonly<{
+      id: string;
+      props: Record<string, unknown>;
+    }>[],
+    backend: GraphBackend | TransactionBackend,
+  ) => Promise<ResolvedMutationSetAttempt<readonly Node[]>>;
   /** See NodeOperations.upsertDirtyCheck. */
   upsertDirtyCheck?: UpsertDirtyCheckFunction;
   executeDelete: (
@@ -382,6 +397,8 @@ export function createNodeCollection<
     executeUpdateWhere: executeNodeUpdateWhere,
     executeUpsertUpdateBatch: executeNodeUpsertUpdateBatch,
     executeResolvedMutationSet: executeNodeResolvedMutationSet,
+    prepareReplacement,
+    executeReplacementBatch: executeNodeReplacementBatch,
     executeDelete: executeNodeDelete,
     executeDeleteBatch: executeNodeDeleteBatch,
     executeHardDelete: executeNodeHardDelete,
@@ -744,6 +761,87 @@ export function createNodeCollection<
       const results = await executeNodeCreateBatch(batchInputs, backend);
       await config.maybeRefreshStatisticsAfterBulk?.(results.length);
       return narrowNodes<N>(results);
+    },
+
+    async bulkReplaceById(
+      items: readonly Readonly<{
+        id: string;
+        props: z.input<N["schema"]>;
+      }>[],
+    ): Promise<Node<N>[]> {
+      if (items.length === 0) return [];
+      const seenIds = new Set<string>();
+      for (const item of items) {
+        if (seenIds.has(item.id)) {
+          throw new ValidationError(
+            `bulkReplaceById requires distinct node ids; received "${item.id}" more than once.`,
+            {
+              entityType: "node",
+              kind,
+              operation: "update",
+              id: item.id,
+              issues: [],
+            },
+          );
+        }
+        seenIds.add(item.id);
+      }
+      const prepared = items.map((item) => ({
+        id: item.id,
+        props: prepareReplacement(kind, item.props),
+      }));
+      const attempt = await executeNodeReplacementBatch(
+        kind,
+        prepared,
+        backend,
+      );
+      if (attempt.outcome === "applied") {
+        await config.maybeRefreshStatisticsAfterBulk?.(attempt.value.length);
+        return narrowNodes<N>(attempt.value);
+      }
+      const results = await runOptionallyInTransaction(
+        backend,
+        async (target) => {
+          const rows = await getNodeRowsByIds(
+            target,
+            batchPointRead,
+            graphId,
+            kind,
+            prepared.map((item) => item.id),
+          );
+          const results = new Map<string, Node<N>>();
+          const creates = prepared.filter((item) => !rows.has(item.id));
+          const updates = prepared.filter((item) => rows.has(item.id));
+          if (creates.length > 0) {
+            const created = await executeNodeCreateBatch(
+              creates.map((item) =>
+                buildCreateInput(kind, item.props, { id: item.id }),
+              ),
+              target,
+              { propsPreValidated: true },
+            );
+            for (const row of created) results.set(row.id, narrowNode<N>(row));
+          }
+          if (updates.length > 0) {
+            const updated = await executeNodeUpsertUpdateBatch(
+              updates.map((item) => {
+                const existing = requireDefined(rows.get(item.id));
+                return {
+                  input: buildUpsertUpdateInput(kind, item.id, item.props),
+                  clearDeleted: existing.deleted_at !== undefined,
+                  existing,
+                  replacementProps: item.props,
+                };
+              }),
+              target,
+            );
+            for (const row of updated) results.set(row.id, narrowNode<N>(row));
+          }
+          return prepared.map((item) => requireDefined(results.get(item.id)));
+        },
+      );
+      await config.maybeRefreshStatisticsAfterBulk?.(results.length);
+      return results;
     },
 
     async bulkUpsertById(

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -21,7 +21,12 @@ import {
   type NodeType,
   type TemporalMode,
 } from "../../core/types";
-import { ConfigurationError, ValidationError } from "../../errors";
+import {
+  ConfigurationError,
+  ENTITY_ALREADY_EXISTS_CODE,
+  NodeNotFoundError,
+  ValidationError,
+} from "../../errors";
 import type { DynamicNodeAccessor, NodeAccessor } from "../../query/builder";
 import { type QueryBuilder } from "../../query/builder";
 import { type Predicate } from "../../query/predicates";
@@ -68,6 +73,16 @@ import {
   resolveTemporalReadParams,
   type TemporalReadParams,
 } from "./temporal-read-params";
+
+function isNodeReplacementPartitionMovement(error: unknown): boolean {
+  return (
+    error instanceof NodeNotFoundError ||
+    (error instanceof ValidationError &&
+      error.details.issues.some(
+        (issue) => issue.code === ENTITY_ALREADY_EXISTS_CODE,
+      ))
+  );
+}
 
 type OnImmutableLowerBound = "preserve" | "refuse";
 
@@ -799,46 +814,51 @@ export function createNodeCollection<
         await config.maybeRefreshStatisticsAfterBulk?.(attempt.value.length);
         return narrowNodes<N>(attempt.value);
       }
-      const results = await runOptionallyInTransaction(
+      const results = await runResolvedMutationSetConverging(
+        "node",
         backend,
-        async (target) => {
-          const rows = await getNodeRowsByIds(
-            target,
-            batchPointRead,
-            graphId,
-            kind,
-            prepared.map((item) => item.id),
-          );
-          const results = new Map<string, Node<N>>();
-          const creates = prepared.filter((item) => !rows.has(item.id));
-          const updates = prepared.filter((item) => rows.has(item.id));
-          if (creates.length > 0) {
-            const created = await executeNodeCreateBatch(
-              creates.map((item) =>
-                buildCreateInput(kind, item.props, { id: item.id }),
-              ),
+        () =>
+          runOptionallyInTransaction(backend, async (target) => {
+            const rows = await getNodeRowsByIds(
               target,
-              { propsPreValidated: true },
+              batchPointRead,
+              graphId,
+              kind,
+              prepared.map((item) => item.id),
             );
-            for (const row of created) results.set(row.id, narrowNode<N>(row));
-          }
-          if (updates.length > 0) {
-            const updated = await executeNodeUpsertUpdateBatch(
-              updates.map((item) => {
-                const existing = requireDefined(rows.get(item.id));
-                return {
-                  input: buildUpsertUpdateInput(kind, item.id, item.props),
-                  clearDeleted: existing.deleted_at !== undefined,
-                  existing,
-                  replacementProps: item.props,
-                };
-              }),
-              target,
-            );
-            for (const row of updated) results.set(row.id, narrowNode<N>(row));
-          }
-          return prepared.map((item) => requireDefined(results.get(item.id)));
-        },
+            const results = new Map<string, Node<N>>();
+            const creates = prepared.filter((item) => !rows.has(item.id));
+            const updates = prepared.filter((item) => rows.has(item.id));
+            if (creates.length > 0) {
+              const created = await executeNodeCreateBatch(
+                creates.map((item) =>
+                  buildCreateInput(kind, item.props, { id: item.id }),
+                ),
+                target,
+                { propsPreValidated: true },
+              );
+              for (const row of created)
+                results.set(row.id, narrowNode<N>(row));
+            }
+            if (updates.length > 0) {
+              const updated = await executeNodeUpsertUpdateBatch(
+                updates.map((item) => {
+                  const existing = requireDefined(rows.get(item.id));
+                  return {
+                    input: buildUpsertUpdateInput(kind, item.id, item.props),
+                    clearDeleted: existing.deleted_at !== undefined,
+                    existing,
+                    replacementProps: item.props,
+                  };
+                }),
+                target,
+              );
+              for (const row of updated)
+                results.set(row.id, narrowNode<N>(row));
+            }
+            return prepared.map((item) => requireDefined(results.get(item.id)));
+          }),
+        { isMovement: isNodeReplacementPartitionMovement },
       );
       await config.maybeRefreshStatisticsAfterBulk?.(results.length);
       return results;

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -12,6 +12,7 @@ import {
   type AtomicEdgeResolvedUpdateBatchExecutor,
   type AtomicNodeBatchExecutor as BackendAtomicNodeBatchExecutor,
   type AtomicNodeDeleteBatchExecutor,
+  type AtomicNodeReplacementBatchExecutor,
   type AtomicNodeResolvedMutationSetExecutor,
   type AtomicNodeResolvedUpdateBatchExecutor,
   resolveAtomicMutationPrograms,
@@ -133,6 +134,67 @@ export function resolveAtomicNodeBatchExecutor(
   }
 
   return profile.createNodes;
+}
+
+export type AtomicNodeReplacementEligibilityInput =
+  CommonAtomicMutationEligibility &
+    Readonly<{
+      registry: KindRegistry;
+      kind: string;
+      entryCount: number;
+      identityEnabled: boolean;
+    }>;
+
+/** The one owner of the static store proof for blind node replacement. */
+export function resolveAtomicNodeReplacementBatchProgram(
+  input: AtomicNodeReplacementEligibilityInput,
+):
+  | Readonly<{
+      executor: AtomicNodeReplacementBatchExecutor;
+      releaseClaims: boolean;
+    }>
+  | undefined {
+  if (input.entryCount === 0 || input.identityEnabled) return;
+  if (!hasOwnKey(input.graph.nodes, input.kind)) return;
+  const registration = input.graph.nodes[input.kind];
+  if (registration === undefined) return;
+  const executor = resolveAtomicMutationProfile(input)?.replaceNodes;
+  if (executor === undefined) return;
+  const releasedClaimFamilies = new Set(executor.releasedClaimFamilies);
+  const hasDisjointness =
+    input.registry.getDisjointKinds(input.kind).length > 0;
+  const hasUniqueness = (registration.unique ?? []).length > 0;
+  const maxEntries =
+    hasDisjointness || hasUniqueness ?
+      executor.maxEntries.claimed
+    : executor.maxEntries.plain;
+  if (input.entryCount > maxEntries) return;
+  if (
+    hasDisjointness &&
+    (!supportsAtomicNodeClaimFamily(executor.claimSupport, "disjointness") ||
+      !releasedClaimFamilies.has("disjointness"))
+  ) {
+    return;
+  }
+  if (
+    hasUniqueness &&
+    (!supportsAtomicNodeClaimFamily(executor.claimSupport, "uniqueness") ||
+      !releasedClaimFamilies.has("uniqueness"))
+  ) {
+    return;
+  }
+  if (
+    !supportsAtomicNodeProjections(
+      executor.projectionSupport,
+      atomicNodeProjectionFamilies(registration),
+    )
+  ) {
+    return;
+  }
+  return {
+    executor,
+    releaseClaims: hasDisjointness || hasUniqueness,
+  };
 }
 
 export type AtomicEdgeBatchEligibilityInput = CommonAtomicMutationEligibility &

--- a/packages/typegraph/src/store/operations/index.ts
+++ b/packages/typegraph/src/store/operations/index.ts
@@ -49,6 +49,7 @@ export {
   executeNodeFindByConstraint,
   executeNodeGetOrCreateByConstraint,
   executeNodeHardDelete,
+  executeNodeReplacementBatch,
   executeNodeResolvedMutationSet,
   executeNodeUpdate,
   executeNodeUpdateWhere,
@@ -56,6 +57,7 @@ export {
   executeNodeUpsertUpdateBatch,
   type NodeOperationContext,
   nodeUpsertDirtyCheck,
+  prepareNodeReplacement,
 } from "./node-operations";
 export { runWritePlan } from "./write-executor";
 export {

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -1799,6 +1799,9 @@ export async function executeNodeReplacementBatch<G extends GraphDef>(
       ...(projections === undefined ? {} : { projections }),
     }),
   );
+  if (executor.accepts?.(entries) === false) {
+    return unsupportedResolvedMutationSet();
+  }
   const returnedRows = await withAtomicNodeClaimTranslation(
     preparedCreates,
     () =>
@@ -1815,8 +1818,13 @@ export async function executeNodeReplacementBatch<G extends GraphDef>(
     await diagnoseAtomicNodeBatchNoRow(ctx, backend, preparedCreates);
   }
   if (returnedRows.length !== items.length) {
-    throw new CompilerInvariantError(
+    throw new DatabaseOperationError(
       "Atomic node replacement returned a partial result.",
+      {
+        operation: "upsert",
+        entity: "node",
+        attempted: items.map((item) => ({ kind, id: item.id })),
+      },
     );
   }
   memoizeLeasedSchemaFence(ctx, backend);

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -52,6 +52,7 @@ import {
   type AtomicNodeDeleteBatchExecutor,
   AtomicNodeDeleteRestrictedRefusalError,
   type AtomicNodeProjection,
+  type AtomicNodeReplacementEntry,
   type AtomicNodeResolvedUpdateBatchExecutor,
   supportsAtomicNodeClaims,
 } from "../../backend/capabilities/atomic-mutation-program";
@@ -209,6 +210,7 @@ import {
   assertAtomicDeleteSchemaFenceMatched,
   resolveAtomicNodeBatchExecutor,
   resolveAtomicNodeDeleteBatchExecutor,
+  resolveAtomicNodeReplacementBatchProgram,
   resolveAtomicNodeResolvedMutationSetExecutor,
   resolveAtomicNodeResolvedUpdateBatchExecutor,
 } from "./atomic-mutation-program";
@@ -1190,12 +1192,17 @@ export function nodeUpsertDirtyCheck<G extends GraphDef>(
   };
 }
 
+type NodeUpdateExecutionOptions = Readonly<{
+  clearDeleted?: boolean;
+  replacementProps?: Record<string, unknown>;
+}>;
+
 async function performNodeUpdate<G extends GraphDef>(
   ctx: NodeOperationContext<G>,
   input: UpsertUpdateNodeInput,
   session: NodeWriteSession,
   target: WriteTarget,
-  options?: Readonly<{ clearDeleted?: boolean }>,
+  options?: NodeUpdateExecutionOptions,
   resolvedExisting?: BackendNodeRow,
 ): Promise<Node> {
   const { kind, id } = input;
@@ -1206,11 +1213,13 @@ async function performNodeUpdate<G extends GraphDef>(
     resolvedExisting ?? (await target.getNode(ctx.graphId, kind, id));
   if (!existing) throw new NodeNotFoundError(kind, id);
 
-  const { registration, validatedProps } = resolveNodeUpdateProps(
-    ctx,
-    existing,
-    input.props,
-  );
+  const { registration, validatedProps } =
+    options?.replacementProps === undefined ?
+      resolveNodeUpdateProps(ctx, existing, input.props)
+    : {
+        registration: getNodeRegistration(ctx.graph, kind),
+        validatedProps: options.replacementProps,
+      };
   const nodeKind = registration.type;
 
   const validTo = validateOptionalCanonicalIsoDate(input.validTo, "validTo");
@@ -1389,7 +1398,7 @@ async function performNodeUpdateWithResurrectionRecovery<G extends GraphDef>(
   input: UpsertUpdateNodeInput,
   session: NodeWriteSession,
   target: WriteTarget,
-  options?: Readonly<{ clearDeleted?: boolean }>,
+  options?: NodeUpdateExecutionOptions,
   resolvedExisting?: BackendNodeRow,
 ): Promise<Node> {
   for (let attempt = 1; attempt <= NODE_UPDATE_ATTEMPTS; attempt += 1) {
@@ -1401,7 +1410,9 @@ async function performNodeUpdateWithResurrectionRecovery<G extends GraphDef>(
         input,
         session,
         target,
-        attempt === 1 ? options : undefined,
+        attempt === 1 ? options
+        : options?.replacementProps === undefined ? undefined
+        : { replacementProps: options.replacementProps },
         attempt === 1 ? resolvedExisting : undefined,
       );
     } catch (error) {
@@ -1722,6 +1733,98 @@ function atomicNodeBatchEntries(
     return;
   }
   return entries;
+}
+
+/**
+ * Validates a replacement document once for both atomic and portable paths.
+ * The portable update carries this complete postimage through its internal
+ * replacement marker instead of parsing or merging it again.
+ */
+export function prepareNodeReplacement<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  kind: string,
+  props: Record<string, unknown>,
+): Record<string, unknown> {
+  const schema = getNodeRegistration(ctx.graph, kind).type.schema;
+  return validateNodeProps(schema, props, { kind, operation: "update" });
+}
+
+/**
+ * Attempts one read-free, schema-fenced replacement program.
+ *
+ * `unsupported` proves that no SQL ran; the collection then enters the full
+ * portable upsert path with the replacement patches prepared above.
+ */
+export async function executeNodeReplacementBatch<G extends GraphDef>(
+  ctx: NodeOperationContext<G>,
+  kind: string,
+  items: readonly Readonly<{ id: string; props: Record<string, unknown> }>[],
+  backend: GraphBackend | TransactionBackend,
+): Promise<ResolvedMutationSetAttempt<readonly Node[]>> {
+  if (items.length === 0) return appliedResolvedMutationSet([]);
+  const program = resolveAtomicNodeReplacementBatchProgram({
+    backend,
+    graph: ctx.graph,
+    registry: ctx.registry,
+    kind,
+    entryCount: items.length,
+    schemaVersion: ctx.schemaVersion,
+    identityEnabled: ctx.identity !== undefined,
+    historyEnabled: ctx.historyEnabled,
+    revisionTrackingEnabled: ctx.revisionTrackingEnabled,
+  });
+  if (program === undefined) return unsupportedResolvedMutationSet();
+  const { executor, releaseClaims } = program;
+
+  const inputs = items.map((item) => ({
+    kind,
+    id: item.id,
+    props: item.props,
+  }));
+  const preparedCreates = await prepareAtomicBatchCreates(
+    ctx,
+    inputs,
+    backend,
+    { propsPreValidated: true },
+  );
+  const createEntries = atomicNodeBatchEntries(
+    preparedCreates,
+    executor.claimSupport,
+  );
+  if (createEntries === undefined) return unsupportedResolvedMutationSet();
+  const entries: readonly AtomicNodeReplacementEntry[] = createEntries.map(
+    ({ params, claims, projections }) => ({
+      params,
+      ...(claims === undefined ? {} : { claims }),
+      ...(projections === undefined ? {} : { projections }),
+    }),
+  );
+  const returnedRows = await withAtomicNodeClaimTranslation(
+    preparedCreates,
+    () =>
+      executor({
+        entries,
+        releaseClaims,
+        schemaFence: {
+          graphId: ctx.graphId,
+          expectedVersion: requireDefined(ctx.schemaVersion),
+        },
+      }),
+  );
+  if (returnedRows.length === 0) {
+    await diagnoseAtomicNodeBatchNoRow(ctx, backend, preparedCreates);
+  }
+  if (returnedRows.length !== items.length) {
+    throw new CompilerInvariantError(
+      "Atomic node replacement returned a partial result.",
+    );
+  }
+  memoizeLeasedSchemaFence(ctx, backend);
+  return appliedResolvedMutationSet(
+    restoreAtomicNodeBatchRows(ctx.graphId, preparedCreates, returnedRows).map(
+      (row) => rowToNode(row),
+    ),
+  );
 }
 
 async function withAtomicNodeClaimTranslation<TResult>(
@@ -3242,11 +3345,9 @@ export async function executeNodeResolvedMutationSet<G extends GraphDef>(
   }
   const resolvedUpdates = updates.map((entry) => {
     const existing = requireDefined(entry.existing);
-    const { validatedProps } = resolveNodeUpdateProps(
-      ctx,
-      existing,
-      entry.input.props,
-    );
+    const validatedProps =
+      entry.replacementProps ??
+      resolveNodeUpdateProps(ctx, existing, entry.input.props).validatedProps;
     return {
       graphId: ctx.graphId,
       kind: entry.input.kind,
@@ -3351,7 +3452,14 @@ export async function executeNodeUpsertUpdateBatch<G extends GraphDef>(
             entry.input,
             session,
             target,
-            entry.clearDeleted ? { clearDeleted: true } : undefined,
+            entry.clearDeleted || entry.replacementProps !== undefined ?
+              {
+                ...(entry.clearDeleted ? { clearDeleted: true } : {}),
+                ...(entry.replacementProps === undefined ?
+                  {}
+                : { replacementProps: entry.replacementProps }),
+              }
+            : undefined,
             resolvedRows?.get(entry.input.id),
           ),
         );
@@ -3408,11 +3516,9 @@ async function executeAtomicNodeResolvedUpdates<G extends GraphDef>(
     }
     const resolved = entries.map((entry) => {
       const row = requireDefined(byId.get(entry.input.id));
-      const { validatedProps } = resolveNodeUpdateProps(
-        ctx,
-        row,
-        entry.input.props,
-      );
+      const validatedProps =
+        entry.replacementProps ??
+        resolveNodeUpdateProps(ctx, row, entry.input.props).validatedProps;
       return {
         graphId: ctx.graphId,
         kind: entry.input.kind,

--- a/packages/typegraph/src/store/resolved-mutation-set.ts
+++ b/packages/typegraph/src/store/resolved-mutation-set.ts
@@ -68,6 +68,7 @@ export async function runResolvedMutationSetConverging<T>(
   entity: "node" | "edge",
   backend: GraphBackend | TransactionBackend,
   run: () => Promise<T>,
+  options?: Readonly<{ isMovement?: (error: unknown) => boolean }>,
 ): Promise<T> {
   for (
     let attempt = 1;
@@ -77,10 +78,10 @@ export async function runResolvedMutationSetConverging<T>(
     try {
       return await run();
     } catch (error) {
-      if (
-        !(error instanceof ResolvedMutationSetMoved) ||
-        !error.isOwnedBy(entity, backend)
-      ) {
+      const isOwnedAtomicMovement =
+        error instanceof ResolvedMutationSetMoved &&
+        error.isOwnedBy(entity, backend);
+      if (!isOwnedAtomicMovement && options?.isMovement?.(error) !== true) {
         throw error;
       }
       if (attempt === RESOLVED_MUTATION_SET_ATTEMPTS) {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -267,6 +267,7 @@ import {
   executeNodeFindByConstraint,
   executeNodeGetOrCreateByConstraint,
   executeNodeHardDelete,
+  executeNodeReplacementBatch,
   executeNodeResolvedMutationSet,
   executeNodeUpdate,
   executeNodeUpdateWhere,
@@ -274,6 +275,7 @@ import {
   lockSchemaVersionForStoreWrite,
   type NodeOperationContext,
   nodeUpsertDirtyCheck,
+  prepareNodeReplacement,
 } from "./operations";
 import {
   runInWriteTransaction,
@@ -1948,8 +1950,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       maybeRefreshStatisticsAfterBulk: (rowCount) =>
         this.#maybeRefreshStatisticsAfterBulk(rowCount),
       executeCreate: (input, backend) => executeNodeCreate(ctx, input, backend),
-      executeCreateBatch: (inputs, backend) =>
-        executeNodeCreateBatch(ctx, inputs, backend),
+      executeCreateBatch: (inputs, backend, options) =>
+        executeNodeCreateBatch(ctx, inputs, backend, options),
       executeCreateNoReturnBatch: (inputs, backend) =>
         executeNodeCreateNoReturnBatch(ctx, inputs, backend),
       executeUpdate: (input, backend, options) =>
@@ -1973,6 +1975,10 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         executeNodeUpsertUpdateBatch(ctx, entries, backend),
       executeResolvedMutationSet: (creates, updates, backend) =>
         executeNodeResolvedMutationSet(ctx, creates, updates, backend),
+      prepareReplacement: (kind, props) =>
+        prepareNodeReplacement(ctx, kind, props),
+      executeReplacementBatch: (kind, items, backend) =>
+        executeNodeReplacementBatch(ctx, kind, items, backend),
       // Present only when opted in; its absence is the coalesce off switch.
       ...(ctx.coalesceUnchangedUpsertsEnabled && {
         upsertDirtyCheck: (kind, id, existingProps, inputProps) =>

--- a/packages/typegraph/src/store/transaction-receipt.ts
+++ b/packages/typegraph/src/store/transaction-receipt.ts
@@ -107,6 +107,7 @@ const NODE_WRITE_INTENT_COUNTERS = {
   upsertById: countSingleWrite,
   upsertByIdFromRecord: countSingleWrite,
   bulkCreate: countBulkInputAt(0),
+  bulkReplaceById: countBulkInputAt(0),
   bulkUpsertById: countBulkInputAt(0),
   bulkInsert: countBulkInputAt(0),
   bulkDelete: countBulkInputAt(0),

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -1048,6 +1048,23 @@ export type NodeCollection<
   ) => Promise<Node<N>[]>;
 
   /**
+   * Replaces complete node documents by id.
+   *
+   * Missing ids are created. Tombstones are resurrected with a freshly stamped
+   * validity window. Live rows preserve their stored validity window. Unlike
+   * `bulkUpsertById`, every `props` value is a complete replacement: omitted
+   * optional fields are removed rather than merged from the stored document.
+   * Duplicate ids are refused because replacement describes a set, not an
+   * ordered script.
+   */
+  bulkReplaceById: (
+    items: readonly Readonly<{
+      id: string;
+      props: z.input<N["schema"]>;
+    }>[],
+  ) => Promise<Node<N>[]>;
+
+  /**
    * Insert multiple nodes without returning results.
    *
    * This is the dedicated fast path for bulk inserts. Unlike `bulkCreate`

--- a/packages/typegraph/tests/atomic-generated-node-batch-pglite.test.ts
+++ b/packages/typegraph/tests/atomic-generated-node-batch-pglite.test.ts
@@ -144,6 +144,11 @@ const composedGraph = defineGraph({
   },
   edges: {},
 });
+const replacementComposedGraph = defineGraph({
+  id: `${composedGraph.id}-replacement`,
+  nodes: composedGraph.nodes,
+  edges: {},
+});
 const ScopedPerson = defineNode("ScopedPerson", {
   schema: z.object({ email: z.string() }),
 });
@@ -506,6 +511,47 @@ describe("constrained generated-node atomic SQL on PGlite", () => {
         limit: 10,
       }),
     ).resolves.toHaveLength(0);
+  });
+
+  it("replaces claimed projected nodes through one PostgreSQL program", async () => {
+    const directBackend = createPostgresBackend(backend.db, { vector: false });
+    const [store] = await createStoreWithSchema(
+      replacementComposedGraph,
+      directBackend,
+    );
+
+    await store.nodes.ComposedDocument.bulkInsert([
+      {
+        id: "replace-a",
+        props: { slug: "a", tenant: "tenant", title: "Before A" },
+      },
+      {
+        id: "replace-b",
+        props: { slug: "b", tenant: "tenant", title: "Before B" },
+      },
+    ]);
+
+    const rows = await store.nodes.ComposedDocument.bulkReplaceById([
+      {
+        id: "replace-a",
+        props: { slug: "released", tenant: "tenant", title: "Quasar A" },
+      },
+      {
+        id: "replace-b",
+        props: { slug: "a", tenant: "tenant", title: "Quasar B" },
+      },
+    ]);
+
+    expect(rows.map((row) => [row.id, row.slug, row.title])).toEqual([
+      ["replace-a", "released", "Quasar A"],
+      ["replace-b", "a", "Quasar B"],
+    ]);
+    await expect(
+      store.search.fulltext("ComposedDocument", {
+        query: "Quasar",
+        limit: 10,
+      }),
+    ).resolves.toHaveLength(2);
   });
 
   it("refuses a legacy cross-scope claim through the PostgreSQL program", async () => {

--- a/packages/typegraph/tests/atomic-mutation-program-conformance-bundled-libsql.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-conformance-bundled-libsql.test.ts
@@ -253,6 +253,18 @@ function buildCases(
   const createNodesStale = scenario(client, backend, "create-nodes-stale");
   const createNodesRefusal = scenario(client, backend, "create-nodes-refusal");
 
+  const replaceNodesSuccess = scenario(
+    client,
+    backend,
+    "replace-nodes-success",
+  );
+  const replaceNodesStale = scenario(client, backend, "replace-nodes-stale");
+  const replaceNodesRefusal = scenario(
+    client,
+    backend,
+    "replace-nodes-refusal",
+  );
+
   const createEdgesSuccess = scenario(client, backend, "create-edges-success");
   const createEdgesStale = scenario(client, backend, "create-edges-stale");
   const createEdgesRefusal = scenario(client, backend, "create-edges-refusal");
@@ -347,6 +359,79 @@ function buildCases(
             },
           ]),
         observeState: createNodesRefusal.observe,
+        errorMatches: (error) => error instanceof ValidationError,
+      },
+    },
+    {
+      variant: "replaceNodes",
+      orderedSuccess: {
+        prepare: async () => {
+          const store = await replaceNodesSuccess.open();
+          await store.nodes.Person.bulkInsert([
+            {
+              id: "replace-existing",
+              props: { name: "Before", score: 0 },
+            },
+          ]);
+          return {
+            expectedResult: [
+              ["replace-new", "New"],
+              ["replace-existing", "After"],
+            ],
+            expectedState: {
+              edges: [],
+              nodes: [
+                ["replace-existing", "After", 2],
+                ["replace-new", "New", 1],
+              ],
+            },
+          };
+        },
+        execute: async () => {
+          const nodes = await replaceNodesSuccess
+            .requireStore()
+            .nodes.Person.bulkReplaceById([
+              {
+                id: "replace-new",
+                props: { name: "New", score: 1 },
+              },
+              {
+                id: "replace-existing",
+                props: { name: "After", score: 2 },
+              },
+            ]);
+          return nodes.map((node) => [node.id, node.name]);
+        },
+        observeState: replaceNodesSuccess.observe,
+      },
+      staleFenceNoWrite: {
+        dispatch: "required",
+        prepare: async () => {
+          await replaceNodesStale.open();
+          await replaceNodesStale.stale();
+          return { expectedState: await replaceNodesStale.observe() };
+        },
+        execute: () =>
+          replaceNodesStale
+            .requireStore()
+            .nodes.Person.bulkReplaceById([
+              { id: "stale-replace", props: { name: "Stale", score: 1 } },
+            ]),
+        observeState: replaceNodesStale.observe,
+        errorMatches: (error) => error instanceof StaleVersionError,
+      },
+      semanticRefusalRollback: {
+        dispatch: "pre-dispatch",
+        prepare: async () => {
+          await replaceNodesRefusal.open();
+          return { expectedState: await replaceNodesRefusal.observe() };
+        },
+        execute: () =>
+          replaceNodesRefusal.requireStore().nodes.Person.bulkReplaceById([
+            { id: "repeated-node", props: { name: "First", score: 2 } },
+            { id: "repeated-node", props: { name: "Second", score: 3 } },
+          ]),
+        observeState: replaceNodesRefusal.observe,
         errorMatches: (error) => error instanceof ValidationError,
       },
     },
@@ -1314,6 +1399,7 @@ describe("bundled atomic mutation program semantic conformance: libSQL", () => {
       );
       expect(required).toEqual([
         "createNodes",
+        "replaceNodes",
         "createEdges",
         "deleteNodes",
         "deleteEdges",

--- a/packages/typegraph/tests/atomic-mutation-program-pglite-routing.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-pglite-routing.test.ts
@@ -51,6 +51,7 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
         ),
       ).toEqual([
         "createNodes",
+        "replaceNodes",
         "createEdges",
         "deleteNodes",
         "deleteEdges",
@@ -100,6 +101,12 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
             { id: "created-node-a", props: { name: "A", score: 10 } },
             { id: "created-node-b", props: { name: "B", score: 11 } },
           ]);
+          await store.nodes.Person.bulkReplaceById([
+            {
+              id: "created-node-a",
+              props: { name: "Replaced A", score: 12 },
+            },
+          ]);
           await store.edges.relates.bulkCreate([
             {
               id: "created-edge-a",
@@ -131,6 +138,7 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
 
       expect(dispatched).toEqual([
         "createNodes",
+        "replaceNodes",
         "createEdges",
         "updateNodes",
         "updateEdges",
@@ -182,6 +190,7 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
               resolveAtomicMutationPrograms(transactionBackend),
             );
             expect(Object.keys(sessionProfile)).toEqual([
+              "replaceNodes",
               "mutateNodes",
               "mutateEdges",
             ]);
@@ -193,7 +202,11 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
                 sessionProfile,
                 transactionBackend.capabilities.execution,
               ),
-            ).toEqual(["mutateNodes", "mutateEdges.resolvedSet"]);
+            ).toEqual([
+              "replaceNodes",
+              "mutateNodes",
+              "mutateEdges.resolvedSet",
+            ]);
             const ordinaryWrapper = deriveBackend(transactionBackend, {});
             expect(ordinaryWrapper.capabilities.execution.atomicBatch).toBe(
               "none",
@@ -236,8 +249,8 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
       expect(dispatched).toEqual(["mutateNodes", "mutateEdges.resolvedSet"]);
 
       dispatched.length = 0;
-      await store.transaction((tx) =>
-        tx.nodes.Person.bulkUpsertById([
+      await store.transaction(async (tx) => {
+        await tx.nodes.Person.bulkUpsertById([
           {
             id: "caller-session-new",
             props: { name: "Caller new", score: 6 },
@@ -246,9 +259,15 @@ describe("interactive PostgreSQL atomic mutation routing", () => {
             id: requireDefined(existingNode).id,
             props: { name: "Caller updated", score: 7 },
           },
-        ]),
-      );
-      expect(dispatched).toEqual(["mutateNodes"]);
+        ]);
+        await tx.nodes.Person.bulkReplaceById([
+          {
+            id: "caller-session-replace",
+            props: { name: "Caller replaced", score: 8 },
+          },
+        ]);
+      });
+      expect(dispatched).toEqual(["mutateNodes", "replaceNodes"]);
 
       dispatched.length = 0;
       const repeated = await store.nodes.Person.bulkUpsertById([

--- a/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
+++ b/packages/typegraph/tests/atomic-mutation-program-profile.test.ts
@@ -14,6 +14,7 @@ import {
   type AtomicNodeBatchExecutor,
   type AtomicNodeBatchInput,
   atomicNodeClaimInputCost,
+  type AtomicNodeReplacementBatchExecutor,
   type AtomicNodeResolvedUpdateBatchExecutor,
   hasAtomicMutationProgramRegistration,
   registerAtomicMutationPrograms,
@@ -562,6 +563,30 @@ describe("atomic mutation program execution profile", () => {
         code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
         family: "mutateEdges",
         limit: "maxEntries.durableConvergence",
+      },
+    });
+    expect(hasAtomicMutationProgramRegistration(backend)).toBe(false);
+  });
+
+  it("refuses malformed replacement limits before publishing the profile", () => {
+    const backend = createCustomAtomicRoot();
+    registerAtomicSqlProgram(backend, emptyAtomicBatch);
+    const replaceNodes = (() =>
+      Promise.resolve([])) as unknown as AtomicNodeReplacementBatchExecutor;
+    Object.defineProperty(replaceNodes, "maxEntries", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const error = captureThrown(() =>
+      registerAtomicMutationPrograms(backend, { replaceNodes }),
+    );
+    expect(error).toBeInstanceOf(ConfigurationError);
+    expect(error).toMatchObject({
+      details: {
+        code: "ATOMIC_MUTATION_PROGRAM_REGISTRATION_MISMATCH",
+        family: "replaceNodes",
+        limit: "maxEntries",
       },
     });
     expect(hasAtomicMutationProgramRegistration(backend)).toBe(false);

--- a/packages/typegraph/tests/atomic-node-replacement.test.ts
+++ b/packages/typegraph/tests/atomic-node-replacement.test.ts
@@ -8,6 +8,7 @@ import { z } from "zod";
 
 import { StaleVersionError, UniquenessError } from "../src";
 import { deriveBackend } from "../src/backend/derive-backend";
+import { atomicNodeReplacementSubmissionMaxEntries } from "../src/backend/drizzle/operation-backend-core";
 import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
 import { defineGraph, defineNode, searchable } from "../src/core";
 import { migrateSchema } from "../src/schema";
@@ -83,6 +84,12 @@ async function closeFixture(
 }
 
 describe("atomic node replacement", () => {
+  it("derives its advertised ceiling from the replacement chunk budget", () => {
+    expect(atomicNodeReplacementSubmissionMaxEntries(100)).toBe(311);
+    expect(atomicNodeReplacementSubmissionMaxEntries(101)).toBe(311);
+    expect(atomicNodeReplacementSubmissionMaxEntries(102)).toBe(311);
+  });
+
   it("creates, replaces, and resurrects complete documents in one exchange", async () => {
     const fixture = await createFixture();
     try {
@@ -155,6 +162,26 @@ describe("atomic node replacement", () => {
     }
   });
 
+  it("admits claimed batches by actual statement work beyond 32 members", async () => {
+    const fixture = await createFixture();
+    try {
+      const items = Array.from({ length: 33 }, (_, index) => ({
+        id: `claimed-${index}`,
+        props: { slug: `slug-${index}`, title: `Title ${index}` },
+      }));
+      const batch = vi.spyOn(fixture.client, "batch");
+      const execute = vi.spyOn(fixture.client, "execute");
+
+      await expect(
+        fixture.store.nodes.Document.bulkReplaceById(items),
+      ).resolves.toHaveLength(items.length);
+      expect(batch).toHaveBeenCalledOnce();
+      expect(execute).not.toHaveBeenCalled();
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
   it("preserves replacement semantics on an unregistered derived backend", async () => {
     const fixture = await createFixture();
     try {
@@ -179,6 +206,37 @@ describe("atomic node replacement", () => {
       });
       expect(row?.note).toBeUndefined();
       expect(batch).not.toHaveBeenCalled();
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("rebuilds the portable partition after a concurrent create", async () => {
+    const fixture = await createFixture();
+    try {
+      const getNodes = fixture.backend.getNodes;
+      expect(getNodes).toBeDefined();
+      let injected = false;
+      const racingBackend = deriveBackend(fixture.backend, {
+        getNodes: async (graphId, kind, ids) => {
+          const rows = await getNodes?.(graphId, kind, ids);
+          if (!injected) {
+            injected = true;
+            await fixture.store.nodes.Document.create(
+              { slug: "raced", title: "Concurrent" },
+              { id: "raced" },
+            );
+          }
+          return rows ?? [];
+        },
+      });
+      const [portable] = await createVerifiedStore(graph, racingBackend);
+
+      await expect(
+        portable.nodes.Document.bulkReplaceById([
+          { id: "raced", props: { slug: "raced", title: "Replacement" } },
+        ]),
+      ).resolves.toMatchObject([{ id: "raced", title: "Replacement" }]);
     } finally {
       await closeFixture(fixture);
     }

--- a/packages/typegraph/tests/atomic-node-replacement.test.ts
+++ b/packages/typegraph/tests/atomic-node-replacement.test.ts
@@ -1,0 +1,262 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createClient } from "@libsql/client";
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { StaleVersionError, UniquenessError } from "../src";
+import { deriveBackend } from "../src/backend/derive-backend";
+import { createLibsqlBackend } from "../src/backend/sqlite/libsql";
+import { defineGraph, defineNode, searchable } from "../src/core";
+import { migrateSchema } from "../src/schema";
+import { createStoreWithSchema, createVerifiedStore } from "../src/store";
+
+const Document = defineNode("Document", {
+  schema: z.object({
+    slug: z.string(),
+    title: searchable(),
+    note: z.string().optional(),
+  }),
+});
+const TransformDocument = defineNode("TransformDocument", {
+  schema: z.object({ token: z.string().transform((value) => `${value}!`) }),
+});
+
+const graph = defineGraph({
+  id: "atomic-node-replacement",
+  nodes: {
+    Document: {
+      type: Document,
+      unique: [
+        {
+          name: "document_slug",
+          fields: ["slug"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    TransformDocument: { type: TransformDocument },
+  },
+  edges: {},
+});
+
+const evolvedGraph = defineGraph({
+  id: graph.id,
+  nodes: {
+    Document: {
+      type: defineNode("Document", {
+        schema: z.object({
+          slug: z.string(),
+          title: searchable(),
+          note: z.string().optional(),
+          revision: z.string().optional(),
+        }),
+      }),
+      unique: graph.nodes.Document.unique,
+    },
+    TransformDocument: { type: TransformDocument },
+  },
+  edges: {},
+});
+
+async function createFixture() {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "typegraph-atomic-node-replacement-"),
+  );
+  const client = createClient({
+    url: `file:${path.join(temporaryDirectory, "graph.db")}`,
+  });
+  const { backend } = await createLibsqlBackend(client);
+  const [store] = await createStoreWithSchema(graph, backend);
+  return { backend, client, store, temporaryDirectory };
+}
+
+async function closeFixture(
+  fixture: Awaited<ReturnType<typeof createFixture>>,
+): Promise<void> {
+  await fixture.backend.close();
+  fixture.client.close();
+  rmSync(fixture.temporaryDirectory, { recursive: true, force: true });
+}
+
+describe("atomic node replacement", () => {
+  it("creates, replaces, and resurrects complete documents in one exchange", async () => {
+    const fixture = await createFixture();
+    try {
+      const live = await fixture.store.nodes.Document.create(
+        { slug: "live", title: "Before", note: "remove me" },
+        {
+          id: "live",
+          validFrom: "2026-01-01T00:00:00.000Z",
+          validTo: "2027-01-01T00:00:00.000Z",
+        },
+      );
+      await fixture.store.nodes.Document.create(
+        { slug: "deleted", title: "Deleted", note: "old" },
+        { id: "deleted", validFrom: "2020-01-01T00:00:00.000Z" },
+      );
+      await fixture.store.nodes.Document.delete("deleted" as never);
+      const batch = vi.spyOn(fixture.client, "batch");
+      const execute = vi.spyOn(fixture.client, "execute");
+
+      const rows = await fixture.store.nodes.Document.bulkReplaceById([
+        { id: "new", props: { slug: "new", title: "Created" } },
+        { id: "live", props: { slug: "live", title: "Replaced" } },
+        {
+          id: "deleted",
+          props: { slug: "deleted", title: "Resurrected" },
+        },
+      ]);
+
+      expect(batch).toHaveBeenCalledOnce();
+      expect(execute).not.toHaveBeenCalled();
+      expect(rows.map((row) => [row.id, row.title, row.note])).toEqual([
+        ["new", "Created", undefined],
+        ["live", "Replaced", undefined],
+        ["deleted", "Resurrected", undefined],
+      ]);
+      expect(rows[1]?.meta.validFrom).toBe(live.meta.validFrom);
+      expect(rows[1]?.meta.validTo).toBe(live.meta.validTo);
+      expect(rows[2]?.meta.validFrom).not.toBe("2020-01-01T00:00:00.000Z");
+      await expect(
+        fixture.store.search.fulltext("Document", {
+          query: "Created OR Replaced OR Resurrected",
+          mode: "raw",
+          limit: 10,
+        }),
+      ).resolves.toHaveLength(3);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("moves unique claims across replacement members atomically", async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.store.nodes.Document.bulkInsert([
+        { id: "a", props: { slug: "shared", title: "A" } },
+        { id: "b", props: { slug: "other", title: "B" } },
+      ]);
+
+      await expect(
+        fixture.store.nodes.Document.bulkReplaceById([
+          { id: "a", props: { slug: "released", title: "A2" } },
+          { id: "b", props: { slug: "shared", title: "B2" } },
+        ]),
+      ).resolves.toMatchObject([
+        { id: "a", slug: "released" },
+        { id: "b", slug: "shared" },
+      ]);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("preserves replacement semantics on an unregistered derived backend", async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.store.nodes.Document.create(
+        { slug: "portable", title: "Before", note: "remove me" },
+        { id: "portable" },
+      );
+      const [portable] = await createVerifiedStore(
+        graph,
+        deriveBackend(fixture.backend, {}),
+      );
+      const batch = vi.spyOn(fixture.client, "batch");
+
+      const [row] = await portable.nodes.Document.bulkReplaceById([
+        { id: "portable", props: { slug: "portable", title: "After" } },
+      ]);
+
+      expect(row).toMatchObject({
+        id: "portable",
+        slug: "portable",
+        title: "After",
+      });
+      expect(row?.note).toBeUndefined();
+      expect(batch).not.toHaveBeenCalled();
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("applies schema transforms once on atomic and portable paths", async () => {
+    const fixture = await createFixture();
+    try {
+      const [atomic] =
+        await fixture.store.nodes.TransformDocument.bulkReplaceById([
+          { id: "atomic", props: { token: "atomic" } },
+        ]);
+      const [portable] = await createVerifiedStore(
+        graph,
+        deriveBackend(fixture.backend, {}),
+      );
+      const rows = await portable.nodes.TransformDocument.bulkReplaceById([
+        { id: "atomic", props: { token: "portable-live" } },
+        { id: "portable-new", props: { token: "portable-new" } },
+      ]);
+
+      expect(atomic?.token).toBe("atomic!");
+      expect(rows.map((row) => row.token)).toEqual([
+        "portable-live!",
+        "portable-new!",
+      ]);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("rolls every member back when a replacement claim is refused", async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.store.nodes.Document.bulkInsert([
+        { id: "a", props: { slug: "a", title: "Before A" } },
+        { id: "b", props: { slug: "b", title: "Before B" } },
+      ]);
+
+      await expect(
+        fixture.store.nodes.Document.bulkReplaceById([
+          { id: "a", props: { slug: "same", title: "After A" } },
+          { id: "b", props: { slug: "same", title: "After B" } },
+        ]),
+      ).rejects.toBeInstanceOf(UniquenessError);
+      await expect(
+        fixture.store.nodes.Document.getById("a" as never),
+      ).resolves.toMatchObject({ slug: "a", title: "Before A" });
+      await expect(
+        fixture.store.nodes.Document.getById("b" as never),
+      ).resolves.toMatchObject({ slug: "b", title: "Before B" });
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+
+  it("rolls replacements and sidecars back on a stale schema fence", async () => {
+    const fixture = await createFixture();
+    try {
+      await fixture.store.nodes.Document.create(
+        { slug: "stale", title: "Before" },
+        { id: "stale" },
+      );
+      await migrateSchema(fixture.backend, evolvedGraph, 1);
+
+      await expect(
+        fixture.store.nodes.Document.bulkReplaceById([
+          { id: "stale", props: { slug: "stale", title: "After" } },
+        ]),
+      ).rejects.toBeInstanceOf(StaleVersionError);
+      await expect(
+        fixture.store.search.fulltext("Document", {
+          query: "After",
+          limit: 10,
+        }),
+      ).resolves.toHaveLength(0);
+    } finally {
+      await closeFixture(fixture);
+    }
+  });
+});

--- a/packages/typegraph/tests/write-exchange-inventory.test.ts
+++ b/packages/typegraph/tests/write-exchange-inventory.test.ts
@@ -247,6 +247,18 @@ describe("managed write exchange inventory", () => {
             },
           ]),
         ),
+        await measure("claim-projection-node-replacement-batch", () =>
+          store.nodes.ClaimedDocument.bulkReplaceById([
+            {
+              id: "claimed-document-a",
+              props: { slug: "a2", title: "Replaced projection A" },
+            },
+            {
+              id: "claimed-document-b",
+              props: { slug: "b2", title: "Replaced projection B" },
+            },
+          ]),
+        ),
         await measure("unconstrained-edge-batch", () =>
           store.edges.unconstrained.bulkInsert([
             { from, to, props: { role: "U1" } },
@@ -390,6 +402,11 @@ describe("managed write exchange inventory", () => {
             "batch": 1,
             "execute": 0,
             "name": "claim-projection-node-batch",
+          },
+          {
+            "batch": 1,
+            "execute": 0,
+            "name": "claim-projection-node-replacement-batch",
           },
           {
             "batch": 1,


### PR DESCRIPTION
Adds a dedicated node-only `bulkReplaceById` API for complete-document replacement. Missing ids are created, live rows preserve their stored validity windows, and tombstones are resurrected with a freshly stamped window. Omitted optional properties are removed rather than merged, duplicate ids are refused, and history, revision tracking, and Operational Identity retain the portable path.

Eligible bundled roots now execute replacement as one read-free atomic submission. The program composes schema fencing, prior claim release, postimage claim acquisition, row replacement, fulltext and embedding projection transitions, contribution evidence, ordered postimage restoration, and terminal assertions. Bind-weighted chunking and the existing mutation-statement ceiling keep admitted submissions inside declared transport budgets.

Admission and execution share the same replacement chunk planner. Bundled executors expose an exact no-SQL `accepts(entries)` proof, so unusual bind budgets cannot be admitted by a sibling formula and claimed batches are judged by their actual work rather than a fixed 32-member ceiling.

The operation follows the explicit `applied | unsupported` boundary: unsupported proves that no SQL ran before the Store enters the complete portable path. The fallback performs one authoritative batch read, partitions creates from updates, and executes the same replacement semantics inside the available transaction boundary. Its partition is rebuilt through the shared convergence loop if a concurrent create or delete invalidates that read.

The custom-backend profile gains an independently registered and certifiable `replaceNodes` family with explicit plain and claimed entry ceilings, optional exact admission, claim-release metadata, and projection support. The defining executor and entry types are exported from the backend-authoring entrypoint.

Replacement documents are parsed exactly once. The prepared complete postimage is carried through both the atomic and portable paths, preventing non-idempotent Zod transforms from being applied twice; temporarily removing that marker makes the parity regression test fail.

On the measured libSQL transport, an eligible claimed and projected replacement batch records one atomic batch submission and zero ordinary execute exchanges. Documentation and the API reports describe the replacement contract, fallback envelope, custom-backend obligations, and performance shape.