### PR TITLE
feat: support schema-typed dynamic edges and repair generic traversal inference

### DIFF
--- a/.changeset/generic-edge-dispatch.md
+++ b/.changeset/generic-edge-dispatch.md
@@ -1,0 +1,9 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Support generic edge dispatch through `DynamicEdgeCollection<E>` and graph-aware dynamic lookups. Edge property and result types are preserved while endpoint pairs are validated at runtime. Transactions now expose `getEdgeCollection` and `getEdgeCollectionOrThrow`, including scoped receipt accounting; valid-time views expose pinned dynamic edge reads.
+
+Migration: replace generic `tx.edges[kind]` calls or uncorrelated collection casts with `tx.getEdgeCollectionOrThrow(kind)`. Concrete `.edges.<kind>` calls retain compile-time pair checking. Known-kind dynamic lookups now enforce their property schema at compile time; parse unvalidated records before passing them. Broad `EdgeRegistration` annotations continue to permit array or map targets; narrow the target shape when inspecting it. Hand-authored transaction and view mocks must provide the new lookup methods.
+
+Fix outgoing traversal target inference in graph factories that accept generic node types. Preserve the declared target kinds for both array targets and source-dependent maps, including unions of edge kinds.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        typescript-version: ["5.9.3", "6.0.3"]
+        typescript-version: ["5.9.3", "6.0.3", "7.0.2"]
     steps:
       - uses: actions/checkout@v6
 
@@ -307,7 +307,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run layered type tests
+        if: matrix.typescript-version != '7.0.2'
         run: pnpm --filter @nicia-ai/typegraph test:types
+        env:
+          TYPEGRAPH_TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}
+
+      - name: Test packed consumers with TypeScript 7
+        if: matrix.typescript-version == '7.0.2'
+        run: pnpm --filter @nicia-ai/typegraph test:types:consumer
         env:
           TYPEGRAPH_TYPESCRIPT_VERSION: ${{ matrix.typescript-version }}
 

--- a/apps/docs/src/content/docs/schemas-stores.md
+++ b/apps/docs/src/content/docs/schemas-stores.md
@@ -2702,6 +2702,19 @@ The returned collections expose the full API (`create`, `getById`, `find`, `coun
 [`DynamicNodeCollection`](/types#dynamicnodecollection) and
 [`DynamicEdgeCollection`](/types#dynamicedgecollection).
 
+Both edge lookups are also available inside `transaction`, `withTransaction`,
+and receipt-enabled transaction contexts. They resolve the transaction's own
+collections; lookups inside `measure` contribute to that scope's receipt.
+`getEdgeCollectionOrThrow` throws `KindNotFoundError` for an unknown kind and also
+accepts a Store-issued runtime edge token, using the same token validation as the
+Store. Known graph keys retain their edge property schema while endpoints are
+validated at runtime.
+
+For generic graph/kind helpers, use these lookups instead of casting
+`tx.edges[kind]`; see [dynamic edge types and migration](/types#dynamicedgecollection).
+Valid-time views expose `view.getEdgeCollection(kind)` for dynamic reads at their
+pinned coordinate.
+
 ### Dynamic Props Schema Access
 
 Returns the live `z.ZodObject` the store uses internally to validate `.create()` /

--- a/apps/docs/src/content/docs/types.md
+++ b/apps/docs/src/content/docs/types.md
@@ -326,21 +326,64 @@ contain both after runtime evolution.
 
 ### `DynamicEdgeCollection`
 
-An edge collection with widened generics for runtime string-keyed access via
-[`store.getEdgeCollection(kind)`](/schemas-stores#storegetedgecollectionkind).
-Exposes the full `EdgeCollection` API (`create`, `getById`, `find`, `count`,
-`findFrom`, `findTo`, etc.) with widened endpoint types.
+`DynamicEdgeCollection<E>` is an edge collection for runtime endpoint dispatch. Obtain it from
+[`store.getEdgeCollection(kind)`](/schemas-stores#storegetedgecollectionkind),
+`store.getEdgeCollectionOrThrow(kind)`, or either method on a transaction context.
+When `kind` belongs to the graph's TypeScript definition, `E` retains that edge's
+property schema and result type. An arbitrary `string` uses the default
+`AnyEdgeType`, so properties are checked at runtime.
 
-ID parameters (`getById`, `getByIds`, `update`, `delete`, `hardDelete`,
-`bulkDelete`, `bulkUpsertById`) accept plain `string` instead of branded
-`EdgeId<E>`, since the dynamic path typically receives IDs from edge metadata,
-snapshots, or external input where the brand is not available.
+Endpoints accept `{ kind: string; id: string }`. Writes validate endpoint domains
+and source-dependent pairs against the graph's schema. ID parameters accept
+plain `string`; returned edges retain their typed IDs. This surface exposes the
+full collection API, including bulk operations.
+
+Use it for helpers generic over a graph and edge kind:
 
 ```typescript
-import type { DynamicEdgeCollection } from "@nicia-ai/typegraph";
+import type { EdgeKinds, GraphDef, NodeRef, TransactionContext } from "@nicia-ai/typegraph";
+import type { z } from "zod";
 
-// Derived from EdgeCollection<AnyEdgeType, NodeType, NodeType> with branded ID parameters widened to string
+async function connect<G extends GraphDef, K extends EdgeKinds<G>>(
+  tx: TransactionContext<G>,
+  kind: K,
+  from: NodeRef,
+  to: NodeRef,
+  props: z.input<G["edges"][K]["type"]["schema"]>,
+) {
+  return tx.getEdgeCollectionOrThrow(kind).getOrCreateByEndpoints(
+    from, to, props, { ifExists: "update" },
+  );
+}
 ```
+
+For a reusable collection parameter, use `DynamicEdgeCollection<E>`. No collection
+cast or dependency on generated declaration filenames is needed.
+
+**Upgrading from 0.54/0.55:** source-dependent targets in 0.55 made endpoint
+arguments a union of valid pairs. TypeScript cannot resolve that union inside
+some generic `G`/`K` helpers, even for array-valued targets. Migrate dynamic calls
+from `tx.edges[kind]` to `tx.getEdgeCollectionOrThrow(kind)` (or check the optional
+lookup result). Generic `EdgeCollection<E, From, To>` and
+`TypedEdgeCollection<EdgeRegistration<E, From, To>>` annotations can encounter the
+same deferred-type limitation; use `DynamicEdgeCollection<E>` when endpoints are
+runtime data. Keep `store.edges.specificKind` for compile-time endpoint checking.
+
+`EdgeRegistration` now permits array or map targets in broad annotations. Code
+inspecting `.to` must narrow with `isEdgeTargetMap`; an explicitly Cartesian
+registration can specify `readonly To[]` as its fourth type argument.
+
+Known-kind dynamic lookups now check properties at compile time. Callers passing
+an unvalidated record should parse it with the selected schema first. An `unknown`
+property value was not accepted by the typed 0.54 API either.
+
+### `DynamicStoreViewEdgeCollection<E>`
+
+`view.getEdgeCollection(kind)` returns an optional dynamic collection bound to the
+view's valid-time coordinate. It retains known edge property types and accepts
+runtime endpoint references and string IDs. It exposes only the view's reads:
+there are no writes, deferred batch reads, or per-call temporal overrides.
+Recorded-time views retain their narrower reconstructing-read API.
 
 ## Subgraph Types
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -463,7 +463,7 @@ only SQLite unit/property tests). The jobs are:
 | **Lint & Type Check** | `typecheck`, `lint` (ESLint), `prettier`, `test:docs` (markdownlint), `test:unused` (knip) |
 | **Test (SQLite)** | Two `test:unit` shards on Node 22, `test:property` on Node 24, plus a SQLite perf sanity check and example smoke tests |
 | **Test (Coverage)** | Four V8 coverage shards on Node 24; a merge job combines their blob reports and enforces the coverage thresholds |
-| **Type Tests** | `test:types` against TypeScript 5.9.3 and 6.0.3 |
+| **Type Tests** | `test:types` against TypeScript 5.9.3 and 6.0.3; packed-consumer checks against 7.0.2 |
 | **Test (PostgreSQL)** | `test:postgres` against `pgvector/pgvector:pg18` (PostgreSQL + pgvector), plus a PostgreSQL perf sanity check |
 | **Test (Durable Objects SQLite)** | `test:do` — the workerd / Cloudflare Durable Objects SQLite lane |
 | **Build artifacts** | `turbo run build` in parallel with the test jobs |
@@ -477,3 +477,27 @@ To reproduce the core gate locally before pushing, run `pnpm fix && pnpm
 typecheck && pnpm test`, then `pnpm test:postgres` (Docker-backed) for any
 change touching backend, store, or collection code. Coverage thresholds are
 enforced by `pnpm test:coverage`.
+
+## Type-level consumer contracts
+
+Runtime and property tests execute transpiled JavaScript. They cannot establish
+that a generic TypeScript function is callable: generic relationships and
+conditional types have been erased before a generated property-test case runs.
+For public type changes, add compiler fixtures for both concrete and generic
+consumers, including generic graph/kind dispatch, generic node factories, mixed target
+declarations, explicit type annotations,
+independent endpoint unions, and required property inputs. Pair positive cases
+with negative cases so widening away the invariant fails the same fixture.
+
+`type-smoke/edge-endpoint-compat.ts` runs in the package source typecheck and the
+isolated packed-artifact consumer check. The latter uses the selected TypeScript
+compiler against published-style declarations. `tsd` uses its own bundled
+`@tsd/typescript`; installing a sibling `typescript` version does not select tsd's
+compiler. Its declaration assertions complement the compiler matrix rather than
+constituting that matrix. The TS 7 lane checks packed consumers because the
+repository source configuration still uses `baseUrl`, removed by TS 7.
+
+The API report and surface-diff checker detect structural member changes, not
+semantic call-signature compatibility or deferred generic conditionals. A clean
+report does not replace compile fixtures. See the
+[0.55 endpoint type regression analysis](TYPE_REGRESSION_055.md).

--- a/docs/TYPE_REGRESSION_055.md
+++ b/docs/TYPE_REGRESSION_055.md
@@ -1,0 +1,108 @@
+# 0.55 generic type regressions
+
+## Cause and scope
+
+The source-dependent target implementation in #604 changed endpoint-taking
+collection methods from flat parameters to distributive unions of argument
+tuples and bulk items. A concrete registration reduces to its permitted pairs.
+For `G extends GraphDef` and `K extends EdgeKinds<G>`, the extracted pair type
+remains deferred. TypeScript cannot prove that an independently assembled
+argument tuple satisfies that conditional, even when the graph is constrained to
+array-valued targets. This is a declaration-level regression, not a write-engine
+failure. #605 supplied the changeset; it did not introduce the implementation.
+
+The compiler reproduction compared installed 0.54.0 and 0.55.0 artifacts with
+TypeScript 5.9.3 and 7.0.2. The original report used `props: unknown`; that input
+fails on both releases. Correcting it to the edge schema's `z.input` makes the
+0.54 program pass and the 0.55 program fail, isolating the endpoint regression.
+
+| Consumer | 0.54 | 0.55 | Disposition |
+| --- | --- | --- | --- |
+| Generic `getOrCreateByEndpoints`, `findByEndpoints` | Compiles | Rejected | Dynamic lookup with schema-preserving `E` |
+| Generic `create`, `batchFindByEndpoints` | Compiles | Rejected | Same dynamic collection |
+| Generic `bulkCreate`, `bulkInsert`, `bulkUpsertById`, `bulkGetOrCreateByEndpoints` | Compiles | Rejected | Same dynamic collection |
+| Generic valid-time view `findByEndpoints` | Compiles | Rejected | Pinned dynamic view lookup |
+| Generic `EdgeCollection<E, From, To>` and typed registration annotations | Compiles in checked calls | Rejected in checked calls | `DynamicEdgeCollection<E>` for runtime endpoints |
+| Generic node factory followed by traversal `.to(targetKind)` | Compiles | Rejected | Direct target-kind projection without schema inference |
+| Concrete array registrations and concrete kind union | Compiles | Compiles | Preserve static surface |
+| Concrete map registration with an undeclared pair | Feature absent | Rejected | Preserve rejection |
+| Broad `EdgeRegistration.to` assumed to be an array | Array shape | Array/map shape | Narrow with `isEdgeTargetMap`, or declare an explicit Cartesian fourth argument |
+| Recorded view `findByEndpoints` | Absent | Absent | Not a regression; reconstructing views intentionally lack it |
+| `props: unknown` on the typed API | Rejected | Rejected | Parse or carry the schema's input type |
+
+The audit covered the endpoint aliases and their collection/view consumers, graph
+registration defaults, target extraction, and the adjacent traversal/registration
+changes in #604. A second regression affects query factories whose target node
+schema remains generic: outgoing target extraction began inferring a node type
+through nested array/map conditionals, leaving the known target kind deferred.
+An installed-artifact query reproduction compiles on 0.54 and fails on 0.55.
+Directly projecting the kind through numeric keys repairs this without changing
+the traversal API. Distributing the projection over target declarations preserves
+unions of maps with disjoint source keys. Positive and negative compiler cases
+cover both this factory and the map-union case. The broad-registration target
+shape change is deliberate. This is a
+bounded consumer audit, not proof of compatibility for every possible TypeScript
+program.
+
+## Why the existing checks missed it
+
+- The feature's type assertions exercised concrete registrations and concrete
+  endpoint literals. They demonstrated pair safety but did not compile helpers
+  abstracted over a graph, edge key, endpoint type parameter, or generic node
+  schema inside a graph factory.
+- Runtime unit tests, property tests, and runtime mutation tests run JavaScript.
+  They can find invalid writes but cannot observe erased generic relationships.
+  Increasing their case count would not exercise the failing compiler contract.
+- Packed smoke tests used real declarations, but their calls were also concrete.
+  Packaging coverage did not imply coverage of generic abstraction shapes.
+- API reports and the surface compatibility checker inventory structural
+  members. These methods still existed; their conditional signatures became
+  uncallable in generic contexts without a structural removal.
+- The tsd command installed the requested `typescript` beside tsd. However, tsd
+  imports its own `@tsd/typescript`. That step did not vary its compiler as its
+  old logging suggested. Source and consumer checks did vary their compilers,
+  but lacked the necessary fixture. Missing TS 7 was not the root cause: the
+  failure reproduces on 5.9.3 too.
+- Release notes described the feature and runtime compatibility, but omitted
+  generic dispatch and the broad `.to` annotation migration.
+
+## API decision and prevention
+
+Do not flatten the distributive aliases: experimentally removing their condition
+made generic calls compile while also accepting an undeclared concrete pair.
+The conditional already distributes; that distribution is load-bearing.
+Compatibility overloads that infer whether endpoint evidence has been erased add
+another inference-sensitive contract to every method.
+
+Keep concrete `.edges` calls correlated. Extend the existing runtime lookup
+boundary instead: `DynamicEdgeCollection<E>` preserves property input and result
+types, accepts runtime endpoints and string IDs, and uses the same underlying
+collections and validators. Transaction lookups resolve the transaction/scope
+wrappers, and valid-time view lookups resolve pinned wrappers. No independent
+write implementation is introduced. Broad registration defaults are not reverted
+merely to recreate the previous shape. Hand-authored transaction and view mocks
+must implement the new lookups; this is an intentional pre-1.0 minor API change
+recorded by exact member in the compatibility exception ledger.
+
+The consumer fixture now compiles generic graph/key helpers and explicit dynamic
+collection annotations, generic query factories, and map-union traversals
+alongside concrete positive and negative pair checks,
+required properties, temporal set/clear exclusivity, and read-only view checks.
+It runs against source and packed declarations. The compiler matrix includes a
+TS 7 packed-consumer lane, and tsd logging states its actual compiler ownership.
+Shared backend cases verify transaction rollback, invalid bulk-pair atomicity,
+receipt/scoped receipt attribution, and pinned reads, with and without history.
+
+The load-bearing checks were exercised in an isolated copy of the source:
+routing scoped dynamic lookups through the root collections failed both history
+variants; restoring the context-owned lookup passed. Replacing the dynamic
+collection's selected property schema with `AnyEdgeType` made the fixture's
+property and required-input negative assertions unused; restoring `E` compiled.
+The original installed-artifact comparison independently establishes the generic
+call regression rather than relying on a newly introduced lookup being absent.
+
+Restoring the original query target alias in the isolated source made the generic
+factory and mixed array/map traversal assertions fail; restoring the direct and
+distributive projections compiled. The direct array projection is necessary for
+a generic schema whose kind is known, while the distributive projection retains
+every range when selecting among differently shaped declarations.

--- a/packages/typegraph/etc/api-surface-exceptions.json
+++ b/packages/typegraph/etc/api-surface-exceptions.json
@@ -1,1 +1,282 @@
-[]
+[
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreViewImplementation",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollection",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "TransactionCollections",
+    "member": "getEdgeCollectionOrThrow",
+    "kind": "required-member-added",
+    "reason": "Intentional pre-1.0 minor API addition: generic edge dispatch uses context-owned dynamic lookup methods. Hand-authored transaction or view mocks must implement the lookup; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getById",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "DynamicStoreViewEdgeCollection",
+    "member": "getByIds",
+    "kind": "required-member-added",
+    "reason": "New return type of the required dynamic view lookup, reachable through hand-authored StoreView mocks. The pre-1.0 minor migration requires mocks to provide the lookup and its pinned read collection; see docs/TYPE_REGRESSION_055.md.",
+    "issue": "#604"
+  }
+]

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -87,6 +87,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -1264,7 +1267,12 @@ type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1336,6 +1344,12 @@ type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Readonly<{
@@ -1410,8 +1424,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1442,15 +1456,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1458,8 +1472,8 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1471,16 +1485,21 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 type EdgeConvergeCreateCommand = Readonly<{
@@ -1712,6 +1731,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -5143,9 +5165,11 @@ type ReportNodeIdentity = Readonly<{
 }>;
 
 // @public (undocumented)
-interface RequiredEdgeCollectionLookup {
+interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -5230,7 +5254,7 @@ type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends RuntimeNo
 }> : never;
 
 // @public
-type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -5752,8 +5776,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -6149,6 +6173,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -6340,6 +6367,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -6799,7 +6828,7 @@ type ValidateStoreOptions = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 export const VALIDITY_END_TARGET_PRECEDENCE: "target";

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -84,6 +84,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -951,7 +954,12 @@ type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1023,6 +1031,12 @@ type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Readonly<{
@@ -1097,8 +1111,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1129,15 +1143,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1145,8 +1159,8 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1158,16 +1172,21 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 type EdgeConvergeCreateCommand = Readonly<{
@@ -1399,6 +1418,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -4498,9 +4520,11 @@ type ReleaseIndexMaterializationClaimParams = Readonly<{
 type RemovalMaterializationBackend = Pick<GraphBackend, "ensureKindRemovalsTable" | "getPendingKindRemovals" | "getAllKindRemovals" | "recordKindRemoval" | "ensureReconciliationMarkersTable" | "getReconciliationMarker" | "setReconciliationMarker">;
 
 // @public (undocumented)
-interface RequiredEdgeCollectionLookup {
+interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -4555,7 +4579,7 @@ type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends RuntimeNo
 }> : never;
 
 // @public
-type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -5022,8 +5046,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -5419,6 +5443,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -5610,6 +5637,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -6054,7 +6083,7 @@ type ValidateStoreOptions = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 type ValidityEndMutation = BackendValidityEndMutation;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -84,6 +84,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -979,7 +982,12 @@ type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1051,6 +1059,12 @@ type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Readonly<{
@@ -1125,8 +1139,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1157,15 +1171,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1173,8 +1187,8 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1186,16 +1200,21 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 type EdgeConvergeCreateCommand = Readonly<{
@@ -1427,6 +1446,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -4136,9 +4158,11 @@ type ReleaseIndexMaterializationClaimParams = Readonly<{
 type RemovalMaterializationBackend = Pick<GraphBackend, "ensureKindRemovalsTable" | "getPendingKindRemovals" | "getAllKindRemovals" | "recordKindRemoval" | "ensureReconciliationMarkersTable" | "getReconciliationMarker" | "setReconciliationMarker">;
 
 // @public (undocumented)
-interface RequiredEdgeCollectionLookup {
+interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -4193,7 +4217,7 @@ type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends RuntimeNo
 }> : never;
 
 // @public
-type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -4670,8 +4694,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -5090,6 +5114,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -5281,6 +5308,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -5708,7 +5737,7 @@ type ValidateStoreOptions = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 type ValidityEndMutation = BackendValidityEndMutation;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -84,6 +84,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -950,7 +953,12 @@ type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1022,6 +1030,12 @@ type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Readonly<{
@@ -1096,8 +1110,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1128,15 +1142,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1144,8 +1158,8 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1157,16 +1171,21 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 type EdgeConvergeCreateCommand = Readonly<{
@@ -1398,6 +1417,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -4124,9 +4146,11 @@ type ReleaseIndexMaterializationClaimParams = Readonly<{
 type RemovalMaterializationBackend = Pick<GraphBackend, "ensureKindRemovalsTable" | "getPendingKindRemovals" | "getAllKindRemovals" | "recordKindRemoval" | "ensureReconciliationMarkersTable" | "getReconciliationMarker" | "setReconciliationMarker">;
 
 // @public (undocumented)
-interface RequiredEdgeCollectionLookup {
+interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -4181,7 +4205,7 @@ type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends RuntimeNo
 }> : never;
 
 // @public
-type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -4648,8 +4672,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -5045,6 +5069,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -5236,6 +5263,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -5661,7 +5690,7 @@ type ValidateStoreOptions = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 type ValidityEndMutation = BackendValidityEndMutation;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -84,6 +84,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -944,7 +947,12 @@ type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1016,6 +1024,12 @@ type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Readonly<{
@@ -1090,8 +1104,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1122,15 +1136,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1138,8 +1152,8 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1151,16 +1165,21 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 type EdgeConvergeCreateCommand = Readonly<{
@@ -1395,6 +1414,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -4099,9 +4121,11 @@ type ReleaseIndexMaterializationClaimParams = Readonly<{
 type RemovalMaterializationBackend = Pick<GraphBackend, "ensureKindRemovalsTable" | "getPendingKindRemovals" | "getAllKindRemovals" | "recordKindRemoval" | "ensureReconciliationMarkersTable" | "getReconciliationMarker" | "setReconciliationMarker">;
 
 // @public (undocumented)
-interface RequiredEdgeCollectionLookup {
+interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -4172,7 +4196,7 @@ type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends RuntimeNo
 }> : never;
 
 // @public
-type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -4642,8 +4666,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -5039,6 +5063,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -5236,6 +5263,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -5658,7 +5687,7 @@ type ValidateStoreOptions = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 type ValidityEndMutation = BackendValidityEndMutation;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -84,6 +84,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -989,7 +992,12 @@ type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1061,6 +1069,12 @@ type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType> = Readonly<{
@@ -1135,8 +1149,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1167,15 +1181,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1183,8 +1197,8 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1196,16 +1210,21 @@ type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To 
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 type EdgeConvergeCreateCommand = Readonly<{
@@ -1437,6 +1456,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -4163,9 +4185,11 @@ type ReleaseIndexMaterializationClaimParams = Readonly<{
 type RemovalMaterializationBackend = Pick<GraphBackend, "ensureKindRemovalsTable" | "getPendingKindRemovals" | "getAllKindRemovals" | "recordKindRemoval" | "ensureReconciliationMarkersTable" | "getReconciliationMarker" | "setReconciliationMarker">;
 
 // @public (undocumented)
-interface RequiredEdgeCollectionLookup {
+interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -4220,7 +4244,7 @@ type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends RuntimeNo
 }> : never;
 
 // @public
-type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -4697,8 +4721,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -5117,6 +5141,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -5308,6 +5335,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -5735,7 +5764,7 @@ type ValidateStoreOptions = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 type ValidityEndMutation = BackendValidityEndMutation;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -168,6 +168,9 @@ type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
 }>;
 
 // @public
+type ArrayNodeKinds<T> = T[number & keyof T]["kind" & keyof T[number & keyof T]] & string;
+
+// @public
 type ArrayOp = "contains" | "containsAll" | "containsAny" | "isEmpty" | "isNotEmpty" | "lengthEq" | "lengthGt" | "lengthGte" | "lengthLt" | "lengthLte";
 
 // @public
@@ -1634,7 +1637,12 @@ export type DynamicEdgeAccessor = Readonly<{
 }>;
 
 // @public
-export type DynamicEdgeCollection = WidenBrandedIds<EdgeCollection<AnyEdgeType, NodeType, NodeType>>;
+export type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<EdgeCollection<E, NodeType, NodeType, {
+    from: NodeType;
+    to: NodeType;
+}, string>, "create"> & Readonly<{
+    create: (from: NodeRef, to: NodeRef, ...args: EdgeCreateArguments<E>) => Promise<Edge<E>>;
+}>;
 
 // @public (undocumented)
 export type DynamicEdgeType = AnyEdgeType & Readonly<{
@@ -1706,6 +1714,12 @@ export type DynamicSelectableNode = Readonly<{
     kind: string;
     meta: SelectableNodeMeta;
 }> & Readonly<Record<string, unknown>>;
+
+// @public
+export type DynamicStoreViewEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> & Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (ids: readonly string[]) => Promise<readonly (Edge<E> | undefined)[]>;
+}>;
 
 // @public
 export class EagerMaterializationError extends TypeGraphError {
@@ -1810,8 +1824,8 @@ type EdgeBulkInsertItem<Pairs extends EdgeEndpointPairTypes, Schema extends z.Zo
 }> : never;
 
 // @public (undocumented)
-type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
-    id: EdgeId<E>;
+type EdgeBulkUpsertItem<E extends AnyEdgeType, Pairs extends EdgeEndpointPairTypes, Id extends string = EdgeId<E>> = Pairs extends EdgeEndpointPairTypes ? Readonly<{
+    id: Id;
     from: NodeRef<Pairs["from"]>;
     to: NodeRef<Pairs["to"]>;
     props?: z.input<E["schema"]>;
@@ -1842,15 +1856,15 @@ type EdgeClaimOutcome = Readonly<{
     holderEdgeId: string;
 }>;
 
-// @public (undocumented)
+// @public
 export type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeType, To extends NodeType = NodeType, Pairs extends EdgeEndpointPairTypes = {
     from: From;
     to: To;
-}> = Readonly<{
+}, InputId extends string = EdgeId<E>> = Readonly<{
     create: (...args: EdgeCreateArgumentsTuple<E, Pairs>) => Promise<Edge<E, From, To>>;
-    getById: (id: EdgeId<E>, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
-    getByIds: (ids: readonly EdgeId<E>[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
-    update: (id: EdgeId<E>, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
+    getById: (id: InputId, options?: QueryOptions) => Promise<Edge<E, From, To> | undefined>;
+    getByIds: (ids: readonly InputId[], options?: QueryOptions) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
+    update: (id: InputId, props: Partial<z.input<E["schema"]>>, options?: ValidityEndMutation) => Promise<Edge<E, From, To>>;
     findFrom: (from: NodeRef<From>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     findTo: (to: NodeRef<To>, options?: QueryOptions) => Promise<Edge<E, From, To>[]>;
     bulkFindFrom: (froms: readonly NodeRef<From>[], options?: EdgeBulkFindEndpointOptions) => Promise<readonly Edge<E, From, To>[][]>;
@@ -1858,8 +1872,8 @@ export type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeTy
     batchFindFrom: (from: NodeRef<From>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindTo: (to: NodeRef<To>, options?: QueryOptions) => BatchableQuery<Edge<E, From, To>>;
     batchFindByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => BatchableQuery<Edge<E, From, To>>;
-    delete: (id: EdgeId<E>) => Promise<void>;
-    hardDelete: (id: EdgeId<E>) => Promise<void>;
+    delete: (id: InputId) => Promise<void>;
+    hardDelete: (id: InputId) => Promise<void>;
     find: (filter?: Readonly<{
         from?: NodeRef<From>;
         to?: NodeRef<To>;
@@ -1871,16 +1885,21 @@ export type EdgeCollection<E extends AnyEdgeType, From extends NodeType = NodeTy
         to?: NodeRef<To>;
     }>, temporal?: QueryOptions) => Promise<number>;
     bulkCreate: (items: readonly EdgeBulkCreateItem<Pairs, E["schema"]>[]) => Promise<Edge<E, From, To>[]>;
-    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs>[]) => Promise<Edge<E, From, To>[]>;
+    bulkUpsertById: (items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[]) => Promise<Edge<E, From, To>[]>;
     bulkInsert: (items: readonly EdgeBulkInsertItem<Pairs, E["schema"]>[]) => Promise<void>;
-    bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+    bulkDelete: (ids: readonly InputId[]) => Promise<void>;
     findByEndpoints: (...args: EdgeFindByEndpointsArguments<E, Pairs>) => Promise<Edge<E, From, To> | undefined>;
     getOrCreateByEndpoints: (...args: EdgeGetOrCreateByEndpointsArguments<E, Pairs>) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>>;
     bulkGetOrCreateByEndpoints: (items: readonly EdgeBulkGetOrCreateItem<E, Pairs>[], options?: Pick<EdgeGetOrCreateByEndpointsOptions<E>, "matchOn" | "ifExists">) => Promise<EdgeGetOrCreateByEndpointsResult<E, From, To>[]>;
 }>;
 
 // @public (undocumented)
-export type EdgeCollectionLookup = (kind: string) => DynamicEdgeCollection | undefined;
+export interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    (kind: string): DynamicEdgeCollection | undefined;
+}
 
 // @public
 export type EdgeConvergeCreateCommand = Readonly<{
@@ -2179,6 +2198,9 @@ type EdgeRow = Readonly<{
     updated_at: string;
     deleted_at: string | undefined;
 }>;
+
+// @public
+type EdgeTargetKinds<T> = T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 // @public
 export type EdgeTargetMap = Readonly<Record<string, readonly NodeType[]>>;
@@ -5969,9 +5991,11 @@ export type RepairRelation = "nodes" | "edges" | "recordedNodes" | "recordedEdge
 export type RepairRelationScope = "live" | "live-and-recorded";
 
 // @public (undocumented)
-export interface RequiredEdgeCollectionLookup {
+export interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
     // (undocumented)
     <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+    // (undocumented)
+    <K extends EdgeKinds<G>>(kind: K): DynamicEdgeCollection<G["edges"][K]["type"]>;
     // (undocumented)
     (kind: string): DynamicEdgeCollection;
 }
@@ -6079,7 +6103,7 @@ export type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> = T extends Ru
 }> : never;
 
 // @public
-export type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>>;
+export type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 // @public
 export type RuntimeEdgeFor<T extends RuntimeEdgeKind> = T extends RuntimeEdgeKind ? Edge<RuntimeEdgeTypeFor<T>, NodeType, NodeType> : never;
@@ -6697,8 +6721,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
     runtimeEdgeKind: <const K extends string, const D extends ExtensionEdgeDef>(kind: K, definition: D) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
     getNodeCollection: NodeCollectionLookup;
     getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-    getEdgeCollection: EdgeCollectionLookup;
-    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
     getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
     getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -7147,6 +7171,9 @@ class StoreViewImplementation<G extends GraphDef> extends CoordinatePinnedView<G
     asOfRecorded(recordedAsOf: RecordedInstant): RecordedStoreView<G>;
     bulkFindEdgesFrom<const K extends EdgeKinds<G>>(params: BulkFindEdgesFromParams<G, K>, options?: Omit<EdgeBulkFindEndpointOptions, "temporalMode" | "asOf">): Promise<readonly BulkFindEdgesFromResult<G, K>[]>;
     get edges(): StoreViewEdgeCollections<G>;
+    getEdgeCollection<K extends EdgeKinds<G>>(kind: K): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+    // (undocumented)
+    getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
     get nodes(): StoreViewNodeCollections<G>;
     get search(): StoreSearch<G>;
 }
@@ -7390,6 +7417,8 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
     [TRANSACTION_RUNTIME]: TransactionRuntime;
     nodes: GraphNodeCollections<G>;
     edges: GraphEdgeCollections<G>;
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
     backend: TransactionReadBackend;
     getNodeCollection: <const K extends string>(kind: K) => DynamicNodeCollection<K> | undefined;
 }> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
@@ -7947,7 +7976,7 @@ export type ValidationIssue = Readonly<{
 }>;
 
 // @public
-type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection_2> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ? N["kind"] : G["edges"][EK]["to"] extends (Record<string, readonly (infer N extends NodeType)[]>) ? N["kind"] : never : G["edges"][EK]["from"][number]["kind"] : never;
+type ValidEdgeTargets<G extends GraphDef, EK extends keyof G["edges"] & string, Dir extends TraversalDirection_2> = G["edges"][EK] extends EdgeRegistration ? Dir extends "out" ? ArrayNodeKinds<G["edges"][EK]["to"]> | EdgeTargetKinds<G["edges"][EK]["to"]> : G["edges"][EK]["from"][number]["kind"] : never;
 
 // @public
 export type ValidityEndMutation = BackendValidityEndMutation;

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -211,10 +211,16 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * measured API Extractor result after exporting the intended public contracts;
  * `./core` and the Drizzle indexes entrypoint are unchanged.
  */
+// Dynamic pinned edge lookup adds DynamicStoreViewEdgeCollection to the six
+// non-root Store-bearing entrypoints. Removing that single name reproduces each
+// previous fingerprint; the root exports the type directly and is unchanged.
+// Generic traversal inference adds only ArrayNodeKinds and EdgeTargetKinds to
+// the seven Store-bearing entrypoints. Removing those names reproduces each
+// preceding fingerprint; these helpers are not new package entrypoint exports.
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   ".": {
-    count: 378,
-    sha256: "0cb94bcb6dfd5d167567f7e777f95e844ef837dd19891eb8694aa97e5f3f6662",
+    count: 380,
+    sha256: "fbd1da5eac1bd4d5b2516645e3e6568f3b787a6a9537e1504fd4ca64017634e5",
   },
   "./adapters/drizzle/indexes": {
     count: 24,
@@ -253,36 +259,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "1678650d02e0d9d7cc767ffbacbf163724c82fd4590c219b97d3dff85a6bf2f6",
   },
   "./graph-merge": {
-    count: 703,
-    sha256: "c064127f3073508f81c23fafe05a7b26910107b80904c05bfad0bd769f462df1",
+    count: 706,
+    sha256: "3494595c41f350eac3a5de03adc6589dabee3de481c4747a7d43ac138a7784f1",
   },
   "./indexes": {
     count: 46,
     sha256: "5a43d419097711d242c6208632e7e498374a5977eb10a7faba904b10e13f35cd",
   },
   "./interchange": {
-    count: 689,
-    sha256: "e97787e4c8885fb5fb37d8da55a9f37d4c65e0e05ad73882dbed41b0d98eb287",
+    count: 692,
+    sha256: "f4760194562e7aae14b78a84d54aa4b47505cb7b2e68a08d45463b12d1870fa3",
   },
   "./postgres/pglite": {
-    count: 693,
-    sha256: "05af42a38fdd2ae01bd1fb29940b7d5ac2e99dfcc2d6943d0f38ab04e857d803",
+    count: 696,
+    sha256: "dc01a8fc90496da7732c9f5d0d99d0c755070d99ab65878d784e263278bc590f",
   },
   "./profiler": {
-    count: 691,
-    sha256: "04dbe9758a6958939e07b0ff229ab286745ed4e7170a0d57d5495dc8b169abe0",
+    count: 694,
+    sha256: "593c75cf197ad215ffd18dbab8a911b2bce9f3694f222243b533df4e8fff9bd2",
   },
   "./provenance": {
-    count: 697,
-    sha256: "5f604329ce3285b31051a6222e051440f2a266f328ba3687fb3673ce59d5a47e",
+    count: 700,
+    sha256: "74a5fa745fa37bdc4a760aee4b7f92877f93909784878c5282f07bf2f30335b6",
   },
   "./schema": {
     count: 263,
     sha256: "eb7a0664ed8d89c35213508e4dd563ffeaf96bf2212f6e4a4916aaf9b3f971b5",
   },
   "./sqlite/local": {
-    count: 693,
-    sha256: "05af42a38fdd2ae01bd1fb29940b7d5ac2e99dfcc2d6943d0f38ab04e857d803",
+    count: 696,
+    sha256: "dc01a8fc90496da7732c9f5d0d99d0c755070d99ab65878d784e263278bc590f",
   },
 };
 

--- a/packages/typegraph/scripts/api-surface-compat.ts
+++ b/packages/typegraph/scripts/api-surface-compat.ts
@@ -14,7 +14,15 @@
  * resolved tag has no snapshot for a given entrypoint, the checker refuses
  * (non-zero exit, remediation text) rather than silently comparing nothing.
  *
- * ## The one stated limitation
+ * ## Limitations
+ *
+ * This is a structural member comparison, not a TypeScript assignability or
+ * callable-signature checker. Changed rest tuples, conditional types, generic
+ * defaults, and input/output relationships can break consumers without changing
+ * a member's presence. Source and packed-consumer compiler fixtures cover those
+ * contracts; see docs/TYPE_REGRESSION_055.md.
+ *
+ * ### Effectively required optional members
  *
  * An optional-but-effectively-required member — `foo?: X` whose *absence*
  * throws a typed error at runtime — is invisible to this snapshot differ,

--- a/packages/typegraph/scripts/test-types.ts
+++ b/packages/typegraph/scripts/test-types.ts
@@ -154,24 +154,12 @@ async function runInlineTypecheck(
   );
 }
 
-async function runDeclarationTypeTests(
-  packageDir: string,
-  typescriptVersion: string,
-): Promise<void> {
-  console.log(
-    `Running declaration (tsd) tests with TypeScript ${typescriptVersion}...`,
-  );
+async function runDeclarationTypeTests(packageDir: string): Promise<void> {
+  console.log("Running declaration tests with tsd's bundled TypeScript...");
 
   await runCommand(
     "pnpm",
-    [
-      "dlx",
-      `--package=typescript@${typescriptVersion}`,
-      "--package=tsd",
-      "tsd",
-      "--files",
-      "test-d/**/*.test-d.ts",
-    ],
+    ["dlx", "--package=tsd", "tsd", "--files", "test-d/**/*.test-d.ts"],
     packageDir,
   );
 }
@@ -201,6 +189,10 @@ async function runConsumerTypeSmokeTest(
     await copyFile(
       path.join(fixtureDir, "consumer.ts"),
       path.join(temporaryDir, "consumer.ts"),
+    );
+    await copyFile(
+      path.join(fixtureDir, "edge-endpoint-compat.ts"),
+      path.join(temporaryDir, "edge-endpoint-compat.ts"),
     );
     await copyFile(
       path.join(fixtureDir, "tsconfig.json"),
@@ -255,7 +247,7 @@ async function main(): Promise<void> {
   }
 
   if (mode === "all" || mode === "declarations") {
-    await runDeclarationTypeTests(packageDir, typescriptVersion);
+    await runDeclarationTypeTests(packageDir);
   }
 
   if (mode === "all" || mode === "consumer") {

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -656,6 +656,7 @@ export type {
   DynamicNode,
   DynamicNodeCollection,
   DynamicNodeReference,
+  DynamicStoreViewEdgeCollection,
   Edge,
   EdgeBulkFindEndpointOptions,
   EdgeBulkFindOptions,

--- a/packages/typegraph/src/query/builder/edge-target-kinds.ts
+++ b/packages/typegraph/src/query/builder/edge-target-kinds.ts
@@ -1,0 +1,11 @@
+/**
+ * Reads node kinds without an inferred conditional that stays deferred for
+ * arrays of generic node types. Non-array values contribute never.
+ */
+export type ArrayNodeKinds<T> = T[number & keyof T]["kind" &
+  keyof T[number & keyof T]] &
+  string;
+
+/** Projects each declaration separately so mixed arrays/maps retain all kinds. */
+export type EdgeTargetKinds<T> =
+  T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -53,6 +53,7 @@ import {
   type IsDynamicEdgeType,
   type IsDynamicNodeType,
 } from "./dynamic";
+import type { ArrayNodeKinds, EdgeTargetKinds } from "./edge-target-kinds";
 
 export type { TraversalExpansion } from "../ast";
 
@@ -96,18 +97,6 @@ export type BatchResults<Queries extends readonly BatchableQuery<unknown>[]> = {
 // ============================================================
 // Edge Target Type Helpers
 // ============================================================
-
-/**
- * Reads node kinds without an inferred conditional that stays deferred for
- * arrays of generic node types. Non-array values contribute never.
- */
-export type ArrayNodeKinds<T> = T[number & keyof T]["kind" &
-  keyof T[number & keyof T]] &
-  string;
-
-/** Projects each declaration separately so mixed arrays/maps retain all kinds. */
-export type EdgeTargetKinds<T> =
-  T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
 
 /**
  * Extracts the declared target kinds for an edge traversal.

--- a/packages/typegraph/src/query/builder/types.ts
+++ b/packages/typegraph/src/query/builder/types.ts
@@ -98,15 +98,21 @@ export type BatchResults<Queries extends readonly BatchableQuery<unknown>[]> = {
 // ============================================================
 
 /**
- * Extracts the names of valid target node kinds for an edge traversal.
- *
- * For "out" direction: returns the names of node kinds in the edge's "to" array.
- * For "in" direction: returns the names of node kinds in the edge's "from" array.
- *
- * @example
- * // Given: worksAt: { from: [Person], to: [Company, Organization] }
- * // ValidEdgeTargets<G, "worksAt", "out"> = "Company" | "Organization"
- * // ValidEdgeTargets<G, "worksAt", "in"> = "Person"
+ * Reads node kinds without an inferred conditional that stays deferred for
+ * arrays of generic node types. Non-array values contribute never.
+ */
+export type ArrayNodeKinds<T> = T[number & keyof T]["kind" &
+  keyof T[number & keyof T]] &
+  string;
+
+/** Projects each declaration separately so mixed arrays/maps retain all kinds. */
+export type EdgeTargetKinds<T> =
+  T extends unknown ? ArrayNodeKinds<T> | ArrayNodeKinds<T[keyof T]> : never;
+
+/**
+ * Extracts the declared target kinds for an edge traversal.
+ * Outgoing traversals use the full range of an array or source-dependent map;
+ * incoming traversals use the source array.
  */
 export type ValidEdgeTargets<
   G extends GraphDef,
@@ -114,14 +120,11 @@ export type ValidEdgeTargets<
   Dir extends TraversalDirection,
 > =
   G["edges"][EK] extends EdgeRegistration ?
+    // Keep the direct array projection: a generic node schema must not wait
+    // for the distributive helper to resolve before its known kind is usable.
     Dir extends "out" ?
-      G["edges"][EK]["to"] extends readonly (infer N extends NodeType)[] ?
-        N["kind"]
-      : G["edges"][EK]["to"] extends (
-        Record<string, readonly (infer N extends NodeType)[]>
-      ) ?
-        N["kind"]
-      : never
+      | ArrayNodeKinds<G["edges"][EK]["to"]>
+      | EdgeTargetKinds<G["edges"][EK]["to"]>
     : G["edges"][EK]["from"][number]["kind"]
   : never;
 

--- a/packages/typegraph/src/store/index.ts
+++ b/packages/typegraph/src/store/index.ts
@@ -23,6 +23,7 @@ export {
   type DynamicNode,
   type DynamicNodeCollection,
   type DynamicNodeReference,
+  type DynamicStoreViewEdgeCollection,
   type Edge,
   type EdgeBatchReads,
   type EdgeCollection,

--- a/packages/typegraph/src/store/store-view.ts
+++ b/packages/typegraph/src/store/store-view.ts
@@ -86,6 +86,7 @@ import {
 import {
   type BulkFindEdgesFromParams,
   type BulkFindEdgesFromResult,
+  type DynamicStoreViewEdgeCollection,
   type EdgeBulkFindEndpointOptions,
   type EdgeCollection,
   type NodeCollection,
@@ -1043,6 +1044,16 @@ class StoreViewImplementation<
         )
       ),
     );
+  }
+
+  /** Dynamic endpoint reads remain bound to this view's coordinate. */
+  getEdgeCollection<K extends EdgeKinds<G>>(
+    kind: K,
+  ): DynamicStoreViewEdgeCollection<G["edges"][K]["type"]> | undefined;
+  getEdgeCollection(kind: string): DynamicStoreViewEdgeCollection | undefined;
+  getEdgeCollection(kind: string): unknown {
+    if (this.store.getEdgeCollection(kind) === undefined) return undefined;
+    return this.edges[kind as EdgeKinds<G>];
   }
 
   /** Adds a recorded-time pin, returning the narrow reconstructing view. */

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -644,12 +644,18 @@ export interface RequiredNodeCollectionLookup {
   <const K extends string>(kind: K): DynamicNodeCollection<K>;
 }
 
-export type EdgeCollectionLookup = (
-  kind: string,
-) => DynamicEdgeCollection | undefined;
+export interface EdgeCollectionLookup<G extends GraphDef = GraphDef> {
+  <K extends EdgeKinds<G>>(
+    kind: K,
+  ): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+  (kind: string): DynamicEdgeCollection | undefined;
+}
 
-export interface RequiredEdgeCollectionLookup {
+export interface RequiredEdgeCollectionLookup<G extends GraphDef = GraphDef> {
   <T extends RuntimeEdgeKind>(token: T): RuntimeEdgeCollection<T>;
+  <K extends EdgeKinds<G>>(
+    kind: K,
+  ): DynamicEdgeCollection<G["edges"][K]["type"]>;
   (kind: string): DynamicEdgeCollection;
 }
 
@@ -677,8 +683,8 @@ type StoreCore<G extends GraphDef> = Readonly<{
   ) => RuntimeEdgeKind<K, ExtensionObjectSchema<ExtensionEdgeProperties<D>>>;
   getNodeCollection: NodeCollectionLookup;
   getNodeCollectionOrThrow: RequiredNodeCollectionLookup;
-  getEdgeCollection: EdgeCollectionLookup;
-  getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup;
+  getEdgeCollection: EdgeCollectionLookup<G>;
+  getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
   getNodePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
   getNodePropsSchemaOrThrow: (kind: string) => z.ZodObject<z.ZodRawShape>;
   getEdgePropsSchema: (kind: string) => z.ZodObject<z.ZodRawShape> | undefined;
@@ -1940,32 +1946,67 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * Use this for runtime string-keyed access when the kind is not known at
    * compile time. For post-evolve access, prefer `getEdgeCollectionOrThrow`.
    */
-  getEdgeCollection(kind: string): DynamicEdgeCollection | undefined {
-    if (!Object.hasOwn(this.#graph.edges, kind)) return undefined;
-    return this.edges[
-      kind as keyof G["edges"] & string
-    ] as unknown as DynamicEdgeCollection;
+  getEdgeCollection<K extends EdgeKinds<G>>(
+    kind: K,
+  ): DynamicEdgeCollection<G["edges"][K]["type"]> | undefined;
+  getEdgeCollection(kind: string): DynamicEdgeCollection | undefined;
+  getEdgeCollection(kind: string): unknown {
+    return this.#resolveDynamicEdgeCollection(this.edges, kind);
   }
 
-  /**
-   * Returns the edge collection for the given kind. Throws
-   * `KindNotFoundError` when the kind is not registered.
-   */
+  /** Returns a runtime-validated collection; throws when the kind is absent. */
   getEdgeCollectionOrThrow<T extends RuntimeEdgeKind>(
     token: T,
   ): RuntimeEdgeCollection<T>;
+  getEdgeCollectionOrThrow<K extends EdgeKinds<G>>(
+    kind: K,
+  ): DynamicEdgeCollection<G["edges"][K]["type"]>;
   getEdgeCollectionOrThrow(kind: string): DynamicEdgeCollection;
-  getEdgeCollectionOrThrow(
+  getEdgeCollectionOrThrow(kindOrToken: string | RuntimeEdgeKind): unknown {
+    return this.#requireDynamicEdgeCollection(this.edges, kindOrToken);
+  }
+
+  #requireDynamicEdgeCollection(
+    collections: GraphEdgeCollections<G>,
     kindOrToken: string | RuntimeEdgeKind,
   ): DynamicEdgeCollection {
     const kind = this.#resolveRuntimeKind(kindOrToken, "edge");
-    const collection = this.getEdgeCollection(kind);
+    const collection = this.#resolveDynamicEdgeCollection(collections, kind);
     if (collection === undefined) {
-      throw new KindNotFoundError(kind, "edge", {
-        graphId: this.graphId,
-      });
+      throw new KindNotFoundError(kind, "edge", { graphId: this.graphId });
     }
     return collection;
+  }
+
+  #resolveDynamicEdgeCollection(
+    collections: GraphEdgeCollections<G>,
+    kind: string,
+  ): DynamicEdgeCollection | undefined {
+    if (!Object.hasOwn(this.#graph.edges, kind)) return undefined;
+    return collections[
+      kind as EdgeKinds<G>
+    ] as unknown as DynamicEdgeCollection;
+  }
+
+  /** Resolve through the supplied context's wrappers, preserving transaction and receipt ownership. */
+  #edgeCollectionAccess(collections: GraphEdgeCollections<G>): Readonly<{
+    getEdgeCollection: EdgeCollectionLookup<G>;
+    getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
+  }> {
+    const getEdgeCollection = (
+      kind: string,
+    ): DynamicEdgeCollection | undefined =>
+      this.#resolveDynamicEdgeCollection(collections, kind);
+    const getEdgeCollectionOrThrow = (
+      kindOrToken: string | RuntimeEdgeKind,
+    ): DynamicEdgeCollection =>
+      this.#requireDynamicEdgeCollection(collections, kindOrToken);
+    // Lookup erases endpoint evidence, not the selected edge's property schema.
+    return {
+      getEdgeCollection: getEdgeCollection as EdgeCollectionLookup<G>,
+      getEdgeCollectionOrThrow:
+        getEdgeCollectionOrThrow as RequiredEdgeCollectionLookup<G>,
+    };
   }
 
   // === Dynamic Props Schema Access ===
@@ -3597,7 +3638,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
    * `context` never reaches the scope recorder. This makes overlapping/concurrent
    * measures safe by construction (each holds its own scope recorder) and lets
    * scopes nest: the scoped context is itself decorated, so `scoped.measure(...)`
-   * chains one more wrapper. The scoped context's `getNodeCollection` resolves
+   * chains one more wrapper. The scoped context's dynamic collection lookups resolve
    * against the scope-wrapped map too, so dynamic-kind writes are attributed like
    * `scoped.nodes.<Kind>`. The scope receipt's `recorded` is always undefined —
    * the recorded instant is a whole-transaction flush concern.
@@ -3630,6 +3671,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
           nodes,
           edges,
           ...(identity === undefined ? {} : { identity }),
+          ...this.#edgeCollectionAccess(edges),
           getNodeCollection: <const K extends string>(kind: K) =>
             this.#resolveDynamicNodeCollection(nodes, kind),
         }),
@@ -3733,6 +3775,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       backend: createTransactionReadBackend(txBackend),
       [TRANSACTION_RUNTIME]: { backend: txBackend, runNodeOperationHooks },
       getNodeCollection,
+      ...this.#edgeCollectionAccess(edges),
     };
 
     let withSql: AdapterTransactionContext<G, TNativeTransaction>;

--- a/packages/typegraph/src/store/types.ts
+++ b/packages/typegraph/src/store/types.ts
@@ -59,6 +59,10 @@ import type {
   NODE_WRITE_NAMES,
   RECORDED_POINT_READ_NAMES,
 } from "./collection-surface";
+import type {
+  EdgeCollectionLookup,
+  RequiredEdgeCollectionLookup,
+} from "./store";
 
 /**
  * An explicit validity-end mutation. Omission preserves the stored end,
@@ -1320,10 +1324,11 @@ type EdgeBulkCreateItem<
 type EdgeBulkUpsertItem<
   E extends AnyEdgeType,
   Pairs extends EdgeEndpointPairTypes,
+  Id extends string = EdgeId<E>,
 > =
   Pairs extends EdgeEndpointPairTypes ?
     Readonly<{
-      id: EdgeId<E>;
+      id: Id;
       from: NodeRef<Pairs["from"]>;
       to: NodeRef<Pairs["to"]>;
       props?: z.input<E["schema"]>;
@@ -1400,14 +1405,17 @@ type EdgeGetOrCreateByEndpointsArguments<
     ]
   : never;
 
+/**
+ * Typed edge operations. InputId controls accepted ID arguments only; returned
+ * edges retain their schema-derived ID brand. Prefer DynamicEdgeCollection<E>
+ * for runtime endpoint dispatch instead of spelling its parameters manually.
+ */
 export type EdgeCollection<
   E extends AnyEdgeType,
   From extends NodeType = NodeType,
   To extends NodeType = NodeType,
-  Pairs extends EdgeEndpointPairTypes = {
-    from: From;
-    to: To;
-  },
+  Pairs extends EdgeEndpointPairTypes = { from: From; to: To },
+  InputId extends string = EdgeId<E>,
 > = Readonly<{
   /**
    * Create a new edge.
@@ -1428,13 +1436,13 @@ export type EdgeCollection<
 
   /** Get an edge by ID */
   getById: (
-    id: EdgeId<E>,
+    id: InputId,
     options?: QueryOptions,
   ) => Promise<Edge<E, From, To> | undefined>;
 
   /** Get multiple edges by ID, preserving input order (undefined for missing) */
   getByIds: (
-    ids: readonly EdgeId<E>[],
+    ids: readonly InputId[],
     options?: QueryOptions,
   ) => Promise<readonly (Edge<E, From, To> | undefined)[]>;
 
@@ -1443,7 +1451,7 @@ export type EdgeCollection<
    * Reopening a `oneActive` edge rechecks cardinality before the write.
    */
   update: (
-    id: EdgeId<E>,
+    id: InputId,
     props: Partial<z.input<E["schema"]>>,
     options?: ValidityEndMutation,
   ) => Promise<Edge<E, From, To>>;
@@ -1554,7 +1562,7 @@ export type EdgeCollection<
   ) => BatchableQuery<Edge<E, From, To>>;
 
   /** Delete an edge (soft delete - sets deletedAt timestamp) */
-  delete: (id: EdgeId<E>) => Promise<void>;
+  delete: (id: InputId) => Promise<void>;
 
   /**
    * Permanently delete an edge from the database.
@@ -1565,7 +1573,7 @@ export type EdgeCollection<
    * **Warning:** This operation is irreversible and should be used carefully.
    * Consider using soft delete (`delete()`) for most use cases.
    */
-  hardDelete: (id: EdgeId<E>) => Promise<void>;
+  hardDelete: (id: InputId) => Promise<void>;
 
   /** Find edges matching endpoint and pagination criteria */
   find: (
@@ -1644,7 +1652,7 @@ export type EdgeCollection<
    * (free the slot, then claim it) or to apply those items individually.
    */
   bulkUpsertById: (
-    items: readonly EdgeBulkUpsertItem<E, Pairs>[],
+    items: readonly EdgeBulkUpsertItem<E, Pairs, InputId>[],
   ) => Promise<Edge<E, From, To>[]>;
 
   /**
@@ -1676,7 +1684,7 @@ export type EdgeCollection<
    * because the whole batch is one transaction, that refusal rolls back
    * every delete already applied for an earlier id in the same batch.
    */
-  bulkDelete: (ids: readonly EdgeId<E>[]) => Promise<void>;
+  bulkDelete: (ids: readonly InputId[]) => Promise<void>;
 
   /**
    * Find an edge by endpoints and optional property fields.
@@ -2157,6 +2165,10 @@ type TransactionCollections<G extends GraphDef> = Readonly<{
   [TRANSACTION_RUNTIME]: TransactionRuntime;
   nodes: GraphNodeCollections<G>;
   edges: GraphEdgeCollections<G>;
+  /** Runtime endpoint validation with the selected edge's property schema retained. */
+  getEdgeCollection: EdgeCollectionLookup<G>;
+  /** Like getEdgeCollection, throwing KindNotFoundError when absent. */
+  getEdgeCollectionOrThrow: RequiredEdgeCollectionLookup<G>;
   /** Read-only backend projection bound to the same graph transaction. */
   backend: TransactionReadBackend;
   /**
@@ -2322,9 +2334,35 @@ export type DynamicNodeCollection<K extends string = string> = WidenBrandedIds<
  * the dynamic path typically receives IDs from edge metadata, snapshots,
  * or external input where the brand is not available.
  */
-export type DynamicEdgeCollection = WidenBrandedIds<
-  EdgeCollection<AnyEdgeType, NodeType, NodeType>
->;
+export type DynamicEdgeCollection<E extends AnyEdgeType = AnyEdgeType> = Omit<
+  EdgeCollection<
+    E,
+    NodeType,
+    NodeType,
+    { from: NodeType; to: NodeType },
+    string
+  >,
+  "create"
+> &
+  Readonly<{
+    /** Create with runtime-validated endpoints and schema-typed properties. */
+    create: (
+      from: NodeRef,
+      to: NodeRef,
+      ...args: EdgeCreateArguments<E>
+    ) => Promise<Edge<E>>;
+  }>;
+
+/** Runtime endpoint reads at a view's pinned coordinate; no writes or temporal overrides. */
+export type DynamicStoreViewEdgeCollection<
+  E extends AnyEdgeType = AnyEdgeType,
+> = Omit<StoreViewEdgeCollection<E>, "getById" | "getByIds"> &
+  Readonly<{
+    getById: (id: string) => Promise<Edge<E> | undefined>;
+    getByIds: (
+      ids: readonly string[],
+    ) => Promise<readonly (Edge<E> | undefined)[]>;
+  }>;
 
 /** A node collection narrowed by Store-issued runtime-kind evidence. */
 export type RuntimeNodeCollection<T extends RuntimeNodeKind> = WidenBrandedIds<
@@ -2332,9 +2370,8 @@ export type RuntimeNodeCollection<T extends RuntimeNodeKind> = WidenBrandedIds<
 >;
 
 /** An edge collection narrowed by Store-issued runtime-kind evidence. */
-export type RuntimeEdgeCollection<T extends RuntimeEdgeKind> = WidenBrandedIds<
-  EdgeCollection<RuntimeEdgeTypeFor<T>, NodeType, NodeType>
->;
+export type RuntimeEdgeCollection<T extends RuntimeEdgeKind> =
+  DynamicEdgeCollection<RuntimeEdgeTypeFor<T>>;
 
 /** One kind-grouped source input for a token-validated heterogeneous read. */
 export type RuntimeBulkEdgeSourceGroup<T extends RuntimeNodeKind> =

--- a/packages/typegraph/test-d/public-api.test-d.ts
+++ b/packages/typegraph/test-d/public-api.test-d.ts
@@ -885,13 +885,15 @@ void dynamicEdge.bulkUpsertById([
   { id: plainId, from: { kind: "X", id: "1" }, to: { kind: "Y", id: "2" } },
 ]);
 
-// getNodeCollection / getEdgeCollection return the dynamic types
+// Known edge lookups preserve the schema; an arbitrary string uses the erased default.
 expectAssignable<DynamicNodeCollection | undefined>(
   store.getNodeCollection("Person"),
 );
-expectAssignable<DynamicEdgeCollection | undefined>(
+expectType<DynamicEdgeCollection<typeof worksAt> | undefined>(
   store.getEdgeCollection("worksAt"),
 );
+
+expectType<DynamicEdgeCollection | undefined>(store.getEdgeCollection(plainId));
 
 // ============================================================
 // Graph extension — public surface published in 0.25

--- a/packages/typegraph/tests/backends/integration/transaction-receipt.ts
+++ b/packages/typegraph/tests/backends/integration/transaction-receipt.ts
@@ -7,6 +7,8 @@ import {
   defineGraph,
   defineNode,
   type EdgeId,
+  EndpointPairError,
+  KindNotFoundError,
   type NodeId,
   type RecordedInstant,
   recordedInstantRevision,
@@ -71,6 +73,24 @@ const receiptSurfaceGraph = defineGraph({
       from: [ReceiptEntity],
       to: [ReceiptEntity],
       cardinality: "many",
+    },
+  },
+});
+
+const OtherEntity = defineNode("OtherEntity", {
+  schema: z.object({ name: z.string() }),
+});
+const dynamicPairGraph = defineGraph({
+  id: "dynamic_pairs",
+  nodes: {
+    ReceiptEntity: { type: ReceiptEntity },
+    OtherEntity: { type: OtherEntity },
+  },
+  edges: {
+    receiptLinks: {
+      type: receiptLinks,
+      from: [ReceiptEntity, OtherEntity],
+      to: { ReceiptEntity: [ReceiptEntity], OtherEntity: [OtherEntity] },
     },
   },
 });
@@ -348,6 +368,87 @@ export function registerTransactionReceiptIntegrationTests(
       await expect(store.edges.receiptLinks.findFrom(source)).resolves.toEqual(
         [],
       );
+    });
+
+    for (const history of [false, true]) {
+      it(`binds dynamic edge lookups to transaction and scope receipts (history=${String(history)})`, async () => {
+        const store =
+          history ?
+            await context.createHistoryStore(dynamicPairGraph)
+          : await context.createStore(dynamicPairGraph);
+        const outcome = await store.transactionWithReceipt(async (tx) => {
+          const source = await tx.nodes.ReceiptEntity.create({
+            name: "source",
+            slot: "s",
+          });
+          const target = await tx.nodes.ReceiptEntity.create({
+            name: "target",
+            slot: "t",
+          });
+          const other = await tx.nodes.OtherEntity.create({ name: "other" });
+          expect(tx.getEdgeCollection("receiptLinks")).toBe(
+            tx.edges.receiptLinks,
+          );
+          expect(tx.getEdgeCollection("toString")).toBeUndefined();
+          expect(() => tx.getEdgeCollectionOrThrow("missing")).toThrow(
+            KindNotFoundError,
+          );
+          const measured = await tx.measure(async (scoped) => {
+            expect(scoped.getEdgeCollection("receiptLinks")).toBe(
+              scoped.edges.receiptLinks,
+            );
+            await scoped
+              .getEdgeCollectionOrThrow("receiptLinks")
+              .getOrCreateByEndpoints(source, target, { label: "measured" });
+            await expect(
+              scoped.getEdgeCollectionOrThrow("receiptLinks").bulkCreate([
+                {
+                  from: target,
+                  to: source,
+                  props: { label: "must roll back" },
+                },
+                { from: source, to: other, props: { label: "invalid pair" } },
+              ]),
+            ).rejects.toBeInstanceOf(EndpointPairError);
+            expect(await scoped.edges.receiptLinks.count()).toBe(1);
+          });
+          expect(measured.receipt.writes.edges).toEqual({ receiptLinks: 1 });
+          return { source, target };
+        });
+        expect(outcome.receipt.writes.edges).toEqual({ receiptLinks: 1 });
+        expect(await store.edges.receiptLinks.count()).toBe(1);
+        const pinned = store.asOf("2000-01-01T00:00:00.000Z");
+        expect(
+          await pinned
+            .getEdgeCollection("receiptLinks")
+            ?.findByEndpoints(outcome.result.source, outcome.result.target),
+        ).toBeUndefined();
+        expect(pinned.getEdgeCollection("missing")).toBeUndefined();
+        expect(pinned.getEdgeCollection("receiptLinks")).toBe(
+          pinned.edges.receiptLinks,
+        );
+      });
+    }
+
+    it("rolls back dynamic edge writes with their transaction", async () => {
+      const store = await context.createStore(dynamicPairGraph);
+      const source = await store.nodes.ReceiptEntity.create({
+        name: "source",
+        slot: "s",
+      });
+      const target = await store.nodes.ReceiptEntity.create({
+        name: "target",
+        slot: "t",
+      });
+      await expect(
+        store.transaction(async (tx) => {
+          await tx
+            .getEdgeCollectionOrThrow("receiptLinks")
+            .create(source, target, { label: "abort" });
+          throw new Error("abort transaction");
+        }),
+      ).rejects.toThrow("abort transaction");
+      expect(await store.edges.receiptLinks.count()).toBe(0);
     });
 
     it("counts writes made through tx.getNodeCollection", async () => {

--- a/packages/typegraph/tsconfig.json
+++ b/packages/typegraph/tsconfig.json
@@ -42,6 +42,13 @@
       ]
     }
   },
-  "include": ["src", "tests", "examples", "scripts", "tsup.config.ts"],
+  "include": [
+    "src",
+    "tests",
+    "examples",
+    "scripts",
+    "tsup.config.ts",
+    "type-smoke/edge-endpoint-compat.ts"
+  ],
   "exclude": ["tests/do-sqlite"]
 }

--- a/packages/typegraph/type-smoke/edge-endpoint-compat.ts
+++ b/packages/typegraph/type-smoke/edge-endpoint-compat.ts
@@ -1,0 +1,376 @@
+import type { z } from "zod";
+import type {
+  EdgeKinds,
+  GraphDef,
+  TransactionContext,
+  StoreView,
+  Store,
+  DynamicEdgeCollection,
+  DynamicStoreViewEdgeCollection,
+} from "@nicia-ai/typegraph";
+
+export async function verifyGenericEdgeDispatch<
+  G extends GraphDef,
+  K extends EdgeKinds<G>,
+>(
+  tx: TransactionContext<G>,
+  kind: K,
+  from: NodeRef,
+  to: NodeRef,
+  props: z.input<G["edges"][K]["type"]["schema"]>,
+  id: string,
+  view: StoreView<G>,
+  store: Store<G>,
+): Promise<void> {
+  const edges = tx.getEdgeCollectionOrThrow(kind);
+  await edges.getOrCreateByEndpoints(from, to, props, { ifExists: "update" });
+  await edges.findByEndpoints(from, to);
+  edges.batchFindByEndpoints(from, to);
+  await edges.create(from, to, props);
+  await edges.bulkCreate([{ from, to, props }]);
+  await edges.bulkInsert([{ from, to, props }]);
+  await edges.bulkUpsertById([{ id, from, to, props }]);
+  await edges.bulkGetOrCreateByEndpoints([{ from, to, props }], {
+    ifExists: "update",
+  });
+  await tx.getEdgeCollection(kind)?.create(from, to, props);
+  await store.getEdgeCollection(kind)?.getOrCreateByEndpoints(from, to, props);
+  await store
+    .getEdgeCollectionOrThrow(kind)
+    .getOrCreateByEndpoints(from, to, props);
+  await view.getEdgeCollection(kind)?.findByEndpoints(from, to, { props });
+}
+
+// Concrete registration tests must accompany the generic cases: an unguarded
+// fallback would fix every positive call above by discarding pair safety.
+import {
+  asEdgeId,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  type EdgeCollection,
+  type EdgeId,
+  type EdgeRegistration,
+  type NodeRef,
+  type NodeType,
+  type AnyEdgeType,
+  type TypedEdgeCollection,
+} from "@nicia-ai/typegraph";
+import { z as schema } from "zod";
+
+const Employee = defineNode("Employee", { schema: schema.object({}) });
+const Student = defineNode("Student", { schema: schema.object({}) });
+const Department = defineNode("Department", { schema: schema.object({}) });
+const Course = defineNode("Course", { schema: schema.object({}) });
+const assigned = defineEdge("assigned", {
+  schema: schema.object({ weight: schema.number() }),
+});
+const backup = defineEdge("backup", {
+  schema: schema.object({ weight: schema.number() }),
+});
+const graph = defineGraph({
+  id: "endpoint_type_compat",
+  nodes: {
+    Employee: { type: Employee },
+    Student: { type: Student },
+    Department: { type: Department },
+    Course: { type: Course },
+  },
+  edges: {
+    mapped: {
+      type: assigned,
+      from: [Employee, Student],
+      to: { Employee: [Department], Student: [Course] },
+    },
+    cartesian: {
+      type: assigned,
+      from: [Employee, Student],
+      to: [Department, Course],
+    },
+    backup: {
+      type: backup,
+      from: [Employee, Student],
+      to: [Department, Course],
+    },
+  },
+});
+
+export async function verifyConcreteEdgeDispatch(
+  tx: TransactionContext<typeof graph>,
+  view: StoreView<typeof graph>,
+  dynamic: NodeRef,
+  fromUnion: NodeRef<typeof Employee | typeof Student>,
+  toUnion: NodeRef<typeof Department | typeof Course>,
+): Promise<void> {
+  const employee = { kind: "Employee", id: "employee" } as const;
+  const department = { kind: "Department", id: "department" } as const;
+  const course = { kind: "Course", id: "course" } as const;
+  const props = { weight: 1 };
+  const id = asEdgeId<typeof assigned>("edge");
+  await tx.edges.mapped.create(employee, department, props);
+  await tx.edges.mapped.findByEndpoints(employee, department);
+  tx.edges.mapped.batchFindByEndpoints(employee, department);
+  await tx.edges.mapped.getOrCreateByEndpoints(employee, department, props);
+  await tx.edges.mapped.bulkCreate([{ from: employee, to: department, props }]);
+  await tx.edges.mapped.bulkInsert([{ from: employee, to: department, props }]);
+  await tx.edges.mapped.bulkUpsertById([
+    { id, from: employee, to: department, props },
+  ]);
+  await tx.edges.mapped.bulkGetOrCreateByEndpoints([
+    { from: employee, to: department, props },
+  ]);
+  await view.edges.mapped.findByEndpoints(employee, department);
+  // @ts-expect-error Undeclared pair must retain static pair checking.
+  await tx.edges.mapped.create(employee, course, props);
+  // @ts-expect-error Undeclared pair.
+  await tx.edges.mapped.findByEndpoints(employee, course);
+  // @ts-expect-error Undeclared pair.
+  tx.edges.mapped.batchFindByEndpoints(employee, course);
+  // @ts-expect-error Undeclared pair.
+  await tx.edges.mapped.getOrCreateByEndpoints(employee, course, props);
+  // @ts-expect-error Undeclared pair.
+  await tx.edges.mapped.bulkCreate([{ from: employee, to: course, props }]);
+  // @ts-expect-error Undeclared pair.
+  await tx.edges.mapped.bulkInsert([{ from: employee, to: course, props }]);
+  await tx.edges.mapped.bulkUpsertById([
+    // @ts-expect-error Undeclared pair.
+    { id, from: employee, to: course, props },
+  ]);
+  await tx.edges.mapped.bulkGetOrCreateByEndpoints([
+    // @ts-expect-error Undeclared pair.
+    { from: employee, to: course, props },
+  ]);
+  // @ts-expect-error Undeclared pair in a pinned view.
+  await view.edges.mapped.findByEndpoints(employee, course);
+  // @ts-expect-error Independent endpoint unions do not establish a valid pair.
+  await tx.edges.mapped.getOrCreateByEndpoints(fromUnion, toUnion, props);
+  // @ts-expect-error Widening refs cannot bypass the concrete endpoint domains.
+  await tx.edges.mapped.findByEndpoints(dynamic, dynamic);
+  await tx.edges.mapped.findByEndpoints(
+    // @ts-expect-error Inline literals cannot widen during inference.
+    { kind: "Employee", id: "e" },
+    { kind: "Course", id: "c" },
+  );
+  // @ts-expect-error Required edge properties remain required.
+  await tx.edges.mapped.create(employee, department);
+  // @ts-expect-error Property validation remains typed.
+  await tx.edges.mapped.getOrCreateByEndpoints(employee, department, {
+    weight: "wrong",
+  });
+  // @ts-expect-error Pinned views do not accept a temporal override.
+  await view.edges.mapped.findByEndpoints(employee, department, undefined, {
+    temporalMode: "includeTombstones",
+  });
+  // Cartesian endpoints intentionally permit independent unions and cross-pairs.
+  await tx.edges.cartesian.create(employee, course, props);
+  await tx.edges.cartesian.getOrCreateByEndpoints(fromUnion, toUnion, props);
+}
+
+export async function verifyConcreteKindUnion<K extends "cartesian" | "backup">(
+  tx: TransactionContext<typeof graph>,
+  kind: K,
+): Promise<void> {
+  await tx.edges[kind].getOrCreateByEndpoints(
+    { kind: "Employee", id: "e" },
+    { kind: "Course", id: "c" },
+    { weight: 1 },
+  );
+}
+
+export function verifyExistingAnnotations(
+  one: DynamicEdgeCollection<typeof assigned>,
+  two: TypedEdgeCollection<
+    EdgeRegistration<
+      typeof assigned,
+      typeof Employee,
+      NodeType,
+      readonly NodeType[]
+    >
+  >,
+  three: TypedEdgeCollection<
+    EdgeRegistration<typeof assigned, typeof Employee, typeof Department>
+  >,
+  erased: EdgeCollection<typeof assigned>,
+): void {
+  const employee = { kind: "Employee", id: "e" } as const;
+  const department = { kind: "Department", id: "d" } as const;
+  void one.getOrCreateByEndpoints(employee, department, { weight: 1 });
+  void two.getOrCreateByEndpoints(employee, department, { weight: 1 });
+  void three.getOrCreateByEndpoints(employee, department, { weight: 1 });
+  void erased.getOrCreateByEndpoints(employee, department, { weight: 1 });
+  // @ts-expect-error A two-argument registration retains its explicit source.
+  void two.getOrCreateByEndpoints(department, employee, { weight: 1 });
+  // @ts-expect-error A three-argument registration retains its explicit target.
+  void three.getOrCreateByEndpoints(employee, employee, { weight: 1 });
+}
+
+type CartesianGraph = GraphDef &
+  Readonly<{
+    edges: Record<
+      string,
+      Readonly<{
+        type: AnyEdgeType;
+        from: readonly NodeType[];
+        to: readonly NodeType[];
+      }>
+    >;
+  }>;
+
+export async function verifyArrayOnlyGenericDispatch<
+  G extends CartesianGraph,
+  K extends EdgeKinds<G>,
+>(
+  tx: TransactionContext<G>,
+  kind: K,
+  from: NodeRef,
+  to: NodeRef,
+  props: z.input<G["edges"][K]["type"]["schema"]>,
+): Promise<void> {
+  await tx
+    .getEdgeCollectionOrThrow(kind)
+    .getOrCreateByEndpoints(from, to, props, {
+      ifExists: "update",
+    });
+  await tx.getEdgeCollectionOrThrow(kind).findByEndpoints(from, to);
+  await tx.getEdgeCollectionOrThrow(kind).bulkCreate([{ from, to, props }]);
+}
+
+export function verifyGenericAnnotations<E extends AnyEdgeType>(
+  edge: DynamicEdgeCollection<E>,
+  view: DynamicStoreViewEdgeCollection<E>,
+  from: NodeRef,
+  to: NodeRef,
+  props: z.input<E["schema"]>,
+): void {
+  void edge.findByEndpoints(from, to);
+  void edge.getOrCreateByEndpoints(from, to, props);
+  void edge.bulkCreate([{ from, to, props }]);
+  void edge.update("edge", props);
+  void view.findByEndpoints(from, to, { props });
+}
+
+export function verifyDynamicProperties(
+  tx: TransactionContext<typeof graph>,
+  view: StoreView<typeof graph>,
+): void {
+  const edges = tx.getEdgeCollectionOrThrow("mapped");
+  const from = { kind: "Employee", id: "e" };
+  const to = { kind: "Course", id: "c" };
+  // Runtime dispatch deliberately accepts unchecked endpoints; writes still validate them.
+  void edges.create(from, to, { weight: 1 });
+  // @ts-expect-error Known edge schemas are retained on dynamic lookups.
+  void edges.create(from, to, { weight: "bad" });
+  // @ts-expect-error Required properties stay required.
+  void edges.create(from, to);
+  void edges.bulkUpsertById([
+    {
+      id: "id",
+      from,
+      to,
+      props: { weight: 1 },
+      validTo: "date",
+      // @ts-expect-error Temporal set and clear remain mutually exclusive.
+      clearValidTo: true,
+    },
+  ]);
+  const pinned = view.getEdgeCollection("mapped");
+  // @ts-expect-error Dynamic pinned reads have no writes.
+  void pinned?.create(from, to, { weight: 1 });
+  // @ts-expect-error Dynamic pinned reads have no temporal override.
+  void pinned?.findByEndpoints(from, to, undefined, {
+    temporalMode: "includeTombstones",
+  });
+}
+
+export async function verifyDynamicResults(
+  tx: TransactionContext<typeof graph>,
+): Promise<void> {
+  const result = await tx
+    .getEdgeCollectionOrThrow("mapped")
+    .create(
+      { kind: "Employee", id: "e" },
+      { kind: "Department", id: "d" },
+      { weight: 1 },
+    );
+  const weight: number = result.weight;
+  const id: EdgeId<typeof assigned> = result.id;
+  void weight;
+  void id;
+}
+
+// Query factories are a distinct 0.55 regression: the target node's schema may
+// remain generic even when its kind and registration are known.
+declare function storeForGraph<G extends GraphDef>(definition: G): Store<G>;
+export function verifyGenericTraversal<T extends NodeType<"Target">>(
+  Target: T,
+  targetKind: T["kind"],
+): void {
+  const Source = defineNode("Source", { schema: schema.object({}) });
+  const link = defineEdge("link");
+  const definition = defineGraph({
+    id: "generic_traversal",
+    nodes: { Source: { type: Source }, Target: { type: Target } },
+    edges: { link: { type: link, from: [Source], to: [Target] } },
+  });
+  const traversal = storeForGraph(definition)
+    .query()
+    .from("Source", "source")
+    .traverse("link", "edge");
+  traversal.to(targetKind, "target");
+  // @ts-expect-error Target inference must not widen to every string.
+  traversal.to("Missing", "missing");
+}
+
+export function verifyMappedTraversal(store: Store<typeof graph>): void {
+  const traversal = store
+    .query()
+    .from("Employee", "employee")
+    .traverse("mapped", "edge");
+  traversal.to("Department", "department");
+  traversal.to("Course", "course");
+  // Traversal targets use the union of declared ranges; endpoint writes retain pair correlation.
+  // @ts-expect-error Undeclared target kind must remain rejected.
+  traversal.to("Employee", "other");
+}
+
+export function verifyUnionTraversal(): void {
+  const SourceA = defineNode("SourceA", { schema: schema.object({}) });
+  const SourceB = defineNode("SourceB", { schema: schema.object({}) });
+  const TargetA = defineNode("TargetA", { schema: schema.object({}) });
+  const TargetB = defineNode("TargetB", { schema: schema.object({}) });
+  const link = defineEdge("link");
+  const definition = defineGraph({
+    id: "union_traversal",
+    nodes: {
+      SourceA: { type: SourceA },
+      SourceB: { type: SourceB },
+      TargetA: { type: TargetA },
+      TargetB: { type: TargetB },
+    },
+    edges: {
+      first: { type: link, from: [SourceA], to: { SourceA: [TargetA] } },
+      second: { type: link, from: [SourceB], to: { SourceB: [TargetB] } },
+      cartesian: { type: link, from: [SourceA], to: [TargetA] },
+    },
+  });
+  const store = storeForGraph(definition);
+  const kind: "first" | "second" = Math.random() > 0.5 ? "first" : "second";
+  const traversal = store
+    .query()
+    .from("SourceA", "source")
+    .traverse(kind, "edge");
+  traversal.to("TargetA", "a");
+  traversal.to("TargetB", "b");
+  // @ts-expect-error A union of map declarations must not widen its range.
+  traversal.to("SourceA", "invalid");
+  const mixedKind: "cartesian" | "second" =
+    Math.random() > 0.5 ? "cartesian" : "second";
+  const mixed = store
+    .query()
+    .from("SourceA", "source")
+    .traverse(mixedKind, "edge");
+  mixed.to("TargetA", "a");
+  mixed.to("TargetB", "b");
+  // @ts-expect-error Mixed array/map ranges stay exact.
+  mixed.to("SourceA", "invalid");
+}

--- a/packages/typegraph/type-smoke/tsconfig.json
+++ b/packages/typegraph/type-smoke/tsconfig.json
@@ -9,5 +9,5 @@
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true
   },
-  "include": ["consumer.ts"]
+  "include": ["consumer.ts", "edge-endpoint-compat.ts"]
 }


### PR DESCRIPTION
Generic helpers over a graph and edge kind cannot call the correlated endpoint signatures introduced in 0.55, including Cartesian registrations. Provide an explicit runtime dispatch boundary through `DynamicEdgeCollection<E>`: retain the selected edge's property input and result types while validating endpoint kinds and pairs at runtime. Concrete `.edges.<kind>` calls keep their compile-time pair restrictions.

Make existing Store edge lookups graph-aware, add both lookups to transaction contexts, and expose dynamic endpoint reads on valid-time views. Each lookup returns its context's existing collection, preserving transaction rollback, history, scoped receipt accounting, and pinned read coordinates. Share the ID-input representation in `EdgeCollection` rather than transforming arbitrary schema parameters through conditional ID-widening types.

The consumer regression fixture runs against source and packed declarations with concrete negative pair checks alongside generic dispatch. Removing the pair distribution admits undeclared pairs; erasing the dynamic property schema makes the property assertions unused; routing scoped lookups through root collections fails the context ownership cases. Restoring those contracts passes. The investigation compared installed 0.54.0 and 0.55.0 artifacts and records the affected methods, annotation migrations, and coverage gaps in `docs/TYPE_REGRESSION_055.md`.

Add a minor changeset and migration documentation, including the stronger property typing on known-kind dynamic lookups and the new requirements for hand-authored transaction/view mocks. Record those intentional API additions explicitly in the compatibility ledger. Add packed-consumer coverage on TypeScript 7 and correct the tsd runner's compiler attribution: tsd uses its own bundled TypeScript, independent of the selected source/consumer compiler version.

Repair a second 0.55 regression in query factories: nested node inference left a generic target schema unresolved even when its kind was known. Project target kinds directly and distribute over target declarations so map unions retain all their ranges. The consumer fixture covers generic node factories and disjoint map unions, and mixed array/map selections with negative undeclared-kind checks. Restoring the original target alias fails the generic factory and mixed-declaration assertions; the repaired projection passes.
