### PR TITLE
fix: fence startup identity repair against schema migrations

### DIFF
--- a/.changeset/identity-startup-schema-fence.md
+++ b/.changeset/identity-startup-schema-fence.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+Prevent startup identity repair from overwriting a newer schema migration with closure data derived from an older schema. Repair now checks the observed schema version inside its write transaction and raises `StaleVersionError` if a concurrent migration advanced it, preserving the newer closure.

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -198,7 +198,11 @@ disjointness is rejected when it would make a persisted class contradictory.
 
 `rebuildIdentityClosure(store)` repairs the derived current closure from live
 nodes and current assertions. It validates integrity and never advances the
-content revision.
+content revision. Schema-managed rebuilds, including automatic startup repair
+of derived identity relations, pin the schema version used by the rebuild.
+If a concurrent migration advances that version first, repair refuses with
+`StaleVersionError` without overwriting the newer closure. Reopen using the
+current graph definition before retrying.
 
 ### The database-level backstop
 

--- a/docs/IDENTITY_LOCK_ORDER.md
+++ b/docs/IDENTITY_LOCK_ORDER.md
@@ -1,0 +1,79 @@
+# Identity maintenance lock-order audit
+
+Identity work follows the order in
+`packages/typegraph/src/store/operations/write-transaction.ts`: schema-version
+fence, graph-write lock when required, identity lock, row work, then recorded
+clock. An optional earlier lock may be omitted; acquiring it **after** the
+identity lock is not an exemption. Re-entering an already-held lock on the same
+transaction does not change its acquisition order.
+
+## Maintenance callers
+
+The five `lockIdentityGraph` calls in `identity/service-maintenance.ts` have
+these owners:
+
+| Helper | Production callers | Fence and disposition |
+| --- | --- | --- |
+| `rebuildIdentityClosureForContext` | `Store.rebuildIdentityClosure` | The Store opens `runInWriteTransaction`, which validates the Store's schema version before the helper takes the identity lock. History/revision settings determine whether a graph-write lock is also required. The derived-only rebuild never advances content revision. |
+| `rebuildIdentityClosureForContext` | `identitySchemaCommitPreflight` | The backend's schema commit owns the schema fence; the preflight acquires graph-write, then identity, before rebuilding. The rebuild's identity acquisition is reentrant. |
+| `rebuildIdentityClosureForContext` | `prepareStoreWithSchema`'s derived-relation repair callback | The callback opens or adopts a write transaction and fences the schema version used to build its registry. This applies both to an existing relation needing repair and to atomic CREATE+FILL under `schemaWriteTransaction`. It takes identity only after that version check. |
+| `validateIdentityForContext` | Startup validation through `Store.validateIdentity` | Read-only exception: an independent transaction takes identity, reads ledger/nodes/closure/separation, and returns. It never acquires schema, graph-write, DDL, or recorded-clock locks, and never repairs. It can report a contradiction against a stale caller registry; it cannot persist one. |
+| `assertAffectedIdentityClassesConsistent` | Both merge appliers through the Store runtime port | Uses the merge's already-fenced transaction. The rebuild-and-recheck stays in that transaction and does not enter another write frame. |
+| `foldIdentityForCreatedNodes` | Node create/batch/upsert/resurrection and interchange import | Node operations and import acquire their write fences and identity lock before row work. The fold re-enters identity on that same target. |
+| `detachIdentityForNode` | Node soft/hard delete, including delete cascades | Uses the node operation's already-fenced target and re-enters identity; assertion endings and closure repair remain inside the delete transaction. |
+
+`withRecordedIdentityMutationTarget` does not acquire a later graph-write lock:
+it unwraps the existing capture binding and records touches. Its raw target is
+in the same transaction. Derived closure/separation rewrites do not themselves
+write the recorded assertion clock.
+
+`removeIdentityKindsForContext` has no separate bare-lock path. Its
+`runIdentityMutation` owner enters `runInWriteTransaction` before identity.
+`Store.removeKinds` invokes it inside the schema-commit transaction.
+
+## Schema-transition callers
+
+`identitySchemaCommitPreflight` is derived by schema initialization, schema
+migration/ensure, and Store evolution. `identityKindCascadePreflight` is derived
+by schema migration when identity is disabled but retained assertions still
+reference removed kinds. Both run inside `commitSchemaVersionWithPreflight`:
+the backend acquires its schema-commit fence before invoking the preflight,
+and the preflight takes graph-write before identity. A custom implementation
+must honor that backend contract.
+
+When derived-relation DDL is required, its database-wide identity-DDL lock is
+inside the schema-commit fence and outside graph-write/identity locks. Startup
+CREATE+FILL uses the same ordering under `schemaWriteTransaction`; its repair
+callback checks the previously observed schema version before identity work.
+No identity maintenance helper acquires the DDL lock or another graph's schema
+fence while holding identity.
+
+## Defect found and repaired
+
+A bare identity lock serialized startup repair against other identity writers
+but did not bind the repair's registry to the schema it would overwrite:
+
+1. An opener reads schema version 1 with same-id folding enabled and finds a
+   missing or unfilled separation relation.
+2. Another opener migrates to version 2 with folding disabled, committing an
+   unfolded closure.
+3. The old opener enters repair after that migration and rebuilds the closure
+   using version 1's folding rule.
+
+The result was a durable folded closure under a schema that disabled folding,
+even if the stale opener failed later. A transaction alone does not prevent
+this ordering, including on SQLite. The startup callback now uses the shared
+schema-version write fence and refuses with `StaleVersionError` before identity
+mutation if the migration won.
+
+`identity-maintenance-schema-race.test.ts` schedules the migration between
+startup inspection and the repair transaction for both existing and missing
+separation relations, using the same cases on SQLite and PostgreSQL. It checks the typed refusal and the committed closure.
+Removing the startup write-frame fence makes the regression fail.
+
+Existing `write-plan-statement-order.test.ts` covers node, import, identity
+assertion and public rebuild ordering. `identity-separation-upgrade-heal.test.ts`
+covers successful repair, refused migrations and atomic provisioning.
+`identity-adopted-transaction.test.ts` covers the separate SQLite DEFERRED-frame
+limitation: a stale writer-slot upgrade is refused and must be retried in a new
+transaction. This audit does not change that contract.

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -117,6 +117,7 @@ vitest_args+=(
   tests/backends/l2-score-scale-parity.test.ts
   tests/hybrid-single-statement.test.ts
   tests/identity-frontier-bounded.test.ts
+  tests/identity-maintenance-schema-race.test.ts
   tests/search-filter-pushdown.test.ts
   tests/search-liveness.test.ts
   tests/similar-to-approximate.test.ts

--- a/packages/typegraph/src/identity/schema-transition.ts
+++ b/packages/typegraph/src/identity/schema-transition.ts
@@ -247,9 +247,10 @@ async function provisioningForCommit(
  *  - CREATE alone (no live `different` assertion) — empty IS the projection, so
  *    an ordinary idempotent provision is correct and needs no fence.
  *  - FILL alone (the relation exists, empty, and this graph owes rows) — the
- *    self-heal. The recompute opens its own transaction and takes the identity
- *    lock, and the relation is already published, so there is nothing a fence
- *    would add.
+ *    self-heal. The recompute opens its own transaction, validates the schema
+ *    version its registry came from, then takes the identity lock. No DDL fence
+ *    is needed for an already-published relation; the schema-version fence is
+ *    still required to prevent a stale opener overwriting a newer migration.
  */
 async function provisionDerivedRelations(
   backend: GraphBackend,

--- a/packages/typegraph/src/identity/service-maintenance.ts
+++ b/packages/typegraph/src/identity/service-maintenance.ts
@@ -92,6 +92,12 @@ async function runOnTransactionIfSupported(
   await fn(backend);
 }
 
+/**
+ * Caller owns schema-version coherence: Store maintenance/startup repair fence
+ * the observed version, and schema preflights already hold the commit fence.
+ * This helper acquires only identity and never acquires an earlier lock after
+ * it. See docs/IDENTITY_LOCK_ORDER.md for the complete caller audit.
+ */
 export async function rebuildIdentityClosureForContext<G extends GraphDef>(
   ctx: IdentityRebuildContext<G>,
 ): Promise<void> {

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -144,6 +144,7 @@ import {
   detachIdentityForNode,
   foldIdentityForCreatedNodes,
   type IdentityImportSummary,
+  type IdentityRebuildContext,
   type IdentityServiceContext,
   type IdentityTransferAssertion,
   importIdentityAssertionsIntoTarget,
@@ -299,6 +300,7 @@ import {
   runInWriteTransaction,
   withTransactionSchemaFenceLease,
   withWriteTransactionSession,
+  type WriteTransactionContext,
 } from "./operations/write-transaction";
 import {
   advanceRevisionClock,
@@ -1403,7 +1405,8 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
   /** Rebuilds derived current identity closure without advancing revision. */
   async rebuildIdentityClosure(): Promise<void> {
     this.#requireIdentityEnabled();
-    await runInWriteTransaction(
+    await rebuildIdentityClosureWithSchemaFence(
+      this.#identityContext(this.#baseBackend),
       {
         graphId: this.graphId,
         schemaVersion: this.#schemaMetadata.schemaVersion,
@@ -1412,10 +1415,6 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         revisionSchema: this.#sqlSchema(),
         statementExecution: this.#statementExecution,
       },
-      this.#baseBackend,
-      async (target) =>
-        rebuildIdentityClosureForContext(this.#identityContext(target)),
-      { didWrite: () => false },
     );
   }
 
@@ -6475,6 +6474,20 @@ function identityMigrationRequiredError(
   );
 }
 
+/** One fenced, revision-neutral entry for public and startup identity repair. */
+function rebuildIdentityClosureWithSchemaFence<G extends GraphDef>(
+  identityContext: IdentityRebuildContext<G>,
+  writeContext: WriteTransactionContext,
+): Promise<void> {
+  return runInWriteTransaction(
+    writeContext,
+    identityContext.backend,
+    async (target) =>
+      rebuildIdentityClosureForContext({ ...identityContext, backend: target }),
+    { didWrite: () => false },
+  );
+}
+
 async function prepareStoreWithSchema<G extends GraphDef>(
   graph: G,
   backend: GraphBackend,
@@ -6583,14 +6596,27 @@ async function prepareStoreWithSchema<G extends GraphDef>(
       // graph whose semantics ARE committed heals it here.
       ...(identityGate === undefined ?
         {
+          // The registry was resolved before this transaction. Pin its schema
+          // version before taking the identity lock: a concurrent migration
+          // may already have rebuilt under different semantics, and a stale
+          // startup must not overwrite that closure even if boot later fails.
           recomputeDerivedRelations: (target) =>
-            rebuildIdentityClosureForContext({
-              backend: target,
-              graphId: merged.id,
-              registry: identityRegistry,
-              schema: resolvedIdentitySchema,
-              sameIdAcrossKinds: identityProfile.sameIdAcrossKinds,
-            }),
+            rebuildIdentityClosureWithSchemaFence(
+              {
+                backend: target,
+                graphId: merged.id,
+                registry: identityRegistry,
+                schema: resolvedIdentitySchema,
+                sameIdAcrossKinds: identityProfile.sameIdAcrossKinds,
+              },
+              {
+                graphId: merged.id,
+                schemaVersion: activeRow?.version,
+                historyEnabled: false,
+                revisionTrackingEnabled: false,
+                revisionSchema: resolvedIdentitySchema,
+              },
+            ),
         }
       : {}),
     });

--- a/packages/typegraph/tests/identity-maintenance-schema-race.test.ts
+++ b/packages/typegraph/tests/identity-maintenance-schema-race.test.ts
@@ -1,0 +1,128 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+  StaleVersionError,
+} from "../src";
+import { deriveBackend } from "../src/backend/derive-backend";
+import { generatePostgresMigrationSQL } from "../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../src/backend/postgres";
+import { createLocalSqliteBackend } from "../src/backend/sqlite/local";
+import { sql } from "../src/query/sql-fragment";
+import {
+  asCompiledRowsSql,
+  asCompiledStatementSql,
+} from "../src/query/sql-intent";
+import { migrateSchema } from "../src/schema";
+import { requireDefined } from "../src/utils/presence";
+import { provisionPostgresTestDatabase } from "./postgres-test-database";
+
+const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
+const Organization = defineNode("Organization", {
+  schema: z.object({ name: z.string() }),
+});
+let pool: Pool | undefined;
+
+beforeAll(async () => {
+  if (process.env["POSTGRES_URL"] === undefined) return;
+  const connectionString = await provisionPostgresTestDatabase(import.meta.url);
+  pool = new Pool({ connectionString });
+  await pool.query(generatePostgresMigrationSQL());
+});
+
+afterAll(async () => {
+  await pool?.end();
+});
+
+describe.each(["sqlite", "postgres"] as const)(
+  "identity maintenance schema race (%s)",
+  (dialect) => {
+    it
+      .skipIf(
+        dialect === "postgres" && process.env["POSTGRES_URL"] === undefined,
+      )
+      .each(["existing", "missing"] as const)(
+      "does not rebuild a newer identity schema from a stale registry (%s separation relation)",
+      async (relation) => {
+        const backend =
+          dialect === "sqlite" ?
+            createLocalSqliteBackend().backend
+          : createPostgresBackend(drizzle(requireDefined(pool)));
+        const foldGraph = defineGraph({
+          id: `maintenance_schema_race_${relation}`,
+          nodes: {
+            Person: { type: Person },
+            Organization: { type: Organization },
+          },
+          edges: {},
+          identity: { sameIdAcrossKinds: "fold" },
+        });
+        const ignoreGraph = defineGraph({
+          id: foldGraph.id,
+          nodes: foldGraph.nodes,
+          edges: {},
+          identity: { sameIdAcrossKinds: "ignore" },
+        });
+        try {
+          const [seeded] = await createStoreWithSchema(foldGraph, backend);
+          const person = await seeded.nodes.Person.create(
+            { name: "Alice" },
+            { id: "shared" },
+          );
+          await seeded.nodes.Organization.create(
+            { name: "Example" },
+            { id: "shared" },
+          );
+          const other = await seeded.nodes.Person.create(
+            { name: "Bob" },
+            { id: "other" },
+          );
+          await seeded.identity.assertDifferent(person, other);
+          await requireDefined(backend.executeStatement)(
+            asCompiledStatementSql(
+              relation === "existing" ?
+                sql`DELETE FROM typegraph_identity_separation`
+              : sql`DROP TABLE typegraph_identity_separation`,
+            ),
+          );
+          let interleaved = false;
+          async function migrateBeforeRebuild(): Promise<void> {
+            if (interleaved) return;
+            interleaved = true;
+            await migrateSchema(backend, ignoreGraph, 1);
+          }
+          const racing = deriveBackend(backend, {
+            transaction: async (fn, options) => {
+              await migrateBeforeRebuild();
+              return backend.transaction(fn, options);
+            },
+            schemaWriteTransaction: async (graphId, fn) => {
+              await migrateBeforeRebuild();
+              return requireDefined(backend.schemaWriteTransaction)(
+                graphId,
+                fn,
+              );
+            },
+          });
+          await expect(
+            createStoreWithSchema(foldGraph, racing),
+          ).rejects.toThrow(StaleVersionError);
+          expect(interleaved).toBe(true);
+          const rows = await backend.execute(
+            asCompiledRowsSql(
+              sql`SELECT member_kind FROM typegraph_identity_closure WHERE graph_id = ${foldGraph.id}`,
+            ),
+          );
+          expect(rows).toEqual([]);
+        } finally {
+          await backend.close();
+        }
+      },
+    );
+  },
+);


### PR DESCRIPTION
Automatic identity repair during store startup could overwrite a concurrent schema migration's closure with data derived from the opener's older registry. An opener using same-id folding could therefore restore folded classes after another opener had committed a migration disabling folding.

Run the startup repair callback through the shared schema-version write fence before acquiring the identity lock, for both existing-relation repair and atomic CREATE+FILL. A stale opener now receives `StaleVersionError`, leaving the newer closure intact. Derived-only repair still does not advance the content revision.

Document the maintenance and schema-transition caller audit, including the read-only validation exemption and the lock ordering already supplied by node, import, merge, and schema-commit callers. The deterministic interleaving regressions fail for both repair paths when the startup fence is removed and pass when it is restored.

Closes #498
