### PR TITLE
v0.55.0 chore: add missing source-dependent targets changeset

### DIFF
--- a/.changeset/source-dependent-edge-targets.md
+++ b/.changeset/source-dependent-edge-targets.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Define source-dependent edge targets with a `to` map, such as `from: [Employee, Student]` with `to: { Employee: [Department], Student: [Course] }`. This allows one edge kind to connect specific source/target pairs without admitting every combination. Array-valued `to` declarations retain their existing Cartesian-product behavior.
+
+Allowed pairs are preserved in typed writes, runtime validation, schema serialization, imports, graph merges, and runtime graph extensions. Invalid pairs produce `EndpointPairError`, removing allowed pairs is a breaking schema change, and ontology compatibility checks account for the pair relationship. See [source-dependent targets](https://typegraph.dev/core-concepts#source-dependent-targets) for examples and lifecycle rules.


### PR DESCRIPTION
Add the missing minor changeset for source-dependent edge targets, merged in #604, so Changesets can prepare the `@nicia-ai/typegraph` 0.55.0 release.

The release note describes the target-map syntax, endpoint-pair validation and persistence, and links to the usage documentation.
