### PR TITLE
fix: harden release fences and temporal ordering

### DIFF
--- a/.changeset/release-hardening-fences-ordering.md
+++ b/.changeset/release-hardening-fences-ordering.md
@@ -2,6 +2,6 @@
 "@nicia-ai/typegraph": patch
 ---
 
-Fence constrained writes inside caller-adopted SQLite transactions by taking the writer slot before decision-driving reads, acquire graph-merge locks in the canonical schema-first order, and compile temporal-system `orderBy` fields against their physical columns instead of a missing JSON property.
+Fence constrained writes inside caller-adopted SQLite transactions by taking the writer slot before decision-driving reads, acquire graph-merge locks in the canonical schema-first order, and compile temporal-system `orderBy` fields against their physical columns when the schema does not declare a same-named property. Declared properties retain precedence so filtering and ordering use the same field.
 
 Bulk node and edge wrappers now have regression coverage that pins one durable revision advance per public bulk call rather than one advance per member.

--- a/.changeset/release-hardening-fences-ordering.md
+++ b/.changeset/release-hardening-fences-ordering.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Fence constrained writes inside caller-adopted SQLite transactions by taking the writer slot before decision-driving reads, acquire graph-merge locks in the canonical schema-first order, and compile temporal-system `orderBy` fields against their physical columns instead of a missing JSON property.
+
+Bulk node and edge wrappers now have regression coverage that pins one durable revision advance per public bulk call rather than one advance per member.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,7 @@ jobs:
           --reporter=default
           --reporter=blob
           --outputFile.blob=.vitest-reports/blob-${{ matrix.artifact }}.json
+          --testTimeout=15000
           --coverage.thresholds.branches=0
           --coverage.thresholds.functions=0
           --coverage.thresholds.lines=0

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -694,6 +694,13 @@ untouched — see
 [Declared constraints require an interactive transaction](/backend-setup#declared-constraints-require-an-interactive-transaction)
 for what still works there.
 
+`CONSTRAINT_TRANSACTION_NOT_WRITE_FENCED` is the corresponding refusal for a
+caller-adopted SQLite transaction whose `DEFERRED` snapshot became stale before
+the constrained write could take the writer slot. Roll back that transaction
+and retry it with `BEGIN IMMEDIATE`; TypeGraph-owned transactions already use
+that mode. The refusal happens before the constraint probe, so the write is
+fenced or refused rather than allowed to rely on a stale decision.
+
 #### Write-fence declaration codes
 
 `capabilities.pessimisticLocks` resolves one of three write-fence plans a

--- a/apps/docs/src/content/docs/queries/order.md
+++ b/apps/docs/src/content/docs/queries/order.md
@@ -66,6 +66,24 @@ Or use the array syntax:
 ])
 ```
 
+### Temporal System Columns
+
+The alias form can order directly by TypeGraph's physical temporal metadata:
+`valid_from`, `valid_to`, `created_at`, `updated_at`, and `deleted_at`. These
+names resolve to system columns, not properties inside `props`:
+
+```typescript
+const oldestFirst = await store
+  .query()
+  .from("Task", "t")
+  .orderBy("t", "valid_from", "asc")
+  .select((ctx) => ctx.t)
+  .execute();
+```
+
+The same classification applies whether `orderBy()` appears before or after
+`select()`.
+
 ### Null Handling
 
 Control where null values appear:

--- a/apps/docs/src/content/docs/queries/order.md
+++ b/apps/docs/src/content/docs/queries/order.md
@@ -69,8 +69,9 @@ Or use the array syntax:
 ### Temporal System Columns
 
 The alias form can order directly by TypeGraph's physical temporal metadata:
-`valid_from`, `valid_to`, `created_at`, `updated_at`, and `deleted_at`. These
-names resolve to system columns, not properties inside `props`:
+`valid_from`, `valid_to`, `created_at`, `updated_at`, and `deleted_at`. When the
+queried node or edge kinds do not declare a property with that name, it resolves
+to the physical system column:
 
 ```typescript
 const oldestFirst = await store
@@ -83,6 +84,12 @@ const oldestFirst = await store
 
 The same classification applies whether `orderBy()` appears before or after
 `select()`.
+
+A declared property takes precedence over same-named temporal metadata. For
+example, if `Task` declares its own `created_at` property,
+`whereNode("t", (field) => field.created_at...)` and
+`orderBy("t", "created_at")` both address `props.created_at`. Rename the
+property when a query must order by TypeGraph's physical `created_at` column.
 
 ### Null Handling
 

--- a/apps/docs/src/content/docs/recipes.md
+++ b/apps/docs/src/content/docs/recipes.md
@@ -722,6 +722,13 @@ once at startup with `createAdapterStoreWithSchema(graph, backend)` so
 fulltext-backed writes find their durable materialization marker; an uninitialized store
 throws `StoreNotInitializedError` instead of migrating mid-transaction.
 
+On SQLite, open caller-owned transactions that may perform constrained writes
+with `BEGIN IMMEDIATE`. TypeGraph probes the writer slot before any
+decision-driving constraint read; if a `DEFERRED` snapshot was invalidated by a
+concurrent commit, the operation refuses with
+`CONSTRAINT_TRANSACTION_NOT_WRITE_FENCED` and the caller must roll back and
+retry the whole transaction.
+
 `withTransaction` throws `ConfigurationError` on backends that cannot provide
 real rollback (`backend.capabilities.execution.interactiveTransactions === false`:
 `drizzle-orm/neon-http`, Cloudflare D1, SQLite `transactionMode: "none"`) —

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -628,24 +628,6 @@ export const STATEMENT_EXECUTION = {
       ],
     },
     {
-      operation: "adopted constraint transaction writer-slot proof",
-      disposition: {
-        kind: "refuse",
-        code: "CONSTRAINT_WRITE_FENCE_UNSUPPORTED",
-      },
-      sites: [
-        {
-          file: "store/operations/write-transaction.ts",
-          member: "executeStatement",
-          rewiring: {
-            class: "reasoned",
-            reason:
-              "the exact adopted transaction must presence-test and invoke its own statement port before any decision-driving read; a separately resolved bundle would not prove execution on that transaction resource",
-          },
-        },
-      ],
-    },
-    {
       operation: "recorded-time migration",
       disposition: {
         kind: "refuse",

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -628,6 +628,24 @@ export const STATEMENT_EXECUTION = {
       ],
     },
     {
+      operation: "adopted constraint transaction writer-slot proof",
+      disposition: {
+        kind: "refuse",
+        code: "CONSTRAINT_WRITE_FENCE_UNSUPPORTED",
+      },
+      sites: [
+        {
+          file: "store/operations/write-transaction.ts",
+          member: "executeStatement",
+          rewiring: {
+            class: "reasoned",
+            reason:
+              "the exact adopted transaction must presence-test and invoke its own statement port before any decision-driving read; a separately resolved bundle would not prove execution on that transaction resource",
+          },
+        },
+      ],
+    },
+    {
       operation: "recorded-time migration",
       disposition: {
         kind: "refuse",

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -2263,6 +2263,7 @@ async function assertTargetUnchanged<G extends GraphDef>(
     await lockMergeTargetWrite(txBackend, {
       graphId: target.graphId,
       schemaVersion: target.introspect().schemaVersion,
+      graphLock: "required",
       staleSchemaError: (cause) =>
         new BaseVersionMismatchError(
           "The merge target schema changed before the commit transaction; the resolved plan was not applied.",
@@ -3630,6 +3631,7 @@ async function assertMergePlanFenceInsideTransaction<G extends GraphDef>(
       artifact.target.schema.managed ?
         artifact.target.schema.version
       : undefined,
+    graphLock: "required",
     staleSchemaError: (cause) =>
       new MergePlanSchemaMismatchError(
         "The target's active schema no longer matches the merge plan.",
@@ -4864,17 +4866,17 @@ async function commitIncrementalPlan<G extends GraphDef>(
   return runMergeCommit(() =>
     withTxConflictRetry(() =>
       target.transaction(async (tx) => {
-        if (target.revisionTrackingEnabled) {
-          await lockMergeTargetWrite(transactionBackend(tx), {
-            graphId: target.graphId,
-            schemaVersion: target.introspect().schemaVersion,
-            staleSchemaError: (cause) =>
-              new BaseVersionMismatchError(
-                "The merge target schema changed before the incremental commit transaction; the resolved plan was not applied.",
-                { cause },
-              ),
-          });
-        }
+        await lockMergeTargetWrite(transactionBackend(tx), {
+          graphId: target.graphId,
+          schemaVersion: target.introspect().schemaVersion,
+          graphLock:
+            target.revisionTrackingEnabled ? "required" : "not-required",
+          staleSchemaError: (cause) =>
+            new BaseVersionMismatchError(
+              "The merge target schema changed before the incremental commit transaction; the resolved plan was not applied.",
+              { cause },
+            ),
+        });
         // Fork-point TOCTOU guard: the ancestor the whole plan was diffed
         // against is re-read here, so a write to it in the plan→commit window
         // refuses the merge instead of committing diffs against a fork point

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -197,7 +197,6 @@ import {
   advanceRevisionClock,
   forceRecordedGraphRevision,
   forceWriteTransactionRevision,
-  lockRecordedGraphWrite,
   readRecordedClock,
   readRevisionOrigin,
   storeBackend,
@@ -230,6 +229,7 @@ import type {
 } from "./types";
 import type { ValidToChange } from "./valid-window";
 import { resolveValidWindows } from "./valid-window";
+import { lockMergeTargetWrite } from "./write-fence";
 
 /** A node id in its untyped (`NodeType`-default) branded form. */
 type AnyNodeId = NodeId<NodeType>;
@@ -2260,7 +2260,15 @@ async function assertTargetUnchanged<G extends GraphDef>(
     // advance the same clock before committing. Holding it around the
     // read→apply sequence makes the O(1) anchor check a TOCTOU guard without
     // relying on the transaction's snapshot being the latest committed state.
-    await lockRecordedGraphWrite(txBackend, target.graphId);
+    await lockMergeTargetWrite(txBackend, {
+      graphId: target.graphId,
+      schemaVersion: target.introspect().schemaVersion,
+      staleSchemaError: (cause) =>
+        new BaseVersionMismatchError(
+          "The merge target schema changed before the commit transaction; the resolved plan was not applied.",
+          { cause },
+        ),
+    });
     const expectedOrigin = revisionOriginOf(expectedBaseVersion);
     const liveOrigin = await readRevisionOrigin(
       txBackend,
@@ -3616,7 +3624,18 @@ async function assertMergePlanFenceInsideTransaction<G extends GraphDef>(
   txBackend: TransactionBackend,
   artifact: MergePlanArtifactV1,
 ): Promise<void> {
-  await lockRecordedGraphWrite(txBackend, target.graphId);
+  await lockMergeTargetWrite(txBackend, {
+    graphId: target.graphId,
+    schemaVersion:
+      artifact.target.schema.managed ?
+        artifact.target.schema.version
+      : undefined,
+    staleSchemaError: (cause) =>
+      new MergePlanSchemaMismatchError(
+        "The target's active schema no longer matches the merge plan.",
+        { cause, details: { expected: artifact.target.schema } },
+      ),
+  });
   const activeSchema = await txBackend.getActiveSchema(target.graphId);
   const liveSchema = {
     managed: activeSchema !== undefined,
@@ -4846,7 +4865,15 @@ async function commitIncrementalPlan<G extends GraphDef>(
     withTxConflictRetry(() =>
       target.transaction(async (tx) => {
         if (target.revisionTrackingEnabled) {
-          await lockRecordedGraphWrite(transactionBackend(tx), target.graphId);
+          await lockMergeTargetWrite(transactionBackend(tx), {
+            graphId: target.graphId,
+            schemaVersion: target.introspect().schemaVersion,
+            staleSchemaError: (cause) =>
+              new BaseVersionMismatchError(
+                "The merge target schema changed before the incremental commit transaction; the resolved plan was not applied.",
+                { cause },
+              ),
+          });
         }
         // Fork-point TOCTOU guard: the ancestor the whole plan was diffed
         // against is re-read here, so a write to it in the plan→commit window

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -54,7 +54,6 @@ export { forceWriteTransactionRevision } from "../store/operations/write-transac
 export {
   advanceRevisionClock,
   forceRecordedGraphRevision,
-  lockRecordedGraphWrite,
   readRecordedClock,
   readRevisionOrigin,
 } from "../store/recorded-capture";

--- a/packages/typegraph/src/graph-merge/write-fence.ts
+++ b/packages/typegraph/src/graph-merge/write-fence.ts
@@ -1,0 +1,30 @@
+import { type TransactionBackend } from "../backend/types";
+import { TypeGraphError } from "../errors";
+import { lockSchemaVersionForStoreWrite } from "../store/operations/write-transaction";
+import { lockRecordedGraphWrite } from "../store/recorded-capture";
+
+/** Acquires merge fences in the Store's canonical schema-first order. */
+export async function lockMergeTargetWrite(
+  txBackend: TransactionBackend,
+  input: Readonly<{
+    graphId: string;
+    schemaVersion: number | undefined;
+    staleSchemaError: (cause: unknown) => TypeGraphError;
+  }>,
+): Promise<void> {
+  try {
+    await lockSchemaVersionForStoreWrite(
+      { graphId: input.graphId, schemaVersion: input.schemaVersion },
+      txBackend,
+    );
+  } catch (error) {
+    if (
+      !(error instanceof TypeGraphError) ||
+      error.code !== "STALE_SCHEMA_VERSION"
+    ) {
+      throw error;
+    }
+    throw input.staleSchemaError(error);
+  }
+  await lockRecordedGraphWrite(txBackend, input.graphId);
+}

--- a/packages/typegraph/src/graph-merge/write-fence.ts
+++ b/packages/typegraph/src/graph-merge/write-fence.ts
@@ -9,6 +9,7 @@ export async function lockMergeTargetWrite(
   input: Readonly<{
     graphId: string;
     schemaVersion: number | undefined;
+    graphLock: "required" | "not-required";
     staleSchemaError: (cause: unknown) => TypeGraphError;
   }>,
 ): Promise<void> {
@@ -26,5 +27,7 @@ export async function lockMergeTargetWrite(
     }
     throw input.staleSchemaError(error);
   }
-  await lockRecordedGraphWrite(txBackend, input.graphId);
+  if (input.graphLock === "required") {
+    await lockRecordedGraphWrite(txBackend, input.graphId);
+  }
 }

--- a/packages/typegraph/src/interchange/import.ts
+++ b/packages/typegraph/src/interchange/import.ts
@@ -383,6 +383,7 @@ async function importGraphData<G extends GraphDef>(
       // interning exists to rule out.
       claimsVerdict: createClaimsVerdictThunk(backend),
       uniqueSidecarBatch,
+      statementExecution,
       schemaVersion: store.introspect().schemaVersion,
       historyEnabled: store.historyEnabled,
       revisionTrackingEnabled: store.revisionTrackingEnabled,

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -167,27 +167,41 @@ export class ExecutableQuery<
       (traversal) => traversal.edgeAlias === alias,
     );
     const isEdge = edgeTraversal !== undefined;
-    const systemField = resolveSystemOrderField(alias, field, isEdge);
+    const edgeKindNames =
+      edgeTraversal === undefined ? undefined : mergeEdgeKinds(edgeTraversal);
+    const nodeKindNames =
+      isEdge ? undefined
+      : alias === this.#state.startAlias ? this.#state.startKinds
+      : this.#state.traversals.find(
+          (traversal) => traversal.nodeAlias === alias,
+        )?.nodeKinds;
+    const hasDeclaredProperty =
+      edgeKindNames ?
+        this.#config.schemaIntrospector.hasDeclaredEdgeField(
+          edgeKindNames,
+          field,
+        )
+      : nodeKindNames !== undefined &&
+        this.#config.schemaIntrospector.hasDeclaredField(nodeKindNames, field);
+    const systemField = resolveSystemOrderField(
+      alias,
+      field,
+      isEdge,
+      hasDeclaredProperty,
+    );
 
     let typeInfo: FieldTypeInfo | undefined;
     if (systemField === undefined) {
-      if (isEdge) {
-        const edgeKindNames = mergeEdgeKinds(edgeTraversal);
+      if (edgeKindNames) {
         typeInfo = this.#config.schemaIntrospector.getSharedEdgeFieldTypeInfo(
           edgeKindNames,
           field,
         );
       } else {
-        const kindNames =
-          alias === this.#state.startAlias ?
-            this.#state.startKinds
-          : this.#state.traversals.find(
-              (traversal) => traversal.nodeAlias === alias,
-            )?.nodeKinds;
         typeInfo =
-          kindNames ?
+          nodeKindNames ?
             this.#config.schemaIntrospector.getSharedFieldTypeInfo(
-              kindNames,
+              nodeKindNames,
               field,
             )
           : undefined;

--- a/packages/typegraph/src/query/builder/executable-query.ts
+++ b/packages/typegraph/src/query/builder/executable-query.ts
@@ -42,12 +42,12 @@ import {
   nullToUndefined,
   transformPathColumns,
 } from "../execution";
-import { jsonPointer, parseJsonPointer } from "../json-pointer";
-import { fieldRef } from "../predicates";
+import { parseJsonPointer } from "../json-pointer";
 import { type FieldTypeInfo } from "../schema-introspector";
 import { type CompiledSelectSql } from "../sql-intent";
 import { buildQueryAst } from "./ast-builder";
 import { buildCompileOptions } from "./compile-options";
+import { buildOrderSpec, resolveSystemOrderField } from "./order-by-field";
 import { hasParameterReferences, PreparedQuery } from "./prepared-query";
 import {
   buildQueryTemplate,
@@ -167,13 +167,10 @@ export class ExecutableQuery<
       (traversal) => traversal.edgeAlias === alias,
     );
     const isEdge = edgeTraversal !== undefined;
-    const isSystem =
-      field === "id" ||
-      field === "kind" ||
-      (isEdge && (field === "from_id" || field === "to_id"));
+    const systemField = resolveSystemOrderField(alias, field, isEdge);
 
     let typeInfo: FieldTypeInfo | undefined;
-    if (!isSystem) {
+    if (systemField === undefined) {
       if (isEdge) {
         const edgeKindNames = mergeEdgeKinds(edgeTraversal);
         typeInfo = this.#config.schemaIntrospector.getSharedEdgeFieldTypeInfo(
@@ -197,20 +194,13 @@ export class ExecutableQuery<
       }
     }
 
-    const orderSpec: OrderSpec =
-      isSystem ?
-        {
-          field: fieldRef(alias, [field], { valueType: "string" }),
-          direction,
-        }
-      : {
-          field: fieldRef(alias, ["props"], {
-            jsonPointer: jsonPointer([field]),
-            valueType: typeInfo?.valueType,
-            elementType: typeInfo?.elementType,
-          }),
-          direction,
-        };
+    const orderSpec = buildOrderSpec(
+      alias,
+      field,
+      direction,
+      systemField,
+      typeInfo,
+    );
 
     const newState: QueryBuilderState = {
       ...this.#state,

--- a/packages/typegraph/src/query/builder/order-by-field.ts
+++ b/packages/typegraph/src/query/builder/order-by-field.ts
@@ -1,0 +1,64 @@
+import { type FieldRef, type OrderSpec, type SortDirection } from "../ast";
+import { jsonPointer } from "../json-pointer";
+import { fieldRef } from "../predicates";
+import { type FieldTypeInfo } from "../schema-introspector";
+
+const COMMON_SYSTEM_ORDER_FIELDS = new Map<
+  string,
+  NonNullable<FieldRef["valueType"]>
+>([
+  ["id", "string"],
+  ["kind", "string"],
+  ["valid_from", "string"],
+  ["valid_to", "string"],
+  ["created_at", "string"],
+  ["updated_at", "string"],
+  ["deleted_at", "string"],
+]);
+
+const EDGE_SYSTEM_ORDER_FIELDS = new Map<
+  string,
+  NonNullable<FieldRef["valueType"]>
+>([
+  ["from_id", "string"],
+  ["to_id", "string"],
+]);
+
+/**
+ * Resolves an orderable physical system column, or `undefined` when `field`
+ * names a user property. Both fluent builder stages consume this decision so
+ * a newly orderable system column cannot compile through one stage and fall
+ * back to `props` JSON through the other.
+ */
+export function resolveSystemOrderField(
+  alias: string,
+  field: string,
+  isEdge: boolean,
+): FieldRef | undefined {
+  const valueType =
+    COMMON_SYSTEM_ORDER_FIELDS.get(field) ??
+    (isEdge ? EDGE_SYSTEM_ORDER_FIELDS.get(field) : undefined);
+  return valueType === undefined ? undefined : (
+      fieldRef(alias, [field], { valueType })
+    );
+}
+
+/** Builds the shared system-column-or-property order expression. */
+export function buildOrderSpec(
+  alias: string,
+  field: string,
+  direction: SortDirection,
+  systemField: FieldRef | undefined,
+  typeInfo: FieldTypeInfo | undefined,
+): OrderSpec {
+  return {
+    field:
+      systemField ??
+      fieldRef(alias, ["props"], {
+        jsonPointer: jsonPointer([field]),
+        valueType: typeInfo?.valueType,
+        elementType: typeInfo?.elementType,
+      }),
+    direction,
+  };
+}

--- a/packages/typegraph/src/query/builder/order-by-field.ts
+++ b/packages/typegraph/src/query/builder/order-by-field.ts
@@ -24,17 +24,33 @@ const EDGE_SYSTEM_ORDER_FIELDS = new Map<
   ["to_id", "string"],
 ]);
 
+const DECLARED_PROPERTY_SHADOWABLE_SYSTEM_ORDER_FIELDS = new Set([
+  "valid_from",
+  "valid_to",
+  "created_at",
+  "updated_at",
+  "deleted_at",
+]);
+
 /**
  * Resolves an orderable physical system column, or `undefined` when `field`
- * names a user property. Both fluent builder stages consume this decision so
- * a newly orderable system column cannot compile through one stage and fall
- * back to `props` JSON through the other.
+ * names a user property. Declared properties retain precedence over temporal
+ * metadata with the same name, keeping `where*` and `orderBy` semantics
+ * aligned. Structural identity fields remain unconditionally system-owned.
+ * Both fluent builder stages consume this decision so they cannot drift.
  */
 export function resolveSystemOrderField(
   alias: string,
   field: string,
   isEdge: boolean,
+  hasDeclaredProperty: boolean,
 ): FieldRef | undefined {
+  if (
+    hasDeclaredProperty &&
+    DECLARED_PROPERTY_SHADOWABLE_SYSTEM_ORDER_FIELDS.has(field)
+  ) {
+    return undefined;
+  }
   const valueType =
     COMMON_SYSTEM_ORDER_FIELDS.get(field) ??
     (isEdge ? EDGE_SYSTEM_ORDER_FIELDS.get(field) : undefined);

--- a/packages/typegraph/src/query/builder/query-builder.ts
+++ b/packages/typegraph/src/query/builder/query-builder.ts
@@ -23,7 +23,6 @@ import {
   type GroupBySpec,
   type HybridFusionOptions,
   mergeEdgeKinds,
-  type OrderSpec,
   type PredicateExpression,
   type ProjectedField,
   type SortDirection,
@@ -47,6 +46,7 @@ import {
 import { ExecutableAggregateQuery } from "./executable-aggregate-query";
 import { ExecutableQuery } from "./executable-query";
 import { getQueryBuilderInternalContext } from "./internal-context";
+import { buildOrderSpec, resolveSystemOrderField } from "./order-by-field";
 import { TraversalBuilder } from "./traversal-builder";
 import {
   type AliasMap,
@@ -976,32 +976,24 @@ export class QueryBuilder<
   ): QueryBuilder<G, Aliases, EdgeAliases, RecursiveAliases, CoordinateState> {
     const edgeKindNames = this.#getEdgeKindNamesForAlias(alias);
     const isEdge = edgeKindNames !== undefined;
-    const isSystem =
-      field === "id" ||
-      field === "kind" ||
-      (isEdge && (field === "from_id" || field === "to_id"));
-    const typeInfo =
-      isSystem ? undefined
-      : isEdge ?
-        this.#config.schemaIntrospector.getSharedEdgeFieldTypeInfo(
-          edgeKindNames,
-          field,
-        )
-      : this.#getOrderByTypeInfo(alias, field);
-    const orderSpec: OrderSpec =
-      isSystem ?
-        {
-          field: fieldRef(alias, [field], { valueType: "string" }),
-          direction,
-        }
-      : {
-          field: fieldRef(alias, ["props"], {
-            jsonPointer: jsonPointer([field]),
-            valueType: typeInfo?.valueType,
-            elementType: typeInfo?.elementType,
-          }),
-          direction,
-        };
+    const systemField = resolveSystemOrderField(alias, field, isEdge);
+    let typeInfo: FieldTypeInfo | undefined;
+    if (systemField === undefined) {
+      typeInfo =
+        isEdge ?
+          this.#config.schemaIntrospector.getSharedEdgeFieldTypeInfo(
+            edgeKindNames,
+            field,
+          )
+        : this.#getOrderByTypeInfo(alias, field);
+    }
+    const orderSpec = buildOrderSpec(
+      alias,
+      field,
+      direction,
+      systemField,
+      typeInfo,
+    );
 
     const newState: QueryBuilderState = {
       ...this.#state,

--- a/packages/typegraph/src/query/builder/query-builder.ts
+++ b/packages/typegraph/src/query/builder/query-builder.ts
@@ -976,7 +976,22 @@ export class QueryBuilder<
   ): QueryBuilder<G, Aliases, EdgeAliases, RecursiveAliases, CoordinateState> {
     const edgeKindNames = this.#getEdgeKindNamesForAlias(alias);
     const isEdge = edgeKindNames !== undefined;
-    const systemField = resolveSystemOrderField(alias, field, isEdge);
+    const nodeKindNames =
+      isEdge ? undefined : this.#getKindNamesForAlias(alias);
+    const hasDeclaredProperty =
+      isEdge ?
+        this.#config.schemaIntrospector.hasDeclaredEdgeField(
+          edgeKindNames,
+          field,
+        )
+      : nodeKindNames !== undefined &&
+        this.#config.schemaIntrospector.hasDeclaredField(nodeKindNames, field);
+    const systemField = resolveSystemOrderField(
+      alias,
+      field,
+      isEdge,
+      hasDeclaredProperty,
+    );
     let typeInfo: FieldTypeInfo | undefined;
     if (systemField === undefined) {
       typeInfo =
@@ -985,7 +1000,11 @@ export class QueryBuilder<
             edgeKindNames,
             field,
           )
-        : this.#getOrderByTypeInfo(alias, field);
+        : nodeKindNames === undefined ? undefined
+        : this.#config.schemaIntrospector.getSharedFieldTypeInfo(
+            nodeKindNames,
+            field,
+          );
     }
     const orderSpec = buildOrderSpec(
       alias,
@@ -1001,13 +1020,6 @@ export class QueryBuilder<
     };
 
     return new QueryBuilder(this.#config, newState);
-  }
-
-  #getOrderByTypeInfo(alias: string, field: string): FieldTypeInfo | undefined {
-    const kindNames = this.#getKindNamesForAlias(alias);
-    return kindNames ?
-        this.#config.schemaIntrospector.getSharedFieldTypeInfo(kindNames, field)
-      : undefined;
   }
 
   /**

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -84,6 +84,7 @@ import { isBundledRootAutocommitEligible } from "../../backend/capabilities/auto
 import { bindExtraIfReachable } from "../../backend/capabilities/bind";
 import {
   BATCH_POINT_READ,
+  type STATEMENT_EXECUTION,
   type UNIQUE_SIDECAR_BATCH,
 } from "../../backend/capabilities/bundle-registry";
 import {
@@ -280,6 +281,8 @@ export type EdgeOperationContext<G extends GraphDef> = Readonly<{
    * session's `WriteSessionContext` parameter carries the field.
    */
   uniqueSidecarBatch: BundleVerdictOf<typeof UNIQUE_SIDECAR_BATCH>;
+  /** Threaded from `store.ts`; exact transaction targets bind separately. */
+  statementExecution: BundleVerdictOf<typeof STATEMENT_EXECUTION>;
   createOperationContext: (
     operation: "create" | "update" | "delete",
     entity: KindEntity,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -60,6 +60,7 @@ import { isBundledRootAutocommitEligible } from "../../backend/capabilities/auto
 import { bindExtraIfReachable } from "../../backend/capabilities/bind";
 import {
   BATCH_POINT_READ,
+  type STATEMENT_EXECUTION,
   UNIQUE_SIDECAR_BATCH,
 } from "../../backend/capabilities/bundle-registry";
 import {
@@ -271,6 +272,8 @@ export type NodeOperationContext<G extends GraphDef> = Readonly<{
   batchPointRead: BundleVerdictOf<typeof BATCH_POINT_READ>;
   /** Threaded from `store.ts`'s `#uniqueSidecarBatch` — never re-resolved here. */
   uniqueSidecarBatch: BundleVerdictOf<typeof UNIQUE_SIDECAR_BATCH>;
+  /** Threaded from `store.ts`; exact transaction targets bind separately. */
+  statementExecution: BundleVerdictOf<typeof STATEMENT_EXECUTION>;
   createOperationContext: (
     operation: "create" | "update" | "delete",
     entity: KindEntity,

--- a/packages/typegraph/src/store/operations/write-transaction.ts
+++ b/packages/typegraph/src/store/operations/write-transaction.ts
@@ -59,7 +59,10 @@
  * would make the claim above false wherever it matters most. Unconstrained
  * writes assert nothing and keep working on those backends.
  */
-import { isFirstPartyFactory } from "../../backend/capabilities/write-fence";
+import {
+  isFirstPartyFactory,
+  resolveWriteFencePlan,
+} from "../../backend/capabilities/write-fence";
 import {
   type GraphBackend,
   runOptionallyInTransaction,
@@ -67,6 +70,9 @@ import {
 } from "../../backend/types";
 import { ConfigurationError, StaleVersionError } from "../../errors";
 import { type SqlSchema } from "../../query/compiler/schema";
+import { sql } from "../../query/sql-fragment";
+import { asCompiledStatementSql } from "../../query/sql-intent";
+import { isSqliteStaleSnapshotError } from "../../utils/sql-errors";
 import { type ConstraintFenceReason } from "../constraints";
 import {
   advanceRevisionClock,
@@ -201,6 +207,75 @@ export function forceWriteTransactionRevision(
  * manual savepoints inside a managed write are outside the contract.
  */
 const heldGraphWriteLocks = new WeakMap<object, Set<string>>();
+const adoptedTransactionWriterSlots = new WeakSet<object>();
+
+function adoptedConstraintWriterSlotError(
+  ctx: Pick<WriteTransactionContext, "graphId">,
+  cause: unknown,
+): ConfigurationError {
+  return new ConfigurationError(
+    "This constrained write could not take the SQLite writer slot: the adopted transaction was begun DEFERRED and another connection committed after its read snapshot was established.",
+    {
+      code: "CONSTRAINT_TRANSACTION_NOT_WRITE_FENCED",
+      graphId: ctx.graphId,
+      sqliteCode: "SQLITE_BUSY_SNAPSHOT",
+    },
+    {
+      cause,
+      suggestion:
+        "Roll back and re-run the transaction with BEGIN IMMEDIATE, or run the writes through store.transaction(), which acquires the writer slot before any decision-driving read.",
+    },
+  );
+}
+
+/**
+ * Makes SQLite's engine-serialized fence true for a transaction TypeGraph did
+ * not open. A zero-row write takes the writer slot without changing data; it
+ * must run before the schema fence, graph lock, or any constraint probe fixes
+ * a read snapshot. The exact transaction object is memoized only after that
+ * write succeeds, so no later constrained write in the same frame pays again.
+ */
+async function ensureAdoptedConstraintWriterSlot(
+  ctx: WriteTransactionContext,
+  target: GraphBackend | TransactionBackend,
+  transactionMode: WriteTransactionMode,
+  fenceReason: ConstraintFenceReason | undefined,
+): Promise<void> {
+  if (
+    fenceReason === undefined ||
+    transactionMode !== "existing" ||
+    writeTransactionSessions.has(target) ||
+    adoptedTransactionWriterSlots.has(target) ||
+    resolveWriteFencePlan(target).kind !== "engine-serialized"
+  ) {
+    return;
+  }
+  if (target.executeStatement === undefined) {
+    throw new ConfigurationError(
+      "This engine-serialized transaction cannot prove that it holds its writer slot before a constrained write.",
+      {
+        code: "CONSTRAINT_WRITE_FENCE_UNSUPPORTED",
+        graphId: ctx.graphId,
+        constraint: fenceReason,
+      },
+      {
+        suggestion:
+          "Expose transaction-scoped statement execution, or run the constrained write through a backend transaction TypeGraph opens.",
+      },
+    );
+  }
+  try {
+    await target.executeStatement(
+      asCompiledStatementSql(
+        sql`UPDATE ${ctx.revisionSchema.nodesTable} SET graph_id = graph_id WHERE 0`,
+      ),
+    );
+  } catch (error) {
+    if (!isSqliteStaleSnapshotError(error)) throw error;
+    throw adoptedConstraintWriterSlotError(ctx, error);
+  }
+  adoptedTransactionWriterSlots.add(target);
+}
 
 /**
  * Binds nested typed mutations to one caller-owned transaction commit so a
@@ -498,6 +573,12 @@ export function runInWriteTransaction<T>(
     ctx.revisionTrackingEnabled ||
     fenceReason !== undefined;
   return runOptionallyInTransaction(backend, async (target) => {
+    await ensureAdoptedConstraintWriterSlot(
+      ctx,
+      target,
+      transactionMode,
+      fenceReason,
+    );
     const session =
       needsGraphWriteLock ? writeTransactionSessions.get(target) : undefined;
     // Either constructor yields the same compile-time evidence token; which one

--- a/packages/typegraph/src/store/operations/write-transaction.ts
+++ b/packages/typegraph/src/store/operations/write-transaction.ts
@@ -212,7 +212,6 @@ export function forceWriteTransactionRevision(
  * manual savepoints inside a managed write are outside the contract.
  */
 const heldGraphWriteLocks = new WeakMap<object, Set<string>>();
-const adoptedTransactionWriterSlots = new WeakSet<object>();
 
 function adoptedConstraintWriterSlotError(
   ctx: Pick<WriteTransactionContext, "graphId">,
@@ -223,7 +222,6 @@ function adoptedConstraintWriterSlotError(
     {
       code: "CONSTRAINT_TRANSACTION_NOT_WRITE_FENCED",
       graphId: ctx.graphId,
-      sqliteCode: "SQLITE_BUSY_SNAPSHOT",
     },
     {
       cause,
@@ -237,8 +235,9 @@ function adoptedConstraintWriterSlotError(
  * Makes SQLite's engine-serialized fence true for a transaction TypeGraph did
  * not open. A zero-row write takes the writer slot without changing data; it
  * must run before the schema fence, graph lock, or any constraint probe fixes
- * a read snapshot. The exact transaction object is memoized only after that
- * write succeeds, so no later constrained write in the same frame pays again.
+ * a read snapshot. Caller-adopted backends do not expose transaction-lifetime
+ * identity, so this proof deliberately runs at every constrained write rather
+ * than caching connection-scoped evidence across unrelated transactions.
  */
 async function ensureAdoptedConstraintWriterSlot(
   ctx: WriteTransactionContext,
@@ -250,7 +249,6 @@ async function ensureAdoptedConstraintWriterSlot(
     fenceReason === undefined ||
     transactionMode !== "existing" ||
     writeTransactionSessions.has(target) ||
-    adoptedTransactionWriterSlots.has(target) ||
     resolveWriteFencePlan(target).kind !== "engine-serialized"
   ) {
     return;
@@ -284,7 +282,6 @@ async function ensureAdoptedConstraintWriterSlot(
     if (!isSqliteStaleSnapshotError(error)) throw error;
     throw adoptedConstraintWriterSlotError(ctx, error);
   }
-  adoptedTransactionWriterSlots.add(target);
 }
 
 /**

--- a/packages/typegraph/src/store/operations/write-transaction.ts
+++ b/packages/typegraph/src/store/operations/write-transaction.ts
@@ -59,6 +59,9 @@
  * would make the claim above false wherever it matters most. Unconstrained
  * writes assert nothing and keep working on those backends.
  */
+import { statementExecutionMembers } from "../../backend/capabilities/bind";
+import { type STATEMENT_EXECUTION } from "../../backend/capabilities/bundle-registry";
+import { type BundleVerdictOf } from "../../backend/capabilities/resolve";
 import {
   isFirstPartyFactory,
   resolveWriteFencePlan,
@@ -97,6 +100,8 @@ export type WriteTransactionContext = Readonly<{
   historyEnabled: boolean;
   revisionTrackingEnabled: boolean;
   revisionSchema: SqlSchema;
+  /** Resolved once from the root backend; exact targets are bound separately. */
+  statementExecution?: BundleVerdictOf<typeof STATEMENT_EXECUTION>;
 }>;
 
 interface WriteTransactionSession {
@@ -250,7 +255,8 @@ async function ensureAdoptedConstraintWriterSlot(
   ) {
     return;
   }
-  if (target.executeStatement === undefined) {
+  const statementExecution = ctx.statementExecution;
+  if (statementExecution?.supported !== true) {
     throw new ConfigurationError(
       "This engine-serialized transaction cannot prove that it holds its writer slot before a constrained write.",
       {
@@ -264,8 +270,12 @@ async function ensureAdoptedConstraintWriterSlot(
       },
     );
   }
+  const { executeStatement } = statementExecutionMembers(
+    target,
+    statementExecution,
+  );
   try {
-    await target.executeStatement(
+    await executeStatement(
       asCompiledStatementSql(
         sql`UPDATE ${ctx.revisionSchema.nodesTable} SET graph_id = graph_id WHERE 0`,
       ),

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -3072,9 +3072,6 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
               invokeTransaction,
             )
           : invokeTransaction();
-        if (!this.#captureEnabled && !this.#revisionTrackingEnabled) {
-          return invokeWithSchemaFenceLease();
-        }
         return withWriteTransactionSession(
           txBackend,
           {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -19,6 +19,7 @@ import {
 import { bindExtra, bindExtraIfReachable } from "../backend/capabilities/bind";
 import type {
   RECORDED_REVISION_ORIGINS,
+  STATEMENT_EXECUTION,
   UNIQUE_SIDECAR_BATCH,
 } from "../backend/capabilities/bundle-registry";
 import {
@@ -945,6 +946,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * write and read actually executes through.
    */
   readonly #batchPointRead: BundleVerdictOf<typeof BATCH_POINT_READ>;
+  readonly #statementExecution: BundleVerdictOf<typeof STATEMENT_EXECUTION>;
   readonly #uniqueSidecarBatch: BundleVerdictOf<typeof UNIQUE_SIDECAR_BATCH>;
   /**
    * The contribution-health methods and `ensureRevisionOrigin` read
@@ -1067,6 +1069,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       : asGraphWriteBackend(backend);
     this.#claimsVerdict = createClaimsVerdictThunk(this.#backend);
     this.#batchPointRead = batchPointReadVerdict(this.#backend);
+    this.#statementExecution = statementExecutionVerdict(this.#backend);
     this.#uniqueSidecarBatch = uniqueSidecarBatchVerdict(this.#backend);
     this.#contributionHealth = contributionHealthVerdict(this.#baseBackend);
     this.#recordedRevisionOrigins = recordedRevisionOriginsVerdict(
@@ -1340,6 +1343,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         historyEnabled: this.#captureEnabled,
         revisionTrackingEnabled: this.#revisionTrackingEnabled,
         revisionSchema: this.#sqlSchema(),
+        statementExecution: this.#statementExecution,
       },
       this.#baseBackend,
       async (target) =>
@@ -5127,6 +5131,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       revisionTrackingEnabled: this.#revisionTrackingEnabled,
       coalesceUnchangedUpsertsEnabled: this.#coalescesUnchangedUpserts(),
       revisionSchema: this.#sqlSchema(),
+      statementExecution: this.#statementExecution,
       registry: this.#registry,
       claimsVerdict: this.#claimsVerdict,
       batchPointRead: this.#batchPointRead,
@@ -5210,6 +5215,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       claimsVerdict: this.#claimsVerdict,
       batchPointRead: this.#batchPointRead,
       uniqueSidecarBatch: this.#uniqueSidecarBatch,
+      statementExecution: this.#statementExecution,
       createOperationContext: (operation, entity, kind, id) =>
         this.#createOperationContext(operation, entity, kind, id),
       withOperationHooks: runHooks,

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -946,8 +946,9 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * write and read actually executes through.
    */
   readonly #batchPointRead: BundleVerdictOf<typeof BATCH_POINT_READ>;
-  readonly #statementExecution: BundleVerdictOf<typeof STATEMENT_EXECUTION>;
   readonly #uniqueSidecarBatch: BundleVerdictOf<typeof UNIQUE_SIDECAR_BATCH>;
+  /** Root verdict minted once; transaction targets bind its member separately. */
+  readonly #statementExecution: BundleVerdictOf<typeof STATEMENT_EXECUTION>;
   /**
    * The contribution-health methods and `ensureRevisionOrigin` read
    * `#baseBackend`, not `#backend` (recorded capture never wraps them), so
@@ -1069,8 +1070,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       : asGraphWriteBackend(backend);
     this.#claimsVerdict = createClaimsVerdictThunk(this.#backend);
     this.#batchPointRead = batchPointReadVerdict(this.#backend);
-    this.#statementExecution = statementExecutionVerdict(this.#backend);
     this.#uniqueSidecarBatch = uniqueSidecarBatchVerdict(this.#backend);
+    this.#statementExecution = statementExecution;
     this.#contributionHealth = contributionHealthVerdict(this.#baseBackend);
     this.#recordedRevisionOrigins = recordedRevisionOriginsVerdict(
       this.#baseBackend,

--- a/packages/typegraph/tests/backends/integration/ordering.ts
+++ b/packages/typegraph/tests/backends/integration/ordering.ts
@@ -12,6 +12,36 @@ import { type IntegrationTestContext } from "./test-context";
 export function registerOrderingIntegrationTests(
   context: IntegrationTestContext,
 ): void {
+  describe("system temporal columns", () => {
+    it("orders by the physical validity lower bound before and after select", async () => {
+      const store = context.getStore();
+      await store.nodes.Person.create(
+        { name: "Later", age: 30, email: "later@example.com" },
+        { id: "temporal-later", validFrom: "2026-02-01T00:00:00.000Z" },
+      );
+      await store.nodes.Person.create(
+        { name: "Earlier", age: 30, email: "earlier@example.com" },
+        { id: "temporal-earlier", validFrom: "2026-01-01T00:00:00.000Z" },
+      );
+
+      const beforeSelect = await store
+        .query()
+        .from("Person", "p")
+        .orderBy("p", "valid_from", "asc")
+        .select((ctx) => ({ name: ctx.p.name }))
+        .execute();
+      const afterSelect = await store
+        .query()
+        .from("Person", "p")
+        .select((ctx) => ({ name: ctx.p.name }))
+        .orderBy("p", "valid_from", "asc")
+        .execute();
+
+      expect(beforeSelect.map((row) => row.name)).toEqual(["Earlier", "Later"]);
+      expect(afterSelect).toEqual(beforeSelect);
+    });
+  });
+
   describe("Ordering with Nulls", () => {
     beforeEach(async () => {
       const store = context.getStore();

--- a/packages/typegraph/tests/bulk-revision.test.ts
+++ b/packages/typegraph/tests/bulk-revision.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  asEdgeId,
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  recordedInstantRevision,
+} from "../src";
+import { createSqlSchema } from "../src/query/compiler/schema";
+import { readRecordedClock } from "../src/store/recorded-capture";
+import { createTestBackend } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const knows = defineEdge("knows");
+const graph = defineGraph({
+  id: "bulk_revision_boundary",
+  nodes: { Person: { type: Person } },
+  edges: {
+    knows: {
+      type: knows,
+      from: [Person],
+      to: [Person],
+      cardinality: "many",
+    },
+  },
+});
+
+describe("bulk revision boundaries", () => {
+  let backend: ReturnType<typeof createTestBackend>;
+  let schema: ReturnType<typeof createSqlSchema>;
+  let store: Awaited<ReturnType<typeof createStoreWithSchema<typeof graph>>>[0];
+
+  beforeEach(async () => {
+    backend = createTestBackend();
+    schema = createSqlSchema(backend.tableNames);
+    [store] = await createStoreWithSchema(graph, backend, {
+      revisionTracking: true,
+    });
+  });
+
+  async function revision(): Promise<number> {
+    const instant = await readRecordedClock(backend, schema, graph.id);
+    return instant === undefined ? 0 : recordedInstantRevision(instant);
+  }
+
+  async function expectOneRevision(
+    write: () => Promise<unknown>,
+  ): Promise<void> {
+    const before = await revision();
+    await write();
+    expect(await revision()).toBe(before + 1);
+  }
+
+  it("advances once for every node bulk wrapper", async () => {
+    await expectOneRevision(() =>
+      store.nodes.Person.bulkCreate([
+        { props: { name: "create-a" } },
+        { props: { name: "create-b" } },
+      ]),
+    );
+    await expectOneRevision(() =>
+      store.nodes.Person.bulkInsert([
+        { props: { name: "insert-a" } },
+        { props: { name: "insert-b" } },
+      ]),
+    );
+    await expectOneRevision(() =>
+      store.nodes.Person.bulkUpsertById([
+        { id: "upsert-a", props: { name: "upsert-a" } },
+        { id: "upsert-b", props: { name: "upsert-b" } },
+      ]),
+    );
+  });
+
+  it("advances once for every edge bulk wrapper", async () => {
+    const from = await store.nodes.Person.create(
+      { name: "from" },
+      { id: "from" },
+    );
+    const to = await store.nodes.Person.create({ name: "to" }, { id: "to" });
+    await expectOneRevision(() =>
+      store.edges.knows.bulkCreate([
+        { from, to, id: "create-a" },
+        { from, to, id: "create-b" },
+      ]),
+    );
+    await expectOneRevision(() =>
+      store.edges.knows.bulkInsert([
+        { from, to, id: "insert-a" },
+        { from, to, id: "insert-b" },
+      ]),
+    );
+    await expectOneRevision(() =>
+      store.edges.knows.bulkUpsertById([
+        { id: asEdgeId("upsert-a"), from, to },
+        { id: asEdgeId("upsert-b"), from, to },
+      ]),
+    );
+  });
+});

--- a/packages/typegraph/tests/bundle-member-access.test.ts
+++ b/packages/typegraph/tests/bundle-member-access.test.ts
@@ -30,14 +30,14 @@ import {
 } from "../src/backend/capabilities/bundle-registry";
 
 const PILOT_COUNT = 0;
-const ANNOTATED_RESIDUE_COUNT = 7;
-const ANNOTATED_RESIDUE_PAIR_COUNT = 3;
+const ANNOTATED_RESIDUE_COUNT = 9;
+const ANNOTATED_RESIDUE_PAIR_COUNT = 4;
 const STATICALLY_REQUIRED_COUNT = 2;
 const REASONED_FLOOR = 88;
 const DEFERRED_LIVE_TOTAL = 206;
 const DEFERRED_DECLARED_TOTAL = 209;
 const EXCLUDED_COUNT = 4;
-const TOTAL_ROW_COUNT = 307;
+const TOTAL_ROW_COUNT = 309;
 const ANNOTATED_RESIDUE_KEYS = [
   "backend/migrate-recorded-time.ts:160#executeStatement",
   "backend/migrate-recorded-time.ts:167#executeStatement",
@@ -46,6 +46,8 @@ const ANNOTATED_RESIDUE_KEYS = [
   "store/recorded-capture/guards.ts:67#executeStatement",
   "store/recorded-capture/guards.ts:84#executeStatement",
   "store/recorded-capture/guards.ts:219#executeStatement",
+  "store/operations/write-transaction.ts:253#executeStatement",
+  "store/operations/write-transaction.ts:268#executeStatement",
 ] as const;
 
 function rowKey(
@@ -83,7 +85,7 @@ describe("live bundle member access scan (I6, T21)", () => {
     expect(scan.byClass.pilot).toBe(PILOT_COUNT);
   });
 
-  it("the annotated pilot residue is exactly 7 rows over 3 (file, member) pairs", () => {
+  it("the annotated pilot residue is exactly 9 rows over 4 (file, member) pairs", () => {
     const annotatedRows = scan.rows.filter(
       (row) => row.class === "annotated-residue",
     );
@@ -95,6 +97,7 @@ describe("live bundle member access scan (I6, T21)", () => {
         "identity/sql-target.ts#executeStatement",
         "store/recorded-capture/guards.ts#executeStatement",
         "backend/migrate-recorded-time.ts#executeStatement",
+        "store/operations/write-transaction.ts#executeStatement",
       ].toSorted(),
     );
     const liveKeys = new Set(annotatedRows.map((row) => rowKey(row)));
@@ -184,7 +187,7 @@ describe("live bundle member access scan (I6, T21)", () => {
     expect(scan.byClass.deferred).toBe(DEFERRED_LIVE_TOTAL);
   });
 
-  it("the class partition covers every scanned row (total 307)", () => {
+  it("the class partition covers every scanned row (total 309)", () => {
     // STATICALLY_REQUIRED_SITES asserted positively: each must appear in the
     // scan output, so an arm-(b) regression that stops resolving them fails
     // loudly here rather than silently shrinking the bucket.

--- a/packages/typegraph/tests/bundle-member-access.test.ts
+++ b/packages/typegraph/tests/bundle-member-access.test.ts
@@ -30,14 +30,14 @@ import {
 } from "../src/backend/capabilities/bundle-registry";
 
 const PILOT_COUNT = 0;
-const ANNOTATED_RESIDUE_COUNT = 9;
-const ANNOTATED_RESIDUE_PAIR_COUNT = 4;
+const ANNOTATED_RESIDUE_COUNT = 7;
+const ANNOTATED_RESIDUE_PAIR_COUNT = 3;
 const STATICALLY_REQUIRED_COUNT = 2;
 const REASONED_FLOOR = 88;
 const DEFERRED_LIVE_TOTAL = 206;
 const DEFERRED_DECLARED_TOTAL = 209;
 const EXCLUDED_COUNT = 4;
-const TOTAL_ROW_COUNT = 309;
+const TOTAL_ROW_COUNT = 307;
 const ANNOTATED_RESIDUE_KEYS = [
   "backend/migrate-recorded-time.ts:160#executeStatement",
   "backend/migrate-recorded-time.ts:167#executeStatement",
@@ -46,8 +46,6 @@ const ANNOTATED_RESIDUE_KEYS = [
   "store/recorded-capture/guards.ts:67#executeStatement",
   "store/recorded-capture/guards.ts:84#executeStatement",
   "store/recorded-capture/guards.ts:219#executeStatement",
-  "store/operations/write-transaction.ts:253#executeStatement",
-  "store/operations/write-transaction.ts:268#executeStatement",
 ] as const;
 
 function rowKey(
@@ -85,7 +83,7 @@ describe("live bundle member access scan (I6, T21)", () => {
     expect(scan.byClass.pilot).toBe(PILOT_COUNT);
   });
 
-  it("the annotated pilot residue is exactly 9 rows over 4 (file, member) pairs", () => {
+  it("the annotated pilot residue is exactly 7 rows over 3 (file, member) pairs", () => {
     const annotatedRows = scan.rows.filter(
       (row) => row.class === "annotated-residue",
     );
@@ -97,7 +95,6 @@ describe("live bundle member access scan (I6, T21)", () => {
         "identity/sql-target.ts#executeStatement",
         "store/recorded-capture/guards.ts#executeStatement",
         "backend/migrate-recorded-time.ts#executeStatement",
-        "store/operations/write-transaction.ts#executeStatement",
       ].toSorted(),
     );
     const liveKeys = new Set(annotatedRows.map((row) => rowKey(row)));
@@ -187,7 +184,7 @@ describe("live bundle member access scan (I6, T21)", () => {
     expect(scan.byClass.deferred).toBe(DEFERRED_LIVE_TOTAL);
   });
 
-  it("the class partition covers every scanned row (total 309)", () => {
+  it("the class partition covers every scanned row (total 307)", () => {
     // STATICALLY_REQUIRED_SITES asserted positively: each must appear in the
     // scan output, so an arm-(b) regression that stops resolving them fails
     // loudly here rather than silently shrinking the bucket.

--- a/packages/typegraph/tests/constraint-adopted-transaction.test.ts
+++ b/packages/typegraph/tests/constraint-adopted-transaction.test.ts
@@ -51,7 +51,10 @@ async function openStore() {
   );
   openDirectories.push(directory);
   const file = path.join(directory, "graph.db");
-  const owner = new Database(file);
+  const ownerStatements: string[] = [];
+  const owner = new Database(file, {
+    verbose: (statement) => ownerStatements.push(String(statement)),
+  });
   const other = new Database(file, { timeout: 0 });
   openDatabases.push(owner, other);
   owner.pragma("journal_mode = WAL");
@@ -63,7 +66,7 @@ async function openStore() {
   });
   const [store] = await createAdapterStoreWithSchema(graph, backend);
   await store.nodes.Person.create({ name: "Anchor" }, { id: "anchor" });
-  return { other, owner, ownerDb, store };
+  return { other, owner, ownerDb, ownerStatements, store };
 }
 
 function commitUnrelatedRow(other: Database.Database): void {
@@ -114,5 +117,51 @@ describe("constrained writes in adopted SQLite transactions", () => {
     );
     expect(company.id).toBe("company");
     owner.exec("COMMIT");
+  });
+
+  it("proves the writer slot again for a later transaction on the same adopted store", async () => {
+    const { other, owner, ownerDb, store } = await openStore();
+    const transactionStore = store.withTransaction(ownerDb);
+
+    owner.exec("BEGIN IMMEDIATE");
+    await transactionStore.nodes.Company.create(
+      { name: "First company" },
+      { id: "first-company" },
+    );
+    owner.exec("COMMIT");
+
+    owner.exec("BEGIN");
+    await transactionStore.nodes.Person.find();
+    commitUnrelatedRow(other);
+
+    await expect(
+      transactionStore.nodes.Company.create(
+        { name: "Second company" },
+        { id: "second-company" },
+      ),
+    ).rejects.toMatchObject({
+      details: {
+        code: "CONSTRAINT_TRANSACTION_NOT_WRITE_FENCED",
+        graphId: graph.id,
+      },
+    });
+  });
+
+  it("does not probe the writer slot inside a transaction TypeGraph opened", async () => {
+    const { ownerStatements, store } = await openStore();
+    ownerStatements.length = 0;
+
+    await store.transaction(async (transactionStore) => {
+      await transactionStore.nodes.Company.create(
+        { name: "Managed company" },
+        { id: "managed-company" },
+      );
+    });
+
+    expect(
+      ownerStatements.some((statement) =>
+        statement.includes("SET graph_id = graph_id WHERE 0"),
+      ),
+    ).toBe(false);
   });
 });

--- a/packages/typegraph/tests/constraint-adopted-transaction.test.ts
+++ b/packages/typegraph/tests/constraint-adopted-transaction.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { getTableName } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createAdapterStoreWithSchema,
+  defineGraph,
+  defineNode,
+  disjointWith,
+} from "../src";
+import { generateSqliteDDL } from "../src/backend/drizzle/ddl";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { tables } from "../src/backend/sqlite";
+import { ConfigurationError } from "../src/errors";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const graph = defineGraph({
+  id: "constraint_adopted_transaction",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {},
+  ontology: [disjointWith(Person, Company)],
+});
+
+const openDatabases: Database.Database[] = [];
+const openDirectories: string[] = [];
+
+afterEach(async () => {
+  for (const database of openDatabases.splice(0)) {
+    if (database.inTransaction) database.exec("ROLLBACK");
+    database.close();
+  }
+  for (const directory of openDirectories.splice(0)) {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+async function openStore() {
+  const directory = await mkdtemp(
+    path.join(tmpdir(), "typegraph-constraint-fence-"),
+  );
+  openDirectories.push(directory);
+  const file = path.join(directory, "graph.db");
+  const owner = new Database(file);
+  const other = new Database(file, { timeout: 0 });
+  openDatabases.push(owner, other);
+  owner.pragma("journal_mode = WAL");
+  for (const statement of generateSqliteDDL(tables)) owner.exec(statement);
+  const ownerDb = drizzle(owner);
+  const backend = createSqliteBackend(ownerDb, {
+    executionProfile: { isSync: true },
+    tables,
+  });
+  const [store] = await createAdapterStoreWithSchema(graph, backend);
+  await store.nodes.Person.create({ name: "Anchor" }, { id: "anchor" });
+  return { other, owner, ownerDb, store };
+}
+
+function commitUnrelatedRow(other: Database.Database): void {
+  const stamp = "2026-01-01T00:00:00.000Z";
+  other
+    .prepare(
+      `INSERT INTO ${getTableName(tables.nodes)} ` +
+        "(graph_id, kind, id, props, created_at, updated_at, version) " +
+        "VALUES (?, 'Person', 'racer', '{\"name\":\"Racer\"}', ?, ?, 1)",
+    )
+    .run(graph.id, stamp, stamp);
+}
+
+describe("constrained writes in adopted SQLite transactions", () => {
+  it("refuses a stale DEFERRED snapshot before its constraint probe", async () => {
+    const { other, owner, ownerDb, store } = await openStore();
+    owner.exec("BEGIN");
+    const transactionStore = store.withTransaction(ownerDb);
+    await transactionStore.nodes.Person.find();
+    commitUnrelatedRow(other);
+
+    const refusal = await transactionStore.nodes.Company.create(
+      { name: "Safe company" },
+      { id: "company" },
+    ).then(
+      (created): unknown => created,
+      (error: unknown) => error,
+    );
+
+    expect(refusal).toBeInstanceOf(ConfigurationError);
+    expect((refusal as ConfigurationError).details).toMatchObject({
+      code: "CONSTRAINT_TRANSACTION_NOT_WRITE_FENCED",
+      graphId: graph.id,
+    });
+    expect((refusal as ConfigurationError).suggestion).toContain(
+      "BEGIN IMMEDIATE",
+    );
+  });
+
+  it("runs normally when the adopted frame already owns the writer slot", async () => {
+    const { owner, ownerDb, store } = await openStore();
+    owner.exec("BEGIN IMMEDIATE");
+    const transactionStore = store.withTransaction(ownerDb);
+
+    const company = await transactionStore.nodes.Company.create(
+      { name: "Serialized company" },
+      { id: "company" },
+    );
+    expect(company.id).toBe("company");
+    owner.exec("COMMIT");
+  });
+});

--- a/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
+++ b/packages/typegraph/tests/graph-merge/merge-incremental.test.ts
@@ -25,7 +25,12 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { rowPropsToObject } from "../../src/backend/types";
+import { deriveBackend } from "../../src/backend/derive-backend";
+import {
+  rowPropsToObject,
+  type TransactionBackend,
+  type TransactionOptions,
+} from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
 import {
   BaseVersionMismatchError,
@@ -271,6 +276,49 @@ describe.each(backendMatrix())(
         { id: "new-ana", name: "Ana Rivera", mrn: "MRN-1" },
       ]);
       expect(await target.recordedNow()).toBeDefined();
+    });
+
+    it("acquires the schema fence for a managed target without revision tracking", async () => {
+      cleanups = [];
+      const forkPoint = await emptyStore();
+      const provider = await forkOf(forkPoint);
+      await provider.store.nodes.Encounter.create(
+        { reason: "new encounter" },
+        { id: "new-encounter" },
+      );
+
+      const baseBackend = await makeBackend();
+      let schemaFenceCount = 0;
+      const targetBackend = deriveBackend(baseBackend, {
+        transaction: async <T>(
+          fn: (tx: TransactionBackend) => Promise<T>,
+          transactionOptions?: TransactionOptions,
+        ): Promise<T> =>
+          baseBackend.transaction(async (tx) => {
+            const lockSchemaVersionForWrite = requireDefined(
+              tx.lockSchemaVersionForWrite,
+            );
+            const observedTx = deriveBackend(tx, {
+              lockSchemaVersionForWrite: async (input) => {
+                schemaFenceCount += 1;
+                await lockSchemaVersionForWrite(input);
+              },
+            });
+            return fn(observedTx);
+          }, transactionOptions),
+      });
+      const [target] = await createStoreWithSchema(careGraph, targetBackend);
+      schemaFenceCount = 0;
+
+      const result = await mergeIncremental<CareGraph>({
+        forkPoint,
+        target,
+        branches: [provider],
+        options: options(),
+      });
+
+      expect(isOk(result)).toBe(true);
+      expect(schemaFenceCount).toBeGreaterThan(0);
     });
 
     it("HAPPY PATH: resolves a branch addition onto an advanced target's base entity", async () => {

--- a/packages/typegraph/tests/graph-merge/write-fence.test.ts
+++ b/packages/typegraph/tests/graph-merge/write-fence.test.ts
@@ -45,6 +45,7 @@ describe("graph-merge write fences", () => {
     await lockMergeTargetWrite(makeBackend(events), {
       graphId: "merge-fence",
       schemaVersion: 3,
+      graphLock: "required",
       staleSchemaError: (cause) =>
         new BaseVersionMismatchError("schema moved", { cause }),
     });
@@ -59,10 +60,23 @@ describe("graph-merge write fences", () => {
       lockMergeTargetWrite(backend, {
         graphId: "merge-fence",
         schemaVersion: 3,
+        graphLock: "required",
         staleSchemaError: (cause) =>
           new BaseVersionMismatchError("schema moved", { cause }),
       }),
     ).rejects.toBeInstanceOf(BaseVersionMismatchError);
+    expect(events).toEqual(["schema"]);
+  });
+
+  it("can fence schema-managed writes without taking the revision graph lock", async () => {
+    const events: string[] = [];
+    await lockMergeTargetWrite(makeBackend(events), {
+      graphId: "merge-fence",
+      schemaVersion: 3,
+      graphLock: "not-required",
+      staleSchemaError: (cause) =>
+        new BaseVersionMismatchError("schema moved", { cause }),
+    });
     expect(events).toEqual(["schema"]);
   });
 });

--- a/packages/typegraph/tests/graph-merge/write-fence.test.ts
+++ b/packages/typegraph/tests/graph-merge/write-fence.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { type TransactionBackend } from "../../src/backend/types";
+import { StaleVersionError } from "../../src/errors";
+import { BaseVersionMismatchError } from "../../src/graph-merge/errors";
+import { lockMergeTargetWrite } from "../../src/graph-merge/write-fence";
+
+function makeBackend(
+  events: string[],
+  staleSchema = false,
+): TransactionBackend {
+  return {
+    dialect: "postgres",
+    capabilities: {
+      execution: {
+        interactiveTransactions: true,
+        atomicBatch: "none",
+      },
+      pessimisticLocks: {
+        advisoryLocks: true,
+        tableLocks: true,
+        serializedWriters: false,
+      },
+    },
+    lockSchemaVersionForWrite: async () => {
+      events.push("schema");
+      if (staleSchema) {
+        throw new StaleVersionError({
+          graphId: "merge-fence",
+          expected: 3,
+          actual: 4,
+        });
+      }
+    },
+    execute: async () => {
+      events.push("graph");
+      return [{ transaction_isolation: "read committed" }];
+    },
+  } as unknown as TransactionBackend;
+}
+
+describe("graph-merge write fences", () => {
+  it("acquires the schema fence before the graph lock", async () => {
+    const events: string[] = [];
+    await lockMergeTargetWrite(makeBackend(events), {
+      graphId: "merge-fence",
+      schemaVersion: 3,
+      staleSchemaError: (cause) =>
+        new BaseVersionMismatchError("schema moved", { cause }),
+    });
+    expect(events).toEqual(["schema", "graph"]);
+  });
+
+  it("translates a stale schema without acquiring the graph lock", async () => {
+    const events: string[] = [];
+    const backend = makeBackend(events, true);
+
+    await expect(
+      lockMergeTargetWrite(backend, {
+        graphId: "merge-fence",
+        schemaVersion: 3,
+        staleSchemaError: (cause) =>
+          new BaseVersionMismatchError("schema moved", { cause }),
+      }),
+    ).rejects.toBeInstanceOf(BaseVersionMismatchError);
+    expect(events).toEqual(["schema"]);
+  });
+});

--- a/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
@@ -4,9 +4,10 @@
  * Two ratchets, both comment-stripped AST scans over `src/**` (modelled on
  * `tests/recursive-traversal-inventory.test.ts`):
  *
- *  1. `resolveWriteFencePlan` has exactly **10** call sites — the 8 lock
- *     sites (J1-J8) plus the 2 construction gates (J9a recorded-clock
- *     ownership, J9b identity) — enumerated in both directions, keyed on
+ *  1. `resolveWriteFencePlan` has exactly **11** call sites — the 8 lock
+ *     sites (J1-J8), the 2 construction gates (J9a recorded-clock
+ *     ownership, J9b identity), and the adopted-transaction writer-slot
+ *     proof (J9c) — enumerated in both directions, keyed on
  *     `(file, trimmed line)` so line drift cannot rot the pin.
  *  2. Zero dialect-literal comparisons (`dialect (!==|===) "postgres"/
  *     "sqlite"`, in a `BinaryExpression` or a `SwitchStatement` discriminant)
@@ -52,7 +53,7 @@ type InventoryEntry = Readonly<{
   reason: string;
 }>;
 
-/** The 10 `resolveWriteFencePlan` call sites (Contract J, I8). */
+/** The 11 `resolveWriteFencePlan` call sites (Contract J, I8). */
 const CALL_SITES: readonly InventoryEntry[] = [
   {
     file: "store/recorded-capture/clock.ts",
@@ -123,6 +124,13 @@ const CALL_SITES: readonly InventoryEntry[] = [
     site: "J9a",
     reason:
       "The recorded-clock-allocation construction gate refuses an unfenced backend before any statement runs.",
+  },
+  {
+    file: "store/operations/write-transaction.ts",
+    line: 'resolveWriteFencePlan(target).kind !== "engine-serialized"',
+    site: "J9c",
+    reason:
+      "An adopted engine-serialized transaction proves its writer slot before any constrained-write read.",
   },
 ];
 
@@ -379,13 +387,13 @@ function scanSourceTree<T>(
   );
 }
 
-describe("T17 — resolveWriteFencePlan has exactly 10 call sites", () => {
+describe("T17 — resolveWriteFencePlan has exactly 11 call sites", () => {
   const found = scanSourceTree(scanForResolveCalls);
   const diff = diffAgainstInventory(found, CALL_SITES);
 
-  it("has exactly the 10 declared call sites, both directions", () => {
-    expect(found).toHaveLength(10);
-    expect(CALL_SITES).toHaveLength(10);
+  it("has exactly the 11 declared call sites, both directions", () => {
+    expect(found).toHaveLength(11);
+    expect(CALL_SITES).toHaveLength(11);
     const undeclaredReport = diff.undeclared.map(
       (site) => `${site.file}:${String(site.lineNumber)}  ${site.line}`,
     );

--- a/packages/typegraph/tests/query-builder.test.ts
+++ b/packages/typegraph/tests/query-builder.test.ts
@@ -56,6 +56,7 @@ const Person = defineNode("Person", {
     email: z.string().optional(),
     isActive: z.boolean().default(true),
     tags: z.array(z.string()).optional(),
+    created_at: z.string().optional(),
     metadata: z
       .object({
         source: z.string(),
@@ -81,6 +82,7 @@ const Company = defineNode("Company", {
 const worksAt = defineEdge("worksAt", {
   schema: z.object({
     role: z.string(),
+    created_at: z.string().optional(),
   }),
 });
 
@@ -345,6 +347,26 @@ describe("Query Builder Basics", () => {
     expect(ast.orderBy?.[0]?.direction).toBe("asc");
   });
 
+  it("orders a declared temporal-named property through props before and after select", () => {
+    const beforeSelect = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .orderBy("p", "created_at", "asc")
+      .select((context) => context.p);
+    const afterSelect = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .select((context) => context.p)
+      .orderBy("p", "created_at", "asc");
+
+    for (const query of [beforeSelect, afterSelect]) {
+      const { sql } = toSqlWithParams(
+        compileQuery(query.toAst(), graph.id, "sqlite"),
+      );
+      expect(sql).toContain("ORDER BY (json_extract");
+      expect(sql).toContain("p_props");
+      expect(sql).toContain("created_at");
+    }
+  });
+
   it("supports limit and offset for pagination", () => {
     const query = createQueryBuilder<typeof graph>(graph.id, registry)
       .from("Person", "p")
@@ -386,6 +408,22 @@ describe("Query Builder - Traversals", () => {
     const ast = query.toAst();
 
     expect(requireDefined(ast.traversals[0]).direction).toBe("in");
+  });
+
+  it("orders a declared temporal-named edge property through props", () => {
+    const query = createQueryBuilder<typeof graph>(graph.id, registry)
+      .from("Person", "p")
+      .traverse("worksAt", "e")
+      .to("Organization", "o")
+      .orderBy("e", "created_at", "asc")
+      .select((context) => context.o);
+    const { sql } = toSqlWithParams(
+      compileQuery(query.toAst(), graph.id, "sqlite"),
+    );
+
+    expect(sql).toContain("ORDER BY (json_extract");
+    expect(sql).toContain("e_props");
+    expect(sql).toContain("created_at");
   });
 });
 


### PR DESCRIPTION
Close the remaining correctness gaps identified in the pre-release issue audit: adopted SQLite transactions now prove their writer slot before any constrained-write read, graph-merge commits acquire the schema fence before the optional per-graph lock, and both query-builder stages resolve temporal ordering through one schema-aware owner.

Caller-adopted transaction handles do not expose a transaction-lifetime identity, so every constrained write proves the SQLite writer slot instead of caching evidence on a reusable connection-shaped object. TypeGraph-opened transactions are always marked through the existing write-session owner and pay no probe. A stale DEFERRED snapshot refuses before constraint reads with BEGIN IMMEDIATE guidance; it remains a ConfigurationError because TypeGraph cannot restart a caller-owned raw transaction, while the engine-specific conflict remains available through the cause chain.

Graph merge now uses one schema-first helper at every commit seam. Schema-managed incremental targets acquire their schema fence even without revision tracking, revision-tracked targets then acquire the graph lock, and stale schema evidence is translated into the merge API error appropriate to the caller.

System ordering recognizes id, kind, endpoints, and temporal lifecycle columns through one shared resolver used before and after select(). The five temporal names fall back to physical columns only when the queried kinds do not declare a same-named property; declared properties retain JSON-property precedence so where and orderBy agree. The cross-backend integration case proves physical valid_from ordering on SQLite and PostgreSQL, while node and edge regressions pin same-named property behavior.

This also adds a regression matrix proving all six node and edge bulk wrappers advance a revision-tracked store exactly once per public call, closing an issue whose implementation was subsumed by the shared atomic and portable batch executors.

Closes #492
Closes #493
Closes #496
Closes #497