### PR TITLE
feat: support explicit open-left validity windows and preserve them in merges

### DIFF
--- a/.changeset/open-left-store-merge-windows.md
+++ b/.changeset/open-left-store-merge-windows.md
@@ -1,0 +1,7 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Accept `validFrom: null` on Store node and edge creation and upsert inputs to explicitly request an open-left validity window. Omitted lower bounds keep their existing default behavior; live-row upserts still refuse changes to an immutable lower bound.
+
+Preserve open-left staged node and edge windows through snapshot and incremental graph merges, edge repointing, and serialized merge plans instead of narrowing them to the merge commit time. Keep repeated bulk-upsert coalescing from confusing an unknown creation timestamp with a confirmed open-left bound.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -990,8 +990,13 @@ Unsupported backends are refused rather than falling back to sequential checks.
 
 ## Valid-time windows
 
-**A new row's window travels with the merge.** A branch-authored node or edge
-window — including a deliberately ended one on a resurrection — is written
+**A new row's window travels with the merge.** An explicitly open-left row stays
+open-left through snapshot and incremental merges, including edge repointing.
+Reviewable plans serialize that lower bound as `validFrom: null`; an omitted
+plan field means the write states no lower-bound change. JSON export/import and
+plan application preserve the distinction.
+
+A branch-authored node or edge window — including a deliberately ended one on a resurrection — is written
 as-is by the commit rather than reset to merge time. When the incremental
 target itself also created the surviving row, the target's committed window
 wins.

--- a/apps/docs/src/content/docs/queries/temporal.md
+++ b/apps/docs/src/content/docs/queries/temporal.md
@@ -529,8 +529,10 @@ When querying with temporal context, these fields are available:
 
 A row may have **no lower bound at all**, which means "valid since forever, as
 far as this store knows". `asOf` and `current` treat such a row as valid at
-every instant at or before its `validTo`. Two writes produce one:
+every instant strictly before its `validTo`, or every instant if it has no end.
+These writes produce one:
 
+- a Store create or resurrecting upsert stating `validFrom: null`;
 - an interchange record stating `validFrom: null` — a source row confirmed to
   have no lower bound, round-tripped rather than re-stamped;
 - a **born-already-ended** write: one that CREATES a row, or RESETS its window,

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -849,11 +849,35 @@ example with multiple graphs.
 
 The store provides typed node and edge collections via `store.nodes.*` and `store.edges.*`.
 
-Every write method below that accepts a `validFrom` option (`create`,
+On creation, every method that accepts `validFrom` (`create`,
 `createFromRecord`, `upsertById`, `upsertByIdFromRecord`, `bulkCreate`,
-`bulkInsert`, `bulkUpsertById`, and their edge equivalents) defaults it to
-that operation's own creation timestamp when omitted. `validTo` remains
-optional and open-ended until set.
+`bulkInsert`, `bulkUpsertById`, and their edge equivalents) distinguishes three
+inputs:
+
+| Input | Stored lower bound |
+| --- | --- |
+| Omitted | The operation's creation timestamp, except for the born-ended case below |
+| Canonical UTC timestamp | That timestamp |
+| `null` | No lower bound: an explicitly **open-left** window |
+
+```typescript
+const person = await store.nodes.Person.create(
+  { name: "Alice" },
+  { validFrom: null },
+);
+// person.meta.validFrom === undefined
+```
+
+An open-left row is visible at every valid-time coordinate before its `validTo`,
+or at every coordinate when there is no end. Returned metadata uses `undefined`
+for an absent bound; pass `validFrom: row.meta.validFrom ?? null` to preserve that
+state when creating a copy. Passing `undefined` requests the creation default.
+`validTo` remains optional and open-ended until set.
+
+On a live upsert, omission preserves the stored lower bound. An explicit `null`
+restates an already open-left row and is refused if the live row has a timestamp,
+just as a different timestamp is refused. `onImmutableLowerBound: "preserve"`
+continues to make the stated bound creation/resurrection-only input.
 
 The one exception is a row **born already ended**: a write that CREATES or
 RESETS a row's window while stating a `validTo` at or before its own instant and
@@ -914,7 +938,7 @@ Creates a new node.
 ```typescript
 store.nodes.Person.create(
   props: { name: string; email?: string },
-  options?: { id?: string; validFrom?: string; validTo?: string }
+  options?: { id?: string; validFrom?: string | null; validTo?: string }
 ): Promise<Node<Person>>;
 ```
 
@@ -1132,7 +1156,7 @@ at runtime, not compile time. The return type is fully typed — only the input 
 ```typescript
 store.nodes.Person.createFromRecord(
   data: Record<string, unknown>,
-  options?: { id?: string; validFrom?: string; validTo?: string }
+  options?: { id?: string; validFrom?: string | null; validTo?: string }
 ): Promise<Node<Person>>;
 ```
 
@@ -1152,7 +1176,7 @@ store.nodes.Person.upsertById(
   id: string,
   props: { name: string; email?: string },
   options?: {
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "refuse" | "preserve";
@@ -1207,7 +1231,7 @@ store.nodes.Person.upsertByIdFromRecord(
   id: string,
   data: Record<string, unknown>,
   options?: {
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "refuse" | "preserve";
@@ -1232,7 +1256,7 @@ store.nodes.Person.bulkCreate(
   items: readonly {
     props: { name: string; email?: string };
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   }[]
 ): Promise<Node<Person>[]>;
@@ -1254,7 +1278,7 @@ store.nodes.Person.bulkInsert(
   items: readonly {
     props: { name: string; email?: string };
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   }[]
 ): Promise<void>;
@@ -1269,7 +1293,7 @@ store.nodes.Person.bulkUpsertById(
   items: readonly {
     id: string;
     props: { name: string; email?: string };
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "refuse" | "preserve";
@@ -1732,7 +1756,7 @@ store.edges.worksAt.bulkCreate(
     to: NodeRef<Company>;
     props?: { role: string };
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   }[]
 ): Promise<Edge<worksAt>[]>;
@@ -1756,7 +1780,7 @@ store.edges.worksAt.bulkInsert(
     to: NodeRef<Company>;
     props?: { role: string };
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   }[]
 ): Promise<void>;
@@ -1788,7 +1812,7 @@ store.edges.worksAt.bulkUpsertById(
     from: NodeRef<Person>;
     to: NodeRef<Company>;
     props?: { role: string };
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
   }[]
@@ -1845,7 +1869,7 @@ store.edges.worksAt.getOrCreateByEndpoints(
   options?: {
     matchOn?: readonly ("role")[]; // Default: []
     ifExists?: "return" | "update"; // Default: "return"
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "refuse" | "preserve"; // Default: "refuse"
@@ -1927,7 +1951,7 @@ store.edges.worksAt.bulkGetOrCreateByEndpoints(
     from: NodeRef<Person>;
     to: NodeRef<Company>;
     props: { role: string };
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "refuse" | "preserve";

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -1378,7 +1378,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1395,7 +1395,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1405,7 +1405,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1415,7 +1415,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1561,7 +1561,7 @@ type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1619,7 +1619,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -3782,7 +3782,7 @@ export type MergePlanEdgeUpsert = Readonly<{
     to: MergePlanEntityRef;
     setProps: Readonly<Record<string, JsonValue>>;
     unsetProps: readonly string[];
-    validFrom?: string | undefined;
+    validFrom?: string | null | undefined;
     validTo?: string | undefined;
 }>;
 
@@ -3884,7 +3884,7 @@ export type MergePlanNodeUpsert = Readonly<{
     id: string;
     setProps: Readonly<Record<string, JsonValue>>;
     unsetProps: readonly string[];
-    validFrom?: string | undefined;
+    validFrom?: string | null | undefined;
     validTo?: string | undefined;
 }>;
 
@@ -4097,7 +4097,7 @@ type NodeChange = Readonly<{
 type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -4131,27 +4131,27 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -4161,7 +4161,7 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -1065,7 +1065,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1082,7 +1082,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1092,7 +1092,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1102,7 +1102,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1248,7 +1248,7 @@ type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1306,7 +1306,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -3575,7 +3575,7 @@ type NodeChange = Readonly<{
 type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -3609,27 +3609,27 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -3639,7 +3639,7 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -1093,7 +1093,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1110,7 +1110,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1120,7 +1120,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1130,7 +1130,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1276,7 +1276,7 @@ type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1334,7 +1334,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -3189,7 +3189,7 @@ type NodeChange = Readonly<{
 type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -3223,27 +3223,27 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -3253,7 +3253,7 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -1064,7 +1064,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1081,7 +1081,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1091,7 +1091,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1101,7 +1101,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1247,7 +1247,7 @@ type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1305,7 +1305,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -3129,7 +3129,7 @@ type NodeChange = Readonly<{
 type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -3163,27 +3163,27 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -3193,7 +3193,7 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -1058,7 +1058,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1075,7 +1075,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1085,7 +1085,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1095,7 +1095,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1241,7 +1241,7 @@ type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1299,7 +1299,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -3135,7 +3135,7 @@ type NodeChange = Readonly<{
 type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -3169,27 +3169,27 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -3199,7 +3199,7 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -1103,7 +1103,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1120,7 +1120,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1130,7 +1130,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1140,7 +1140,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1286,7 +1286,7 @@ type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1344,7 +1344,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -3216,7 +3216,7 @@ type NodeChange = Readonly<{
 type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -3250,27 +3250,27 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -3280,7 +3280,7 @@ type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -1237,7 +1237,7 @@ export type CreateEdgeInput<E extends AnyEdgeType = EdgeType> = Readonly<{
     toKind: string;
     toId: string;
     props: z.infer<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1252,7 +1252,7 @@ export type CreateNodeInput<N extends NodeType = NodeType> = Readonly<{
     kind: N["kind"];
     id?: string;
     props: z.infer<N["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -1778,7 +1778,7 @@ type EdgeBulkCreateItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1795,7 +1795,7 @@ type EdgeBulkGetOrCreateItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPa
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation : never;
 
@@ -1805,7 +1805,7 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
     to: NodeRef<Pairs["to"]>;
     props?: z.input<Schema>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }> : never;
 
@@ -1815,7 +1815,7 @@ type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTyp
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
-    validFrom?: string;
+    validFrom?: string | null;
 }> & ValidityEndMutation : never;
 
 // @public
@@ -1961,7 +1961,7 @@ export type EdgeCreateCommandResult = Readonly<{
 // @public
 type EdgeCreateOptions = Readonly<{
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
 }>;
 
@@ -2022,7 +2022,7 @@ options?: EdgeGetOrCreateByEndpointsOptions<E>
 export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> = Readonly<{
     matchOn?: readonly (keyof z.input<E["schema"]>)[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
 }> & ValidityEndMutation;
 
@@ -4780,7 +4780,7 @@ type NodeChange = Readonly<{
 export type NodeCollection<N extends NodeType, CN extends string = string> = Readonly<{
     create: (props: z.input<N["schema"]>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     getById: (id: NodeId<N>, options?: QueryOptions) => Promise<Node<N> | undefined>;
@@ -4814,27 +4814,27 @@ export type NodeCollection<N extends NodeType, CN extends string = string> = Rea
     count: (temporal?: QueryOptions) => Promise<number>;
     createFromRecord: (data: Record<string, unknown>, options?: Readonly<{
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>) => Promise<Node<N>>;
     upsertById: (id: string, props: z.input<N["schema"]>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     upsertByIdFromRecord: (id: string, data: Record<string, unknown>, options?: Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation) => Promise<Node<N>>;
     bulkCreate: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<Node<N>[]>;
     bulkUpsertById: (items: readonly (Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         onImmutableLowerBound?: "preserve" | "refuse";
     }> & ValidityEndMutation)[]) => Promise<Node<N>[]>;
     bulkReplaceById: (items: readonly Readonly<{
@@ -4844,7 +4844,7 @@ export type NodeCollection<N extends NodeType, CN extends string = string> = Rea
     bulkInsert: (items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
     }>[]) => Promise<void>;
     bulkDelete: (ids: readonly NodeId<N>[]) => Promise<void>;

--- a/packages/typegraph/src/graph-merge/canonicalize.ts
+++ b/packages/typegraph/src/graph-merge/canonicalize.ts
@@ -92,10 +92,11 @@ export type ClusterMember = Readonly<{
   kind: string;
   branchId: BranchId;
   props: Readonly<Record<string, JsonValue>>;
-  // The row's valid-time window. A `validTo` on a staged member means the
+  // The row's valid-time window. null explicitly preserves an open-left start.
+  // A `validTo` on a staged member means the
   // branch authored the node as ALREADY ENDED — the commit must not resurrect
   // it as current.
-  validFrom?: string;
+  validFrom?: string | null;
   validTo?: string;
 }>;
 
@@ -115,7 +116,7 @@ export type CanonicalEntity = Readonly<{
   // untouched). Carried to the commit upsert so a branch-authored window —
   // including a deliberately ENDED one on a resurrection — survives the
   // merge instead of being reset to merge time.
-  validFrom?: string;
+  validFrom?: string | null;
   validTo?: string;
   // The effective survivor window, including committed base survivors whose
   // window is intentionally not copied into the upsert fields above. Identity
@@ -477,9 +478,9 @@ export function canonicalizeCluster(
     ...(windowSource.validTo === undefined ?
       {}
     : { validTo: windowSource.validTo }),
-    ...(windowSource.validFrom === undefined ?
-      {}
-    : { endpointValidFrom: windowSource.validFrom }),
+    ...(typeof windowSource.validFrom === "string" ?
+      { endpointValidFrom: windowSource.validFrom }
+    : {}),
     ...(windowSource.validTo === undefined ?
       {}
     : { endpointValidTo: windowSource.validTo }),

--- a/packages/typegraph/src/graph-merge/edge-repoint.ts
+++ b/packages/typegraph/src/graph-merge/edge-repoint.ts
@@ -184,7 +184,7 @@ export type StagedEdge = Readonly<{
    * resolved across the folded set (see {@link repointEdges}), because an end is
    * a monotone claim that must not be lost to the survivor pick.
    */
-  validFrom?: string;
+  validFrom?: string | null;
 }> &
   ValidityEndMutation;
 
@@ -207,7 +207,7 @@ export type MergedEdge = Readonly<{
   props: Readonly<Record<string, JsonValue>>;
   mergedIds: readonly EdgeId[];
   /** The survivor's {@link StagedEdge} window, if it carried one. */
-  validFrom?: string;
+  validFrom?: string | null;
 }> &
   ValidityEndMutation;
 

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -614,9 +614,7 @@ function clusterMembersFor(
         kind: staged.node.kind,
         branchId: staged.branchId,
         props: staged.node.props as Readonly<Record<string, JsonValue>>,
-        ...(staged.node.row.valid_from === undefined ?
-          {}
-        : { validFrom: staged.node.row.valid_from }),
+        validFrom: staged.node.row.valid_from ?? null,
         ...(staged.node.row.valid_to === undefined ?
           {}
         : { validTo: staged.node.row.valid_to }),
@@ -790,9 +788,7 @@ function toStagedEdge(branchId: BranchId, item: StagedNewEdge): StagedEdge {
     toKind: item.edge.toKind,
     props: item.edge.props as Readonly<Record<string, JsonValue>>,
     branchId,
-    ...(item.edge.row.valid_from === undefined ?
-      {}
-    : { validFrom: item.edge.row.valid_from }),
+    validFrom: item.edge.row.valid_from ?? null,
     ...(item.edge.row.valid_to === undefined ?
       {}
     : { validTo: item.edge.row.valid_to }),
@@ -1730,7 +1726,7 @@ type PlannedNodeWrite = Readonly<{
    * the committed window", which is what lets an otherwise-unchanged write
    * coalesce.
    */
-  validFrom?: string;
+  validFrom?: string | null;
 }> &
   ValidityEndMutation;
 
@@ -1862,7 +1858,7 @@ function nodeWriteProps(
   };
 }
 
-type NodeWriteWindowOptions = Readonly<{ validFrom?: string }> &
+type NodeWriteWindowOptions = Readonly<{ validFrom?: string | null }> &
   ValidityEndMutation;
 
 /** Converts the plan's explicit set/clear state into the collection option union. */
@@ -1884,7 +1880,7 @@ type MechanicalNodeWrite = Readonly<{
   kind: string;
   id: string;
   props: Readonly<Record<string, unknown>>;
-  validFrom?: string;
+  validFrom?: string | null;
 }> &
   ValidityEndMutation;
 
@@ -2346,7 +2342,7 @@ type NodeCollectionLike = Readonly<{
   upsertByIdFromRecord: (
     id: string,
     data: Record<string, unknown>,
-    options?: Readonly<{ validFrom?: string }> & ValidityEndMutation,
+    options?: Readonly<{ validFrom?: string | null }> & ValidityEndMutation,
   ) => Promise<unknown>;
   delete: (id: string) => Promise<void>;
 }>;
@@ -2363,7 +2359,7 @@ type EdgeCollectionLike = Readonly<{
       from: Readonly<{ kind: string; id: string }>;
       to: Readonly<{ kind: string; id: string }>;
       props?: Record<string, unknown>;
-      validFrom?: string;
+      validFrom?: string | null;
     }> &
       ValidityEndMutation)[],
   ) => Promise<unknown>;

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -53,7 +53,7 @@ export type MergePlanNodeUpsert = Readonly<{
   id: string;
   setProps: Readonly<Record<string, JsonValue>>;
   unsetProps: readonly string[];
-  validFrom?: string | undefined;
+  validFrom?: string | null | undefined;
   validTo?: string | undefined;
 }>;
 
@@ -66,7 +66,7 @@ export type MergePlanEdgeUpsert = Readonly<{
   to: MergePlanEntityRef;
   setProps: Readonly<Record<string, JsonValue>>;
   unsetProps: readonly string[];
-  validFrom?: string | undefined;
+  validFrom?: string | null | undefined;
   validTo?: string | undefined;
 }>;
 
@@ -321,7 +321,7 @@ const nodeUpsertSchema = z
     id: nonEmptyStringSchema,
     setProps: jsonObjectSchema,
     unsetProps: z.array(nonEmptyStringSchema),
-    validFrom: nonEmptyStringSchema.optional(),
+    validFrom: nonEmptyStringSchema.nullable().optional(),
     validTo: nonEmptyStringSchema.optional(),
   })
   .strict();
@@ -334,7 +334,7 @@ const edgeUpsertSchema = z
     to: mergePlanEntityRefSchema,
     setProps: jsonObjectSchema,
     unsetProps: z.array(nonEmptyStringSchema),
-    validFrom: nonEmptyStringSchema.optional(),
+    validFrom: nonEmptyStringSchema.nullable().optional(),
     validTo: nonEmptyStringSchema.optional(),
   })
   .strict();

--- a/packages/typegraph/src/store/collection-factory.ts
+++ b/packages/typegraph/src/store/collection-factory.ts
@@ -246,7 +246,7 @@ export type EdgeOperations = Readonly<{
     options?: Readonly<{
       matchOn?: readonly string[];
       ifExists?: IfExistsMode;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
       clearValidTo?: true;
       onImmutableLowerBound?: "preserve" | "refuse";
@@ -260,7 +260,7 @@ export type EdgeOperations = Readonly<{
       toKind: string;
       toId: string;
       props: Record<string, unknown>;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
       clearValidTo?: true;
       onImmutableLowerBound?: "preserve" | "refuse";

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -103,9 +103,12 @@ type CurrentWindow = Readonly<{
  *
  * Counting it as a change is also what lets the comparison canonicalize the
  * STORED side only ({@link statedBoundMatchesStored}): past this guard the
- * requested value is known canonical.
+ * requested value is known canonical, or explicitly open-left for `validFrom`.
+ * The upper bound retains its separate set/clear protocol: null must reach the
+ * write path for rejection even when the stored upper bound is absent.
  */
 function windowFieldChanges(
+  field: "validFrom" | "validTo",
   requested: string | null | undefined,
   stored: string | typeof UNKNOWN_VALIDITY_LOWER_BOUND | undefined,
 ): boolean {
@@ -114,7 +117,9 @@ function windowFieldChanges(
   }
   if (
     stored === UNKNOWN_VALIDITY_LOWER_BOUND ||
-    (requested !== null && !isCanonicalIsoDate(requested))
+    (requested === null ?
+      field !== "validFrom"
+    : !isCanonicalIsoDate(requested))
   ) {
     return true;
   }
@@ -128,7 +133,7 @@ function lowerBoundRequiresWrite(
 ): boolean {
   const requestedValidFrom = requested?.validFrom;
   if (!preservesImmutableLowerBound(requested?.onImmutableLowerBound)) {
-    return windowFieldChanges(requestedValidFrom, stored);
+    return windowFieldChanges("validFrom", requestedValidFrom, stored);
   }
   return (
     requestedValidFrom !== undefined &&
@@ -160,7 +165,7 @@ export function upsertWindowChanges(
       validityEndAfterMutation(requested, current.valid_to) !==
         current.valid_to) ||
     (requested?.clearValidTo === true && requested.validTo !== undefined) ||
-    windowFieldChanges(requested?.validTo, current.valid_to)
+    windowFieldChanges("validTo", requested?.validTo, current.valid_to)
   );
 }
 

--- a/packages/typegraph/src/store/collections/coalesce.ts
+++ b/packages/typegraph/src/store/collections/coalesce.ts
@@ -62,20 +62,21 @@ export function findRepeatedUpsertIds(
  * A validity window as a row carries it, in the column names a backend returns —
  * so a prefetched row is comparable without being reshaped.
  *
- * `undefined` means BOTH "no bound" (an open window) and "a bound this layer
- * cannot know", and the two need no distinguishing: an absent bound never equals
- * a requested one, so an item naming a bound against either always writes. That
- * is what makes {@link windowAfterUpsertCreate} safe to leave `undefined` where
- * the backend will stamp the write instant.
+ * `undefined` is a known open-left bound. A private symbol is an UNKNOWN
+ * prediction for a queued create whose backend will choose the lower bound.
+ * Keeping those distinct prevents a later explicit open-left request from
+ * coalescing against an earlier, not-yet-stamped create.
  */
+const UNKNOWN_VALIDITY_LOWER_BOUND = Symbol("unknownValidityLowerBound");
+
 export type UpsertWindow = Readonly<{
-  valid_from: string | undefined;
+  valid_from: string | typeof UNKNOWN_VALIDITY_LOWER_BOUND | undefined;
   valid_to: string | undefined;
 }>;
 
 /** The window bounds an upsert item may request. */
 type RequestedWindow = Readonly<{
-  validFrom?: string;
+  validFrom?: string | null;
   validTo?: string;
   clearValidTo?: true;
   onImmutableLowerBound?: "preserve" | "refuse";
@@ -83,7 +84,7 @@ type RequestedWindow = Readonly<{
 
 /** A window to compare against — a row, or an {@link UpsertWindow}. */
 type CurrentWindow = Readonly<{
-  valid_from?: string | undefined;
+  valid_from?: string | typeof UNKNOWN_VALIDITY_LOWER_BOUND | undefined;
   valid_to?: string | undefined;
 }>;
 
@@ -105,13 +106,16 @@ type CurrentWindow = Readonly<{
  * requested value is known canonical.
  */
 function windowFieldChanges(
-  requested: string | undefined,
-  stored: string | undefined,
+  requested: string | null | undefined,
+  stored: string | typeof UNKNOWN_VALIDITY_LOWER_BOUND | undefined,
 ): boolean {
   if (requested === undefined) {
     return false;
   }
-  if (!isCanonicalIsoDate(requested)) {
+  if (
+    stored === UNKNOWN_VALIDITY_LOWER_BOUND ||
+    (requested !== null && !isCanonicalIsoDate(requested))
+  ) {
     return true;
   }
   return !statedBoundMatchesStored(requested, stored);
@@ -120,14 +124,16 @@ function windowFieldChanges(
 /** Whether the requested lower bound prevents an unchanged upsert from coalescing. */
 function lowerBoundRequiresWrite(
   requested: RequestedWindow | undefined,
-  stored: string | undefined,
+  stored: string | typeof UNKNOWN_VALIDITY_LOWER_BOUND | undefined,
 ): boolean {
   const requestedValidFrom = requested?.validFrom;
   if (!preservesImmutableLowerBound(requested?.onImmutableLowerBound)) {
     return windowFieldChanges(requestedValidFrom, stored);
   }
   return (
-    requestedValidFrom !== undefined && !isCanonicalIsoDate(requestedValidFrom)
+    requestedValidFrom !== undefined &&
+    requestedValidFrom !== null &&
+    !isCanonicalIsoDate(requestedValidFrom)
   );
 }
 
@@ -163,23 +169,19 @@ export function upsertWindowChanges(
  * COMPLETE window — leaves the row holding, for a later item with the same id in
  * the same batch to compare against.
  *
- * An omitted `validFrom` is left `undefined`, and that prediction is now EXACT in
- * one case and conservative in the other:
- *
- *  - BORN-ENDED (a stated `validTo` at or before the write instant): the backend
- *    stamps no lower bound at all, so `undefined` is precisely what the row will
- *    hold, and a later copy restating that shape coalesces correctly;
- *  - every other create: the backend stamps its own write instant, a value this
- *    layer cannot know, so `undefined` remains a deliberate under-approximation.
- *    A later copy naming a lower bound counts as a change and writes, rather than
- *    coalescing against a guess — the bulk path may spend a write the sequential
- *    path would skip, but it never skips one the sequential path makes.
+ * An explicit `null` predicts a known open-left row (`undefined`). Omission
+ * leaves the lower bound unknown: the backend can stamp its instant or
+ * choose no bound for a born-ended write. A later item stating any bound must
+ * therefore reach the write path, which compares against the actual row.
  */
 export function windowAfterUpsertCreate(
   requested: RequestedWindow,
 ): UpsertWindow {
   return {
-    valid_from: requested.validFrom,
+    valid_from:
+      requested.validFrom === null ?
+        undefined
+      : (requested.validFrom ?? UNKNOWN_VALIDITY_LOWER_BOUND),
     valid_to: validityEndAfterMutation(requested, undefined),
   };
 }
@@ -215,12 +217,12 @@ export function windowAfterUpsertUpdate(
 export function shouldCoalesceUpsert(
   existing: Readonly<{
     deleted_at: string | undefined;
-    valid_from?: string | undefined;
+    valid_from?: string | typeof UNKNOWN_VALIDITY_LOWER_BOUND | undefined;
     valid_to?: string | undefined;
   }>,
   options:
     | Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
         clearValidTo?: true;
       }>

--- a/packages/typegraph/src/store/collections/edge-collection.ts
+++ b/packages/typegraph/src/store/collections/edge-collection.ts
@@ -166,7 +166,7 @@ export type EdgeCollectionConfig = Readonly<{
     options?: Readonly<{
       matchOn?: readonly string[];
       ifExists?: IfExistsMode;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
       clearValidTo?: true;
       onImmutableLowerBound?: "preserve" | "refuse";
@@ -180,7 +180,7 @@ export type EdgeCollectionConfig = Readonly<{
       toKind: string;
       toId: string;
       props: Record<string, unknown>;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
       clearValidTo?: true;
       onImmutableLowerBound?: "preserve" | "refuse";
@@ -213,7 +213,11 @@ function buildCreateEdgeInput(
   from: NodeRef,
   to: NodeRef,
   props: Record<string, unknown>,
-  options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+  options?: Readonly<{
+    id?: string;
+    validFrom?: string | null;
+    validTo?: string;
+  }>,
 ): CreateEdgeInput {
   const input: {
     kind: string;
@@ -223,7 +227,7 @@ function buildCreateEdgeInput(
     toKind: string;
     toId: string;
     props: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   } = {
     kind,
@@ -268,7 +272,7 @@ type EdgeUpdateInput = Readonly<{
  */
 export type UpsertUpdateEdgeInput = EdgeUpdateInput &
   Readonly<{
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: "preserve" | "refuse";
   }>;
 
@@ -304,7 +308,7 @@ function buildUpsertUpdateEdgeInput(
   to: NodeRef,
   props: Record<string, unknown>,
   options?: Readonly<{
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
   }>,
@@ -313,7 +317,7 @@ function buildUpsertUpdateEdgeInput(
     id: string;
     identity: EdgeIdentityExpectation;
     props: Partial<Record<string, unknown>>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
   } = {
@@ -395,7 +399,7 @@ function mapBulkEdgeInputs(
     to: NodeRef;
     props?: Record<string, unknown>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   }>[],
 ): CreateEdgeInput[] {
@@ -602,7 +606,11 @@ export function createEdgeCollection<
       from: NodeRef,
       to: NodeRef,
       props?: z.input<E["schema"]>,
-      options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+      options?: Readonly<{
+        id?: string;
+        validFrom?: string | null;
+        validTo?: string;
+      }>,
     ): Promise<Edge<E>> {
       const result = await executeEdgeCreate(
         buildCreateEdgeInput(kind, from, to, props ?? {}, options),
@@ -796,7 +804,7 @@ export function createEdgeCollection<
         to: NodeRef;
         props?: z.input<E["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
       }>[],
     ): Promise<Edge<E>[]> {
@@ -812,7 +820,7 @@ export function createEdgeCollection<
         from: NodeRef;
         to: NodeRef;
         props?: z.input<E["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
         clearValidTo?: true;
       }>[],
@@ -1133,7 +1141,7 @@ export function createEdgeCollection<
         to: NodeRef;
         props?: z.input<E["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
       }>[],
     ): Promise<void> {
@@ -1210,7 +1218,7 @@ export function createEdgeCollection<
         from: NodeRef;
         to: NodeRef;
         props: z.input<E["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
         clearValidTo?: true;
         onImmutableLowerBound?: "preserve" | "refuse";

--- a/packages/typegraph/src/store/collections/node-collection.ts
+++ b/packages/typegraph/src/store/collections/node-collection.ts
@@ -87,7 +87,7 @@ function isNodeReplacementPartitionMovement(error: unknown): boolean {
 type OnImmutableLowerBound = "preserve" | "refuse";
 
 type NodeUpsertOptions = Readonly<{
-  validFrom?: string;
+  validFrom?: string | null;
   onImmutableLowerBound?: OnImmutableLowerBound;
 }> &
   ValidityEndMutation;
@@ -188,7 +188,7 @@ function evaluateNodePredicate<N extends NodeType>(
  */
 export type UpsertUpdateNodeInput = UpdateNodeInput &
   Readonly<{
-    validFrom?: string;
+    validFrom?: string | null;
     onImmutableLowerBound?: OnImmutableLowerBound;
   }>;
 
@@ -322,13 +322,17 @@ export type NodeCollectionConfig = Readonly<{
 function buildCreateInput(
   kind: string,
   props: Record<string, unknown>,
-  options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+  options?: Readonly<{
+    id?: string;
+    validFrom?: string | null;
+    validTo?: string;
+  }>,
 ): CreateNodeInput {
   const input: {
     kind: string;
     id?: string;
     props: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   } = { kind, props };
   if (options?.id !== undefined) input.id = options.id;
@@ -361,7 +365,7 @@ function buildUpsertUpdateInput(
   id: string,
   props: Record<string, unknown>,
   options?: Readonly<{
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: OnImmutableLowerBound;
@@ -371,7 +375,7 @@ function buildUpsertUpdateInput(
     kind: string;
     id: string;
     props: Partial<Record<string, unknown>>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: OnImmutableLowerBound;
@@ -390,7 +394,7 @@ function mapBulkNodeInputs(
   items: readonly Readonly<{
     props: Record<string, unknown>;
     id?: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   }>[],
 ): CreateNodeInput[] {
@@ -437,14 +441,22 @@ export function createNodeCollection<
   return {
     async create(
       props: z.input<N["schema"]>,
-      options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+      options?: Readonly<{
+        id?: string;
+        validFrom?: string | null;
+        validTo?: string;
+      }>,
     ): Promise<Node<N>> {
       return this.createFromRecord(props, options);
     },
 
     async createFromRecord(
       data: Record<string, unknown>,
-      options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+      options?: Readonly<{
+        id?: string;
+        validFrom?: string | null;
+        validTo?: string;
+      }>,
     ): Promise<Node<N>> {
       const result = await executeNodeCreate(
         buildCreateInput(kind, data, options),
@@ -802,7 +814,7 @@ export function createNodeCollection<
       items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
       }>[],
     ): Promise<Node<N>[]> {
@@ -902,7 +914,7 @@ export function createNodeCollection<
       items: readonly Readonly<{
         id: string;
         props: z.input<N["schema"]>;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
         clearValidTo?: true;
         onImmutableLowerBound?: OnImmutableLowerBound;
@@ -1194,7 +1206,7 @@ export function createNodeCollection<
       items: readonly Readonly<{
         props: z.input<N["schema"]>;
         id?: string;
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
       }>[],
     ): Promise<void> {

--- a/packages/typegraph/src/store/operations/atomic-mutation-program.ts
+++ b/packages/typegraph/src/store/operations/atomic-mutation-program.ts
@@ -208,7 +208,7 @@ export type AtomicEdgeConvergenceEligibilityInput =
       kind: string;
       matchOn: readonly string[];
       inputs: readonly Readonly<{
-        validFrom?: string;
+        validFrom?: string | null;
         validTo?: string;
         clearValidTo?: true;
         onImmutableLowerBound?: "preserve" | "refuse";

--- a/packages/typegraph/src/store/operations/edge-operations.ts
+++ b/packages/typegraph/src/store/operations/edge-operations.ts
@@ -137,6 +137,7 @@ import {
   assertWritableValidityWindow,
   preservesImmutableLowerBound,
   validateOptionalCanonicalIsoDate,
+  validateStatedValidityLowerBound,
 } from "../../utils/date";
 import { generateId } from "../../utils/id";
 import { hasOwnKey, readOwnProperty } from "../../utils/object";
@@ -346,7 +347,7 @@ function buildInsertEdgeParams(
   toKind: string,
   toId: string,
   props: Record<string, unknown>,
-  validFrom: string | undefined,
+  validFrom: string | null | undefined,
   validTo: string | undefined,
   matchIdentity?: Readonly<{ name: string; key: string }>,
 ): InsertEdgeParams {
@@ -359,7 +360,7 @@ function buildInsertEdgeParams(
     toKind: string;
     toId: string;
     props: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     matchIdentity?: Readonly<{ name: string; key: string }>;
   } = {
@@ -441,7 +442,7 @@ async function validateAndPrepareEdgeCreate<G extends GraphDef>(
   );
 
   // Validate temporal fields
-  const validFrom = validateOptionalCanonicalIsoDate(
+  const validFrom = validateStatedValidityLowerBound(
     input.validFrom,
     "validFrom",
   );
@@ -1912,7 +1913,7 @@ async function performEdgeUpdate<G extends GraphDef>(
 
   const { validatedProps } = resolveEdgeUpdateProps(ctx, existing, input.props);
 
-  const statedValidFrom = validateOptionalCanonicalIsoDate(
+  const statedValidFrom = validateStatedValidityLowerBound(
     input.validFrom,
     "validFrom",
   );
@@ -3119,7 +3120,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   options?: Readonly<{
     matchOn?: readonly string[];
     ifExists?: IfExistsMode;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "preserve" | "refuse";
@@ -3155,7 +3156,7 @@ export async function executeEdgeGetOrCreateByEndpoints<G extends GraphDef>(
   // pair here. A preserve-mode update defers ordering until its write leg has
   // resolved whether it will create/resurrect (and apply the stated start) or
   // update a live row (and retain the stored start).
-  const validFrom = validateOptionalCanonicalIsoDate(
+  const validFrom = validateStatedValidityLowerBound(
     options?.validFrom,
     "validFrom",
   );
@@ -3497,7 +3498,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     toKind: string;
     toId: string;
     props: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "preserve" | "refuse";
@@ -3538,7 +3539,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
     matchProps: Record<string, unknown>;
     compositeKey: string;
     endpointKey: string;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "preserve" | "refuse";
@@ -3554,7 +3555,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
       operation: "create",
     });
     const matchProps = normalizePersistedEdgeMatchProps(validatedProps);
-    const validFrom = validateOptionalCanonicalIsoDate(
+    const validFrom = validateStatedValidityLowerBound(
       item.validFrom,
       "validFrom",
     );
@@ -3865,7 +3866,7 @@ export async function executeEdgeBulkGetOrCreateByEndpoints<G extends GraphDef>(
      * forwarded on the live-update leg too, where the write guard refuses a
      * bound that differs from the one the row already holds.
      */
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
     clearValidTo?: true;
     onImmutableLowerBound?: "preserve" | "refuse";

--- a/packages/typegraph/src/store/operations/edge-write-pipeline.ts
+++ b/packages/typegraph/src/store/operations/edge-write-pipeline.ts
@@ -81,7 +81,7 @@ export type EdgeUpdateWork = Readonly<{
   id: string;
   props: Record<string, unknown>;
   /** See {@link UpdateEdgeParams.validFrom}: stored on the resurrecting leg. */
-  validFrom?: string;
+  validFrom?: string | null;
   clearDeleted?: boolean;
   /**
    * The cardinality claim this update owes, present only when the write

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -669,7 +669,7 @@ export function createNodeBatchValidationSeams(
       version: 1,
       // The simulated cached row only needs a NodeRow-shaped valid_from
       // (string | undefined, never null) for existence/uniqueness checks,
-      // which don't inspect its value — normalize import's explicit-NULL
+      // which don't inspect its value — normalize the write protocol's explicit-NULL
       // sentinel away rather than widen this cache's row shape.
       valid_from: params.validFrom ?? undefined,
       valid_to: params.validTo,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -144,6 +144,7 @@ import {
   preservesImmutableLowerBound,
   resolveStampedValidityLowerBound,
   validateOptionalCanonicalIsoDate,
+  validateStatedValidityLowerBound,
 } from "../../utils/date";
 import { generateId } from "../../utils/id";
 import { createDataKeyedBag, hasOwnKey } from "../../utils/object";
@@ -490,7 +491,7 @@ function buildInsertNodeParams(
   kind: string,
   id: string,
   props: Record<string, unknown>,
-  validFrom: string | undefined,
+  validFrom: string | null | undefined,
   validTo: string | undefined,
 ): InsertNodeParams {
   const insertParams: {
@@ -498,7 +499,7 @@ function buildInsertNodeParams(
     kind: string;
     id: string;
     props: Record<string, unknown>;
-    validFrom?: string;
+    validFrom?: string | null;
     validTo?: string;
   } = {
     graphId,
@@ -864,7 +865,7 @@ export type NodeCreateDraft = Readonly<{
   nodeKind: NodeType;
   uniqueConstraints: readonly UniqueConstraint[];
   validatedProps: Record<string, unknown>;
-  validFrom: string | undefined;
+  validFrom: string | null | undefined;
   validTo: string | undefined;
 }>;
 
@@ -891,7 +892,7 @@ function draftNodeCreate<G extends GraphDef>(
         operation: "create",
       });
 
-  const validFrom = validateOptionalCanonicalIsoDate(
+  const validFrom = validateStatedValidityLowerBound(
     input.validFrom,
     "validFrom",
   );
@@ -1252,7 +1253,7 @@ async function performNodeUpdate<G extends GraphDef>(
   const preservesLiveLowerBound =
     resurrectionInstant === undefined &&
     preservesImmutableLowerBound(input.onImmutableLowerBound);
-  const statedValidFrom = validateOptionalCanonicalIsoDate(
+  const statedValidFrom = validateStatedValidityLowerBound(
     input.validFrom,
     "validFrom",
   );

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -157,7 +157,8 @@ export type CreateNodeInput<N extends NodeType = NodeType> = Readonly<{
   kind: N["kind"];
   id?: string; // Optional - will generate ULID if not provided
   props: z.infer<N["schema"]>;
-  validFrom?: string;
+  /** Omit to use the creation default; null explicitly requests no lower bound. */
+  validFrom?: string | null;
   validTo?: string;
 }>;
 
@@ -214,7 +215,8 @@ export type CreateEdgeInput<E extends AnyEdgeType = EdgeType> = Readonly<{
   toKind: string;
   toId: string;
   props: z.infer<E["schema"]>;
-  validFrom?: string;
+  /** Omit to use the creation default; null explicitly requests no lower bound. */
+  validFrom?: string | null;
   validTo?: string;
 }>;
 
@@ -797,7 +799,7 @@ export type EdgeGetOrCreateByEndpointsOptions<E extends AnyEdgeType> =
      * (`ifExists: "return"`), which writes nothing at all — there the window
      * describes the edge to create if none is found.
      */
-    validFrom?: string;
+    validFrom?: string | null;
     /**
      * How an `ifExists: "update"` write treats a stated `validFrom` that differs
      * from the live edge's stored lower bound. Default: `"refuse"`.
@@ -842,7 +844,11 @@ export type NodeCollection<
    */
   create: (
     props: z.input<N["schema"]>,
-    options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+    options?: Readonly<{
+      id?: string;
+      validFrom?: string | null;
+      validTo?: string;
+    }>,
   ) => Promise<Node<N>>;
 
   /** Get a node by ID */
@@ -959,7 +965,11 @@ export type NodeCollection<
    */
   createFromRecord: (
     data: Record<string, unknown>,
-    options?: Readonly<{ id?: string; validFrom?: string; validTo?: string }>,
+    options?: Readonly<{
+      id?: string;
+      validFrom?: string | null;
+      validTo?: string;
+    }>,
   ) => Promise<Node<N>>;
 
   /**
@@ -989,7 +999,7 @@ export type NodeCollection<
     id: string,
     props: z.input<N["schema"]>,
     options?: Readonly<{
-      validFrom?: string;
+      validFrom?: string | null;
       onImmutableLowerBound?: "preserve" | "refuse";
     }> &
       ValidityEndMutation,
@@ -1021,7 +1031,7 @@ export type NodeCollection<
     id: string,
     data: Record<string, unknown>,
     options?: Readonly<{
-      validFrom?: string;
+      validFrom?: string | null;
       onImmutableLowerBound?: "preserve" | "refuse";
     }> &
       ValidityEndMutation,
@@ -1043,7 +1053,7 @@ export type NodeCollection<
     items: readonly Readonly<{
       props: z.input<N["schema"]>;
       id?: string;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
     }>[],
   ) => Promise<Node<N>[]>;
@@ -1092,7 +1102,7 @@ export type NodeCollection<
     items: readonly (Readonly<{
       id: string;
       props: z.input<N["schema"]>;
-      validFrom?: string;
+      validFrom?: string | null;
       onImmutableLowerBound?: "preserve" | "refuse";
     }> &
       ValidityEndMutation)[],
@@ -1132,7 +1142,7 @@ export type NodeCollection<
     items: readonly Readonly<{
       props: z.input<N["schema"]>;
       id?: string;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
     }>[],
   ) => Promise<void>;
@@ -1249,7 +1259,7 @@ export type NodeRef<N extends NodeType = NodeType> =
  */
 type EdgeCreateOptions = Readonly<{
   id?: string;
-  validFrom?: string;
+  validFrom?: string | null;
   validTo?: string;
 }>;
 
@@ -1302,7 +1312,7 @@ type EdgeBulkCreateItem<
       to: NodeRef<Pairs["to"]>;
       props?: z.input<Schema>;
       id?: string;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
     }>
   : never;
@@ -1317,7 +1327,7 @@ type EdgeBulkUpsertItem<
       from: NodeRef<Pairs["from"]>;
       to: NodeRef<Pairs["to"]>;
       props?: z.input<E["schema"]>;
-      validFrom?: string;
+      validFrom?: string | null;
     }> &
       ValidityEndMutation
   : never;
@@ -1332,7 +1342,7 @@ type EdgeBulkInsertItem<
       to: NodeRef<Pairs["to"]>;
       props?: z.input<Schema>;
       id?: string;
-      validFrom?: string;
+      validFrom?: string | null;
       validTo?: string;
     }>
   : never;
@@ -1346,7 +1356,7 @@ type EdgeBulkGetOrCreateItem<
       from: NodeRef<Pairs["from"]>;
       to: NodeRef<Pairs["to"]>;
       props: z.input<E["schema"]>;
-      validFrom?: string;
+      validFrom?: string | null;
       onImmutableLowerBound?: "preserve" | "refuse";
     }> &
       ValidityEndMutation

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -342,7 +342,7 @@ export function validityWindowContainsInstant(
  * PRECONDITION: as {@link isEmptyValidityWindow}. This is called BELOW the
  * validation boundary, on a public `GraphBackend` surface, so canonicality is
  * established by whoever reached the backend: store paths through
- * {@link validateOptionalCanonicalIsoDate}, interchange import through its own
+ * {@link validateStatedValidityLowerBound}, interchange import through its own
  * window validator, trusted import through its per-chunk format check. A direct
  * `GraphBackend` caller establishes it itself — a pre-existing property of that
  * surface, written down here rather than left implicit.
@@ -361,7 +361,7 @@ export function resolveStampedValidityLowerBound(
 
 /**
  * The lower bound a write that PASSES THROUGH a stated one stores: `null` — the
- * interchange spelling of a confirmed open-left window — becomes "no bound", and
+ * write-protocol spelling of a confirmed open-left window — becomes "no bound", and
  * a string is stored verbatim.
  *
  * Separate from {@link resolveStampedValidityLowerBound} because it answers a

--- a/packages/typegraph/src/utils/date.ts
+++ b/packages/typegraph/src/utils/date.ts
@@ -199,6 +199,15 @@ export function validateOptionalCanonicalIsoDate(
   return validateCanonicalIsoDate(value, fieldName);
 }
 
+/** Validates the write protocol: omission uses the default; null states no lower bound. */
+export function validateStatedValidityLowerBound(
+  value: string | null | undefined,
+  fieldName: string,
+): string | null | undefined {
+  if (value === null) return value;
+  return validateOptionalCanonicalIsoDate(value, fieldName);
+}
+
 /**
  * Whether a CANONICAL stated bound names the same instant a row already stores.
  *
@@ -219,10 +228,10 @@ export function validateOptionalCanonicalIsoDate(
  * {@link validateCanonicalIsoDate} rather than silently treated as a mismatch.
  */
 export function statedBoundMatchesStored(
-  stated: string,
+  stated: string | null,
   stored: string | undefined,
 ): boolean {
-  return stated === canonicalizeDatabaseTimestamp(stored);
+  return (stated ?? undefined) === canonicalizeDatabaseTimestamp(stored);
 }
 
 /**
@@ -250,10 +259,11 @@ export function statedBoundMatchesStored(
  * output must round-trip.
  */
 export function isInvertedValidityWindow(
-  validFrom: string | undefined,
+  validFrom: string | null | undefined,
   validTo: string | undefined,
 ): boolean {
-  if (validFrom === undefined || validTo === undefined) return false;
+  if (validFrom === undefined || validFrom === null || validTo === undefined)
+    return false;
   return validFrom > validTo;
 }
 
@@ -420,7 +430,7 @@ function assertEffectiveValidityLowerBound(
  */
 export function assertOrderedValidityWindow(
   subject: string,
-  validFrom: string | undefined,
+  validFrom: string | null | undefined,
   validTo: string | undefined,
 ): void {
   if (!isInvertedValidityWindow(validFrom, validTo)) return;
@@ -613,7 +623,7 @@ export function preservesImmutableLowerBound(
  */
 function assertStatedLowerBoundIsApplicable(
   subject: string,
-  statedValidFrom: string,
+  statedValidFrom: string | null,
   storedValidFrom: string | undefined,
 ): void {
   if (statedBoundMatchesStored(statedValidFrom, storedValidFrom)) return;
@@ -635,7 +645,7 @@ function assertStatedLowerBoundIsApplicable(
     {
       suggestion:
         storedValidFrom === undefined ?
-          "Omit validFrom: this row has no lower bound to restate, and only a resurrection can give it one."
+          "Restate validFrom: null or omit validFrom; only a resurrection can give this row a lower bound."
         : `Restate the stored bound ("${storedValidFrom}") or omit validFrom.`,
     },
   );
@@ -682,7 +692,7 @@ function assertStatedLowerBoundIsApplicable(
  */
 export function assertWritableValidityWindow(
   subject: string,
-  validFrom: string | undefined,
+  validFrom: string | null | undefined,
   lowerBound: UpdateValidityLowerBound,
   validTo: string | undefined,
 ): ValidityWindowVerdict {
@@ -702,7 +712,9 @@ export function assertWritableValidityWindow(
 
   assertEffectiveValidityLowerBound(
     subject,
-    validFrom ?? lowerBound.effectiveValidFrom,
+    validFrom === undefined ?
+      lowerBound.effectiveValidFrom
+    : (validFrom ?? undefined),
     validTo,
   );
   // ...and the inversion check falls back to the row's bound only when the

--- a/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
+++ b/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
@@ -123,6 +123,181 @@ export function registerValidityLowerBoundIntegrationTests(
   context: IntegrationTestContext,
 ): void {
   describe("a stated validFrom is applied or refused", () => {
+    /* eslint-disable unicorn/no-null -- Explicit null is the open-left write protocol under test. */
+    it("creates explicit open-left nodes and edges without changing omitted defaults", async () => {
+      const store = await context.createStore(integrationTestGraph);
+      const alice = await store.nodes.Person.create(
+        { name: "Alice", age: 1 },
+        { validFrom: null },
+      );
+      const bob = await store.nodes.Person.upsertById(
+        "open-bob",
+        { name: "Bob", age: 2 },
+        { validFrom: null },
+      );
+      const stamped = await store.nodes.Person.create({
+        name: "Stamped",
+        age: 3,
+      });
+      const edge = await store.edges.knows.create(
+        alice,
+        bob,
+        {},
+        { validFrom: null },
+      );
+      expect(alice.meta.validFrom).toBeUndefined();
+      expect(bob.meta.validFrom).toBeUndefined();
+      expect(edge.meta.validFrom).toBeUndefined();
+      expect(stamped.meta.validFrom).toBeDefined();
+      const ancient = {
+        temporalMode: "asOf",
+        asOf: FOREIGN_VALID_FROM,
+      } as const;
+      expect(await store.nodes.Person.getById(alice.id, ancient)).toBeDefined();
+      expect(await store.edges.knows.getById(edge.id, ancient)).toBeDefined();
+      expect(
+        await store.nodes.Person.getById(stamped.id, ancient),
+      ).toBeUndefined();
+    });
+
+    it("preserves explicit open-left windows through bulk creation and resurrection", async () => {
+      const store = await context.createStore(integrationTestGraph);
+      const people = await store.nodes.Person.bulkCreate([
+        { id: "open-bulk-a", props: { name: "A", age: 1 }, validFrom: null },
+        { id: "open-bulk-b", props: { name: "B", age: 2 }, validFrom: null },
+      ]);
+      const alice = requireDefined(people[0]);
+      const bob = requireDefined(people[1]);
+      const edges = await store.edges.knows.bulkCreate([
+        {
+          id: "open-bulk-edge",
+          from: alice,
+          to: bob,
+          props: {},
+          validFrom: null,
+        },
+      ]);
+      const edge = requireDefined(edges[0]);
+      expect(people.map((person) => person.meta.validFrom)).toEqual([
+        undefined,
+        undefined,
+      ]);
+      expect(edge.meta.validFrom).toBeUndefined();
+      await store.edges.knows.delete(edge.id);
+      const [revivedEdge] = await store.edges.knows.bulkUpsertById([
+        { id: edge.id, from: alice, to: bob, props: {}, validFrom: null },
+      ]);
+      expect(revivedEdge?.meta.validFrom).toBeUndefined();
+      await store.edges.knows.delete(edge.id);
+      await store.nodes.Person.delete(bob.id);
+      const revived = await store.nodes.Person.upsertById(
+        bob.id,
+        { name: "B", age: 2 },
+        { validFrom: null },
+      );
+      expect(revived.meta.validFrom).toBeUndefined();
+    });
+
+    it("replaces a tombstoned edge's timestamp with an explicit open-left historical window", async () => {
+      const store = await context.createStore(integrationTestGraph);
+      const alice = await seedPerson(store, "open-history-a");
+      const bob = await seedPerson(store, "open-history-b");
+      const edge = await store.edges.knows.create(alice, bob, {});
+      expect(edge.meta.validFrom).toBeDefined();
+      await store.edges.knows.delete(edge.id);
+      const [revived] = await store.edges.knows.bulkUpsertById([
+        {
+          id: edge.id,
+          from: alice,
+          to: bob,
+          props: {},
+          validFrom: null,
+          validTo: REVIVED_VALID_TO,
+        },
+      ]);
+      expect(revived?.meta.validFrom).toBeUndefined();
+      expect(revived?.meta.validTo).toBe(REVIVED_VALID_TO);
+    });
+
+    for (const coalesceUnchangedUpserts of [false, true]) {
+      it(`applies or refuses explicit open-left requests with coalescing ${String(coalesceUnchangedUpserts)}`, async () => {
+        const store = await context.createStore(integrationTestGraph, {
+          coalesceUnchangedUpserts,
+        });
+        const open = await store.nodes.Person.create(
+          { name: "Open", age: 1 },
+          { validFrom: null },
+        );
+        const replay = await store.nodes.Person.upsertById(
+          open.id,
+          { name: "Open", age: 1 },
+          { validFrom: null },
+        );
+        expect(replay.meta.validFrom).toBeUndefined();
+        expect(replay.meta.version).toBe(
+          open.meta.version + (coalesceUnchangedUpserts ? 0 : 1),
+        );
+        const stamped = await store.nodes.Person.create({
+          name: "Stamped",
+          age: 2,
+        });
+        await expectImmutableLowerBoundRefusal(
+          store.nodes.Person.upsertById(
+            stamped.id,
+            { name: "Stamped", age: 2 },
+            { validFrom: null },
+          ),
+        );
+        const edge = await store.edges.knows.create(open, stamped, {});
+        await expectImmutableLowerBoundRefusal(
+          store.edges.knows.bulkUpsertById([
+            {
+              id: edge.id,
+              from: open,
+              to: stamped,
+              props: {},
+              validFrom: null,
+            },
+          ]),
+        );
+        await expectImmutableLowerBoundRefusal(
+          store.nodes.Person.bulkUpsertById([
+            { id: "pending-stamp", props: { name: "Pending", age: 3 } },
+            {
+              id: "pending-stamp",
+              props: { name: "Pending", age: 3 },
+              validFrom: null,
+            },
+          ]),
+        );
+        expect(
+          await store.nodes.Person.getById(personId("pending-stamp")),
+        ).toBeUndefined();
+        await expectImmutableLowerBoundRefusal(
+          store.edges.knows.bulkUpsertById([
+            {
+              id: knowsId("pending-edge-stamp"),
+              from: open,
+              to: stamped,
+              props: {},
+            },
+            {
+              id: knowsId("pending-edge-stamp"),
+              from: open,
+              to: stamped,
+              props: {},
+              validFrom: null,
+            },
+          ]),
+        );
+        expect(
+          await store.edges.knows.getById(knowsId("pending-edge-stamp")),
+        ).toBeUndefined();
+      });
+    }
+
+    /* eslint-enable unicorn/no-null */
+
     /**
      * Registers the refusal cases against one `coalesceUnchangedUpserts` state.
      * Both are exercised, because the refusal is a property of the WRITE path:

--- a/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
+++ b/packages/typegraph/tests/backends/integration/validity-lower-bound.ts
@@ -220,6 +220,62 @@ export function registerValidityLowerBoundIntegrationTests(
     });
 
     for (const coalesceUnchangedUpserts of [false, true]) {
+      it.each(["node", "node bulk", "edge bulk"] as const)(
+        `rejects an unsupported null validTo on unchanged %s upserts with coalescing ${String(coalesceUnchangedUpserts)}`,
+        async (writePath) => {
+          const store = await context.createStore(integrationTestGraph, {
+            coalesceUnchangedUpserts,
+          });
+          const alice = await seedPerson(store, "invalid-end-a");
+          const bob = await seedPerson(store, "invalid-end-b");
+          const edge = await store.edges.knows.create(alice, bob, {});
+          const write = () => {
+            switch (writePath) {
+              case "node": {
+                return store.nodes.Person.upsertById(
+                  alice.id,
+                  { name: "Win", age: 1 },
+                  {
+                    // @ts-expect-error JavaScript callers can pass unsupported null upper bounds.
+                    validTo: null,
+                  },
+                );
+              }
+              case "node bulk": {
+                return store.nodes.Person.bulkUpsertById([
+                  {
+                    id: alice.id,
+                    props: { name: "Win", age: 1 },
+                    // @ts-expect-error JavaScript callers can pass unsupported null upper bounds.
+                    validTo: null,
+                  },
+                ]);
+              }
+              case "edge bulk": {
+                return store.edges.knows.bulkUpsertById([
+                  {
+                    id: edge.id,
+                    from: alice,
+                    to: bob,
+                    props: {},
+                    // @ts-expect-error JavaScript callers can pass unsupported null upper bounds.
+                    validTo: null,
+                  },
+                ]);
+              }
+            }
+          };
+          await expect(write()).rejects.toMatchObject({
+            name: "ValidationError",
+            message:
+              'Invalid canonical ISO 8601 datetime for "validTo": "null". Expected fixed-width UTC: YYYY-MM-DDTHH:mm:ss.sssZ',
+          });
+          const storedPerson = await store.nodes.Person.getById(alice.id);
+          const storedEdge = await store.edges.knows.getById(edge.id);
+          expect(storedPerson?.meta).toEqual(alice.meta);
+          expect(storedEdge?.meta).toEqual(edge.meta);
+        },
+      );
       it(`applies or refuses explicit open-left requests with coalescing ${String(coalesceUnchangedUpserts)}`, async () => {
         const store = await context.createStore(integrationTestGraph, {
           coalesceUnchangedUpserts,

--- a/packages/typegraph/tests/graph-merge/branch.test.ts
+++ b/packages/typegraph/tests/graph-merge/branch.test.ts
@@ -10,7 +10,12 @@ import { z } from "zod";
 
 import { rowPropsToObject } from "../../src/backend/types";
 import { branch } from "../../src/graph-merge/branch";
-import { merge } from "../../src/graph-merge/merge";
+import {
+  applyMergePlan,
+  merge,
+  planMerge,
+  planMergeIncremental,
+} from "../../src/graph-merge/merge";
 import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
 import {
   enumerateAllEdges,
@@ -313,6 +318,79 @@ describe.each(backendMatrix())("branch [$name]", (entry) => {
     expect(forkedLegacy).toBeDefined();
     expect(forkedLegacy?.meta.validFrom).toBeUndefined();
   });
+
+  it.each(["direct", "plan", "incremental"] as const)(
+    "preserves open-left staged nodes and edges when merging through %s",
+    async (mode) => {
+      const [baseStore] = await createStoreWithSchema(
+        graph,
+        await makeBackend(),
+        { revisionTracking: true },
+      );
+      const fork = unwrap(await branch<G>(baseStore, () => makeBackend()));
+      const backend = getStoreBackend(fork.store);
+      for (const id of ["open-a", "open-b"]) {
+        await backend.insertNode({
+          graphId: fork.store.graphId,
+          kind: "Person",
+          id,
+          props: { name: id },
+          validFrom: null,
+        });
+      }
+      await backend.insertEdge({
+        graphId: fork.store.graphId,
+        kind: "knows",
+        id: "open-edge",
+        fromKind: "Person",
+        fromId: "open-a",
+        toKind: "Person",
+        toId: "open-b",
+        props: { since: "unknown" },
+        validFrom: null,
+      });
+      if (mode === "direct") {
+        const result = await merge(baseStore, [fork], {});
+        if (isErr(result)) throw result.error;
+      } else {
+        const planned =
+          mode === "plan" ?
+            await planMerge(baseStore, [fork])
+          : await planMergeIncremental({
+              forkPoint: baseStore,
+              target: baseStore,
+              branches: [fork],
+            });
+        const artifact = unwrap(planned);
+        expect(
+          artifact.writes.nodeUpserts.map((node) => node.validFrom),
+        ).toEqual([null, null]);
+        expect(artifact.writes.edgeUpserts[0]?.validFrom).toBeNull();
+        const applied = await applyMergePlan(
+          baseStore,
+          JSON.parse(JSON.stringify(artifact)) as typeof artifact,
+        );
+        if (isErr(applied)) throw applied.error;
+      }
+      const nodes = await enumerateAllNodes(
+        getStoreBackend(baseStore),
+        baseStore.graphId,
+        "Person",
+      );
+      const edges = await enumerateAllEdges(
+        getStoreBackend(baseStore),
+        baseStore.graphId,
+        "knows",
+      );
+      expect(nodes).toHaveLength(2);
+      expect(edges).toHaveLength(1);
+      expect(nodes.map((node) => node.valid_from)).toEqual([
+        undefined,
+        undefined,
+      ]);
+      expect(edges[0]?.valid_from).toBeUndefined();
+    },
+  );
 
   it("honors an explicit branch id from options", async () => {
     const { baseStore } = await seedBase();

--- a/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
+++ b/packages/typegraph/tests/graph-merge/edge-repoint.test.ts
@@ -143,7 +143,7 @@ type MergedEdgeShape = Readonly<{
   toId: string;
   props: Readonly<Record<string, JsonValue>>;
   mergedIds: readonly string[];
-  validFrom: string | undefined;
+  validFrom: string | null | undefined;
   validTo: string | undefined;
 }>;
 

--- a/packages/typegraph/tests/node-claim-write-fusion.test.ts
+++ b/packages/typegraph/tests/node-claim-write-fusion.test.ts
@@ -421,7 +421,7 @@ describe("node claim write fusion", () => {
     });
   });
 
-  it("falls back when a custom command port refuses a claim plan", async () => {
+  it("preserves an explicit open-left bound when a custom command port refuses a claim plan", async () => {
     const fixture = await createRecordedPostgresStore(graph);
     const backend = deriveBackend(fixture.backend, {
       async transaction<T>(
@@ -449,9 +449,18 @@ describe("node claim write fusion", () => {
     });
     const store = createStore(graph, backend);
 
-    await store.nodes.UniqueNode.create({ email: "unsupported-consumer" });
+    const created = await store.nodes.UniqueNode.create(
+      { email: "unsupported-consumer" },
+      // eslint-disable-next-line unicorn/no-null -- Explicit open-left write protocol under test.
+      { validFrom: null },
+    );
+    expect(created.meta.validFrom).toBeUndefined();
     await expect(
-      store.nodes.UniqueNode.create({ email: "unsupported-consumer" }),
+      store.nodes.UniqueNode.create(
+        { email: "unsupported-consumer" },
+        // eslint-disable-next-line unicorn/no-null -- Explicit open-left write protocol under test.
+        { validFrom: null },
+      ),
     ).rejects.toBeInstanceOf(UniquenessError);
     expect(await store.nodes.UniqueNode.find()).toHaveLength(1);
   });

--- a/packages/typegraph/tests/node-claim-write-fusion.test.ts
+++ b/packages/typegraph/tests/node-claim-write-fusion.test.ts
@@ -421,6 +421,28 @@ describe("node claim write fusion", () => {
     });
   });
 
+  it("preserves an explicit open-left bound in a fused unique node create", async () => {
+    const fixture = await createRecordedPostgresStore(graph);
+
+    fixture.reset();
+    const created = await fixture.store.nodes.UniqueNode.create(
+      { email: "fused-open-left@example.com" },
+      // eslint-disable-next-line unicorn/no-null -- Explicit open-left write protocol under test.
+      { validFrom: null },
+    );
+
+    expectFusedClaimAndNode(nodeWrite(fixture.statements));
+    expect(created.meta.validFrom).toBeUndefined();
+    const stored = await fixture.store.nodes.UniqueNode.getById(created.id);
+    expect(stored).toBeDefined();
+    expect(stored?.meta.validFrom).toBeUndefined();
+    await expect(
+      fixture.store.nodes.UniqueNode.create({
+        email: "fused-open-left@example.com",
+      }),
+    ).rejects.toBeInstanceOf(UniquenessError);
+  });
+
   it("preserves an explicit open-left bound when a custom command port refuses a claim plan", async () => {
     const fixture = await createRecordedPostgresStore(graph);
     const backend = deriveBackend(fixture.backend, {

--- a/packages/typegraph/tests/validity-end-types.test.ts
+++ b/packages/typegraph/tests/validity-end-types.test.ts
@@ -27,7 +27,52 @@ declare const store: Store<typeof graph>;
 const personId = asNodeId<typeof Person>("person");
 const edgeId = asEdgeId<typeof knows>("edge");
 
+/* eslint-disable unicorn/no-null -- Tests the explicit open-left protocol and unchanged upper-bound types. */
 function assertAcceptedStoreCalls(): void {
+  void store.nodes.Person.create({ name: "Alice" }, { validFrom: null });
+  void store.nodes.Person.createFromRecord(
+    { name: "Alice" },
+    { validFrom: null },
+  );
+  void store.nodes.Person.upsertById(
+    "person",
+    { name: "Alice" },
+    { validFrom: null },
+  );
+  void store.nodes.Person.bulkCreate([
+    { props: { name: "Alice" }, validFrom: null },
+  ]);
+  void store.nodes.Person.bulkInsert([
+    { props: { name: "Alice" }, validFrom: null },
+  ]);
+  void store.edges.knows.create(
+    { kind: "Person", id: "a" },
+    { kind: "Person", id: "b" },
+    {},
+    { validFrom: null },
+  );
+  void store.edges.knows.bulkUpsertById([
+    {
+      id: edgeId,
+      from: { kind: "Person", id: "a" },
+      to: { kind: "Person", id: "b" },
+      validFrom: null,
+    },
+  ]);
+  void store.nodes.Person.create(
+    { name: "Alice" },
+    {
+      // @ts-expect-error the explicit open-left sentinel does not make arbitrary values valid
+      validFrom: false,
+    },
+  );
+  void store.nodes.Person.create(
+    { name: "Alice" },
+    {
+      // @ts-expect-error validTo retains its existing set/clear protocol
+      validTo: null,
+    },
+  );
   void store.nodes.Person.update(personId, {}, { clearValidTo: true });
   void store.nodes.Person.upsertById(
     "person",
@@ -86,6 +131,8 @@ function assertAcceptedStoreCalls(): void {
     },
   );
 }
+
+/* eslint-enable unicorn/no-null */
 
 describe("validity-end write types", () => {
   it("models set and clear as mutually exclusive operations", () => {


### PR DESCRIPTION
Store node and edge creation and upsert inputs accept `validFrom: null` to explicitly request an open-left validity window. Omitted bounds retain their existing defaults, and live upserts still apply or refuse a stated bound rather than silently changing history.

Graph merges carry a staged row's confirmed absent lower bound through canonicalization, edge repointing, snapshot and incremental commits, and serialized reviewable plans. This prevents an open-left row from being narrowed to the merge commit time. Repeated bulk-upsert coalescing also distinguishes a confirmed absent bound from a creation timestamp the backend has not chosen yet.

Document the input and metadata representations and include a minor changeset. Successful fused claim-and-node creation is covered alongside the custom-port fallback, including preservation of the open-left bound and enforcement of uniqueness.

The regression checks fail under targeted mutations: allowing an unsupported `validTo: null` to coalesce makes the node, bulk-node, and bulk-edge refusal cases fail; replacing the fused create’s explicit `null` with omission makes its preserved-window assertion fail. Restoring the implementation makes each case pass.

Closes #510
Closes #511
