### PR TITLE
feat(graph-merge): compose plan application with transactional callbacks

### DIFF
--- a/.changeset/merge-transaction-callbacks.md
+++ b/.changeset/merge-transaction-callbacks.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Compose reviewed merge-plan application with application-owned graph checks and writes using optional `beforeApply` and `afterApply` callbacks. Prechecks receive transaction-bound read-only collections after the target fence is validated; post-apply work uses typed graph operations before the same transaction commits. Failures roll back the combined operation, and transaction-conflict retries replay both callbacks.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -384,12 +384,102 @@ process stops after apply, the merge may already be committed without a receipt.
 Retain the original review and approval, and reconcile committed history and
 application operation identity before repairing the receipt. Do not treat a
 missing receipt as permission to replay the candidate; applying its old execution
-plan is stale, and replanning is not a duplicate-execution check. Applications
-requiring a receipt atomic with the merge need a separate transaction-composition
-design. This protocol adds no such guarantee.
+plan is stale, and replanning is not a duplicate-execution check. To commit the
+receipt atomically with the merge, create it in an `afterApply` callback as
+described in [Composing application checks and writes](#composing-application-checks-and-writes).
+Review revalidation alone does not add that guarantee.
 
 See the runnable [durable merge review example](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/27-durable-merge-review.ts)
 for the complete schema and lifecycle.
+
+## Composing application checks and writes
+
+Pass execution callbacks to `applyMergePlan()` when a reviewed candidate and
+related application records must commit together:
+
+```typescript
+const result = await applyMergePlan(target, reviewedPlan, {
+  beforeApply: async (reads) => {
+    const resource = await reads.nodes.Resource.getById(resourceId);
+    if (resource?.owner !== "unclaimed") {
+      throw new Error("Resource is already claimed");
+    }
+  },
+  afterApply: async (tx, applied) => {
+    await tx.nodes.Resource.update(resourceId, { owner: "accepted" });
+    const decision = await tx.nodes.Decision.create({
+      status: "accepted",
+      changedNodes: applied.merged.nodes,
+    });
+    await tx.edges.decides.create(decision.id, resourceId, {});
+  },
+});
+if (!isOk(result)) throw result.error;
+// The plan and application writes have now committed together.
+```
+
+`Resource`, `Decision`, and `decides` stand for types registered in your graph.
+Import `MergePlanApplyOptions`, `MergePlanReadContext`, and `MergePlanApplied`
+from `@nicia-ai/typegraph/graph-merge` to type reusable helpers. Callbacks are
+execution options: they are not stored in the artifact or covered by its digest.
+
+The transaction acquires the schema fence before the graph write lock, validates
+schema, revision origin, and revision, and then calls `beforeApply`. This context
+exposes node and edge collection reads and, for identity-enabled graphs, identity
+reads. Write methods, native SQL, and a root Store are absent. Application writes
+before plan application are deliberately unsupported: an uncommitted write can
+change the reviewed state without changing its durable revision yet.
+
+After the precheck, TypeGraph performs the existing plan preflight, identity
+checks, and writes. `afterApply` receives a `TransactionContext` whose reads see
+those writes. Its `applied.merged` contains only the plan's provisional counts;
+callback writes do not contribute to the final report's merge counts. Use the
+supplied contexts for every graph operation. Calling the original Store inside a
+callback does not enlist it in this transaction. Do not retain a context for later
+work, and await every operation before returning.
+
+Callbacks must resolve without a value. Throw or reject to abort; returning a
+value, including an `Err`, is refused with `InvalidMergeOptionsError`. A callback
+rejection, stale plan, merge failure, capture-flush failure, or commit failure
+rolls back the combined graph operation. Errors are converted to the outer
+`Result` after rollback; ordinary application errors are retained in the cause
+chain. Existing typed merge errors and constraint translation remain intact.
+Only the successful outer result confirms commit.
+
+Transaction conflicts (PostgreSQL serialization failures or deadlocks) retry the
+whole transaction up to **three attempts**, including both callbacks. Every
+attempt checks the fence again; an intervening committed write makes the plan
+stale rather than silently rebasing it. Keep callbacks safe to repeat. Do not send
+messages, call external services with side effects, or publish an outcome inside
+a callback. Perform those effects after successful completion, or write an
+application outbox record through `tx` for later delivery. Returned contexts and
+provisional outcomes are not durable notifications.
+
+Protection covers the target graph's transactional state and participating
+TypeGraph writers using its graph fence. It does not make an application policy a
+declarative constraint: every writer changing that policy's state must enforce
+it, for example through its own conditional operation. It does not cover other
+graphs, arbitrary SQL, or external systems. SQLite uses its writer transaction;
+Composed PostgreSQL applications use read-committed isolation and the graph
+write lock with or without history. The lock statement records the effective
+session isolation; incompatible or unknown isolation is refused before callbacks.
+Standalone revision-tracking-only applications retain serializable isolation. Unsupported
+transaction capabilities are refused before callbacks. Existing session-bound
+fence and recorded-capture isolation checks still apply.
+
+With history enabled, plan and application writes share the transaction's
+recorded capture and flush, producing one per-graph recorded revision. Without
+history, revision tracking likewise advances for the combined transaction.
+Failure leaves no live changes or recorded revision from the failed attempt.
+Existing valid-time bounds, including open bounds, retain their semantics.
+
+Optional persisted merge provenance remains separate from recorded history:
+provenance records are persisted only after successful graph commit, and a
+persistence failure remains a report warning. Callbacks do not receive a
+post-commit provenance result. Previously committed review records in the target
+still invalidate a plan's revision fence; this API does not relax plan staleness.
+For a durable candidate review, revalidate the stored review first, then pass
+the compatible result's fresh `plan` and these callbacks to `applyMergePlan()`.
 
 ## Scaling branches and interchange
 

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -69,7 +69,7 @@ type AndPredicate = Readonly<{
 type AnyEdgeType = EdgeType<string, z.ZodObject<z.ZodRawShape>, readonly NodeType[] | undefined, EdgeTargets | undefined>;
 
 // @public
-export function applyMergePlan<G extends GraphDef>(target: Store<G>, input: MergePlanArtifact): Promise<Result<MergeReport<G>, MergeError>>;
+export function applyMergePlan<G extends GraphDef>(target: Store<G>, input: MergePlanArtifact, options?: MergePlanApplyOptions<NoInfer<G>>): Promise<Result<MergeReport<G>, MergeError>>;
 
 // @public (undocumented)
 type ArrayFieldAccessor<U> = BaseFieldAccessor & Readonly<{
@@ -1361,6 +1361,9 @@ type Edge<E extends AnyEdgeType = EdgeType, From extends NodeType = NodeType, To
     toId: NodeId<To>;
     meta: EdgeMeta;
 }> & Readonly<z.infer<E["schema"]>>;
+
+// @public
+const EDGE_TEMPORAL_READ_NAMES: readonly ["getById", "getByIds", "find", "count", "findFrom", "findTo", "bulkFindFrom", "bulkFindTo", "findByEndpoints"];
 
 // @public
 const EDGE_TYPE_BRAND: "__edgeType";
@@ -2790,6 +2793,9 @@ type HybridVectorOptions = Readonly<{
 }>;
 
 // @public
+const IDENTITY_READ_NAMES: readonly ["representativeOf", "membersOf", "nodesOf", "areSame", "areDifferent", "assertionsOf"];
+
+// @public
 type IdentityAssertion<G extends GraphDef> = Readonly<{
     id: IdentityAssertionId;
     relation: IdentityRelation;
@@ -3725,6 +3731,17 @@ export type MergePlanAnchors = Readonly<{
 }>;
 
 // @public
+export type MergePlanApplied = Readonly<{
+    merged: MergedCounts;
+}>;
+
+// @public
+export type MergePlanApplyOptions<G extends GraphDef> = Readonly<{
+    beforeApply?: (reads: MergePlanReadContext<G>) => Promise<void>;
+    afterApply?: (tx: TransactionContext<G>, applied: MergePlanApplied) => Promise<void>;
+}>;
+
+// @public
 export type MergePlanArtifact = MergePlanArtifactV1;
 
 // @public (undocumented)
@@ -3943,6 +3960,18 @@ export type MergePlanProvenanceOptions = Readonly<{
     persist: boolean;
 }>;
 
+// @public
+export type MergePlanReadContext<G extends GraphDef> = Readonly<{
+    nodes: Readonly<{
+        [K in keyof TransactionContext<G>["nodes"]]: Pick<TransactionContext<G>["nodes"][K], (typeof NODE_READ_NAMES)[number]>;
+    }>;
+    edges: Readonly<{
+        [K in keyof TransactionContext<G>["edges"]]: Pick<TransactionContext<G>["edges"][K], (typeof EDGE_TEMPORAL_READ_NAMES)[number]>;
+    }>;
+}> & (G["identity"] extends GraphIdentityConfig ? Readonly<{
+    identity: Pick<IdentityFacade<G>, (typeof IDENTITY_READ_NAMES)[number]>;
+}> : Readonly<Record<never, never>>);
+
 // @public (undocumented)
 export type MergePlanRetype = Readonly<{
     entity: MergePlanEntityRef;
@@ -4146,6 +4175,9 @@ type Node<N extends NodeType = NodeType> = Readonly<{
     id: NodeId<N>;
     meta: NodeMeta;
 }> & Readonly<z.infer<N["schema"]>>;
+
+// @public (undocumented)
+const NODE_READ_NAMES: readonly ["getById", "getByIds", "find", "count", "findByConstraint", "bulkFindByConstraint", "bulkFindByIndex"];
 
 // @public
 const NODE_TYPE_BRAND: "__nodeType";

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -258,9 +258,12 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     count: 16,
     sha256: "1678650d02e0d9d7cc767ffbacbf163724c82fd4590c219b97d3dff85a6bf2f6",
   },
+  // MergePlanReadContext derives its read-only surface from the runtime method
+  // lists: EDGE_TEMPORAL_READ_NAMES, IDENTITY_READ_NAMES, and NODE_READ_NAMES.
+  // These three implementation constants are referenced, not public exports.
   "./graph-merge": {
-    count: 706,
-    sha256: "3494595c41f350eac3a5de03adc6589dabee3de481c4747a7d43ac138a7784f1",
+    count: 709,
+    sha256: "b963d4c34acde32b568a6b2d46eccd7294d04da60f18d0d0c8673dffd596337e",
   },
   "./indexes": {
     count: 46,

--- a/packages/typegraph/src/backend/command-contract.ts
+++ b/packages/typegraph/src/backend/command-contract.ts
@@ -15,15 +15,13 @@ import type {
   NodeCreateCommandResult,
 } from "./types";
 
-export type GraphCommandCoordinationBinding = Readonly<{
-  graphId: string;
-  isolation: GraphCommandIsolation;
-  sessionIdentity: object;
-}>;
-
 const graphCommandCoordinationBindings = new WeakMap<
   object,
-  GraphCommandCoordinationBinding
+  Readonly<{
+    graphId: string;
+    isolation: GraphCommandIsolation;
+    sessionIdentity: object;
+  }>
 >();
 const graphCommandPortSessionIdentities = new WeakMap<object, object>();
 
@@ -112,7 +110,7 @@ function boundGraphCommandCoordination(
   port: GraphCommandPort,
   coordination: GraphCommandCoordination,
   graphId?: string,
-): GraphCommandCoordinationBinding | undefined {
+) {
   const binding = graphCommandCoordinationBindings.get(coordination);
   return (
       binding?.sessionIdentity === graphCommandPortSessionIdentity(port) &&

--- a/packages/typegraph/src/backend/command-contract.ts
+++ b/packages/typegraph/src/backend/command-contract.ts
@@ -15,13 +15,15 @@ import type {
   NodeCreateCommandResult,
 } from "./types";
 
+export type GraphCommandCoordinationBinding = Readonly<{
+  graphId: string;
+  isolation: GraphCommandIsolation;
+  sessionIdentity: object;
+}>;
+
 const graphCommandCoordinationBindings = new WeakMap<
   object,
-  Readonly<{
-    graphId: string;
-    isolation: GraphCommandIsolation;
-    sessionIdentity: object;
-  }>
+  GraphCommandCoordinationBinding
 >();
 const graphCommandPortSessionIdentities = new WeakMap<object, object>();
 
@@ -106,6 +108,32 @@ export function normalizeGraphCommandIsolation(
   }
 }
 
+function boundGraphCommandCoordination(
+  port: GraphCommandPort,
+  coordination: GraphCommandCoordination,
+  graphId?: string,
+): GraphCommandCoordinationBinding | undefined {
+  const binding = graphCommandCoordinationBindings.get(coordination);
+  return (
+      binding?.sessionIdentity === graphCommandPortSessionIdentity(port) &&
+        (graphId === undefined || binding.graphId === graphId)
+    ) ?
+      binding
+    : undefined;
+}
+
+/** Effective isolation of coordination earned by this graph and transaction. */
+export function graphCommandCoordinationIsolation(
+  port: GraphCommandPort,
+  graphId: string,
+  coordination: GraphCommandCoordination,
+): GraphCommandIsolation {
+  return (
+    boundGraphCommandCoordination(port, coordination, graphId)?.isolation ??
+    "unknown"
+  );
+}
+
 /**
  * A match-key convergence must observe the winner after waiting for its graph
  * lock. Repeatable-read snapshots cannot do that; serializable can instead
@@ -116,11 +144,8 @@ export function assertGraphCommandConvergenceIsolation(
   port: GraphCommandPort,
   coordination: GraphCommandCoordination,
 ): void {
-  const binding = graphCommandCoordinationBindings.get(coordination);
   const isolation =
-    binding?.sessionIdentity === graphCommandPortSessionIdentity(port) ?
-      binding.isolation
-    : "unknown";
+    boundGraphCommandCoordination(port, coordination)?.isolation ?? "unknown";
   if (isolation === "read_committed" || isolation === "serializable") return;
   throw new ConfigurationError(
     "Match-key convergence requires read-committed or serializable transaction isolation.",
@@ -141,10 +166,12 @@ export function assertGraphCommandCoordination(
   command: GraphCommand,
   coordination: GraphCommandCoordination,
 ): void {
-  const binding = graphCommandCoordinationBindings.get(coordination);
   if (
-    binding?.sessionIdentity === graphCommandPortSessionIdentity(port) &&
-    binding.graphId === command.plan.params.graphId
+    boundGraphCommandCoordination(
+      port,
+      coordination,
+      command.plan.params.graphId,
+    ) !== undefined
   ) {
     return;
   }

--- a/packages/typegraph/src/graph-merge/apply-callbacks.ts
+++ b/packages/typegraph/src/graph-merge/apply-callbacks.ts
@@ -1,0 +1,112 @@
+import type { GraphDef, GraphIdentityConfig } from "../core/define-graph";
+import type { IdentityFacade } from "../identity/types";
+import {
+  CURRENT_ONLY_READ_NAMES,
+  EDGE_TEMPORAL_READ_NAMES,
+  IDENTITY_READ_NAMES,
+  NODE_TEMPORAL_READ_NAMES,
+} from "../store/collection-surface";
+import type { TransactionContext } from "../store/types";
+import { requireDefined } from "../utils/presence";
+import { InvalidMergeOptionsError } from "./errors";
+import type { MergedCounts } from "./types";
+
+const NODE_READ_NAMES = [
+  ...NODE_TEMPORAL_READ_NAMES,
+  ...CURRENT_ONLY_READ_NAMES,
+] as const;
+
+/** Transaction-bound reads available before applying a fenced merge plan. */
+export type MergePlanReadContext<G extends GraphDef> = Readonly<{
+  nodes: Readonly<{
+    [K in keyof TransactionContext<G>["nodes"]]: Pick<
+      TransactionContext<G>["nodes"][K],
+      (typeof NODE_READ_NAMES)[number]
+    >;
+  }>;
+  edges: Readonly<{
+    [K in keyof TransactionContext<G>["edges"]]: Pick<
+      TransactionContext<G>["edges"][K],
+      (typeof EDGE_TEMPORAL_READ_NAMES)[number]
+    >;
+  }>;
+}> &
+  (G["identity"] extends GraphIdentityConfig ?
+    Readonly<{
+      identity: Pick<IdentityFacade<G>, (typeof IDENTITY_READ_NAMES)[number]>;
+    }>
+  : Readonly<Record<never, never>>);
+
+/** Plan effects inside an uncommitted transaction; excludes callback writes. */
+export type MergePlanApplied = Readonly<{ merged: MergedCounts }>;
+
+/**
+ * Work composed with merge application in its own protected transaction.
+ * Both callbacks may be replayed (up to three attempts) on transaction conflicts.
+ * Await all work, use only the supplied context, and perform no external effects.
+ * Throw/reject to abort; returning a value (including a Result) is refused.
+ */
+export type MergePlanApplyOptions<G extends GraphDef> = Readonly<{
+  /** Runs after the target fence is checked, before plan writes. Reads only. */
+  beforeApply?: (reads: MergePlanReadContext<G>) => Promise<void>;
+  /** Runs after plan writes, before capture flush and commit. */
+  afterApply?: (
+    tx: TransactionContext<G>,
+    applied: MergePlanApplied,
+  ) => Promise<void>;
+}>;
+
+function pickReadMethods<T, K extends keyof T>(
+  source: T,
+  names: readonly K[],
+): Pick<T, K> {
+  return Object.fromEntries(names.map((name) => [name, source[name]])) as Pick<
+    T,
+    K
+  >;
+}
+
+/**
+ * Project actual read-only objects. Enumerate registered kinds: transaction
+ * collection proxies instantiate lazily and do not enumerate their own keys.
+ */
+export function mergePlanReadContext<G extends GraphDef>(
+  tx: TransactionContext<G>,
+  graph: G,
+): MergePlanReadContext<G> {
+  return {
+    nodes: Object.fromEntries(
+      Object.keys(graph.nodes).map((kind) => [
+        kind,
+        pickReadMethods(requireDefined(tx.nodes[kind]), NODE_READ_NAMES),
+      ]),
+    ),
+    edges: Object.fromEntries(
+      Object.keys(graph.edges).map((kind) => [
+        kind,
+        pickReadMethods(
+          requireDefined(tx.edges[kind]),
+          EDGE_TEMPORAL_READ_NAMES,
+        ),
+      ]),
+    ),
+    ...("identity" in tx ?
+      {
+        identity: pickReadMethods(tx.identity, IDENTITY_READ_NAMES),
+      }
+    : {}),
+  } as MergePlanReadContext<G>;
+}
+
+/** JavaScript callers must not accidentally commit by returning an Err. */
+export function assertMergeCallbackResult(
+  result: unknown,
+  callback: keyof MergePlanApplyOptions<GraphDef>,
+): void {
+  if (result !== undefined) {
+    throw new InvalidMergeOptionsError(
+      `${callback} must resolve without a return value; throw or reject to abort merge application.`,
+      { cause: result, details: { callback } },
+    );
+  }
+}

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -1,3 +1,8 @@
+export type {
+  MergePlanApplied,
+  MergePlanApplyOptions,
+  MergePlanReadContext,
+} from "./apply-callbacks";
 // Public barrel for @nicia-ai/typegraph/graph-merge.
 //
 // Keep this surface deliberately narrower than the implementation modules:

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -2,6 +2,11 @@ import { validateEdgeEndpoints } from "../constraints";
 import { IdentityEndpointValidityError } from "../errors";
 import { createDataKeyedBag, hasOwnKey } from "../utils/object";
 import { requireDefined } from "../utils/presence";
+import {
+  assertMergeCallbackResult,
+  type MergePlanApplyOptions,
+  mergePlanReadContext,
+} from "./apply-callbacks";
 /**
  * `merge()` orchestrator (design §7.2, T11).
  *
@@ -3620,6 +3625,7 @@ async function assertMergePlanFenceInsideTransaction<G extends GraphDef>(
   target: Store<G>,
   txBackend: TransactionBackend,
   artifact: MergePlanArtifactV1,
+  requireFreshSnapshot: boolean,
 ): Promise<void> {
   await lockMergeTargetWrite(txBackend, {
     graphId: target.graphId,
@@ -3628,6 +3634,7 @@ async function assertMergePlanFenceInsideTransaction<G extends GraphDef>(
         artifact.target.schema.version
       : undefined,
     graphLock: "required",
+    requireFreshSnapshot,
     staleSchemaError: (cause) =>
       new MergePlanSchemaMismatchError(
         "The target's active schema no longer matches the merge plan.",
@@ -3834,6 +3841,7 @@ function reportFromArtifact<G extends GraphDef>(
 export async function applyMergePlan<G extends GraphDef>(
   target: Store<G>,
   input: MergePlanArtifact,
+  options: MergePlanApplyOptions<NoInfer<G>> = {},
 ): Promise<Result<MergeReport<G>, MergeError>> {
   let validation: Awaited<ReturnType<typeof validateMergePlanArtifact>>;
   try {
@@ -3863,6 +3871,12 @@ export async function applyMergePlan<G extends GraphDef>(
     );
   }
   try {
+    const { beforeApply, afterApply } = options;
+    const composed = beforeApply !== undefined || afterApply !== undefined;
+    const transactionOptions =
+      composed ?
+        ({ isolationLevel: "read_committed" } as const)
+      : mergeCommitTransactionOptions(target);
     assertPublicPlanCapability(target);
     const provenanceStore =
       artifact.provenance.persist ?
@@ -3878,7 +3892,14 @@ export async function applyMergePlan<G extends GraphDef>(
           target,
           txBackend,
           artifact,
+          composed,
         );
+        if (beforeApply !== undefined) {
+          assertMergeCallbackResult(
+            await beforeApply(mergePlanReadContext(tx, target.graph)),
+            "beforeApply",
+          );
+        }
         await preflightWireMergeWrites(
           target,
           tx.nodes as unknown as TxNodes,
@@ -3889,14 +3910,21 @@ export async function applyMergePlan<G extends GraphDef>(
           identityAssertions: artifact.writes.identityAssertions,
           identityRetractions: artifact.writes.identityRetractions,
         });
-        return applyWireMergeWrites(
+        const applied = await applyWireMergeWrites(
           target,
           tx.nodes as unknown as TxNodes,
           tx.edges as unknown as TxEdges,
           txBackend,
           artifact,
         );
-      }, mergeCommitTransactionOptions(target)),
+        if (afterApply !== undefined) {
+          assertMergeCallbackResult(
+            await afterApply(tx, { merged: structuredClone(applied) }),
+            "afterApply",
+          );
+        }
+        return applied;
+      }, transactionOptions),
     );
     const warnings = [...artifact.review.warnings];
     let provenancePersisted: MergeReport<G>["provenancePersisted"];

--- a/packages/typegraph/src/graph-merge/write-fence.ts
+++ b/packages/typegraph/src/graph-merge/write-fence.ts
@@ -1,7 +1,9 @@
+import { graphCommandCoordinationIsolation } from "../backend/command-contract";
 import { type TransactionBackend } from "../backend/types";
 import { TypeGraphError } from "../errors";
 import { lockSchemaVersionForStoreWrite } from "../store/operations/write-transaction";
 import { lockRecordedGraphWrite } from "../store/recorded-capture";
+import { MergePlanCapabilityError } from "./errors";
 
 /** Acquires merge fences in the Store's canonical schema-first order. */
 export async function lockMergeTargetWrite(
@@ -9,9 +11,12 @@ export async function lockMergeTargetWrite(
   input: Readonly<{
     graphId: string;
     schemaVersion: number | undefined;
-    graphLock: "required" | "not-required";
     staleSchemaError: (cause: unknown) => TypeGraphError;
-  }>,
+  }> &
+    (
+      | Readonly<{ graphLock: "required"; requireFreshSnapshot?: boolean }>
+      | Readonly<{ graphLock: "not-required"; requireFreshSnapshot?: never }>
+    ),
 ): Promise<void> {
   try {
     await lockSchemaVersionForStoreWrite(
@@ -28,6 +33,21 @@ export async function lockMergeTargetWrite(
     throw input.staleSchemaError(error);
   }
   if (input.graphLock === "required") {
-    await lockRecordedGraphWrite(txBackend, input.graphId);
+    const lock = await lockRecordedGraphWrite(txBackend, input.graphId);
+    // Serialized engines already own the writer slot. An advisory-lock token
+    // carries the isolation observed by the lock statement on this session.
+    if (input.requireFreshSnapshot && lock.coordination !== undefined) {
+      const isolation = graphCommandCoordinationIsolation(
+        txBackend.commands,
+        input.graphId,
+        lock.coordination,
+      );
+      if (isolation !== "read_committed") {
+        throw new MergePlanCapabilityError(
+          "Merge callbacks require read-committed isolation so their reads observe the target after acquiring its graph lock.",
+          { details: { capability: "mergeCallbackIsolation", isolation } },
+        );
+      }
+    }
   }
 }

--- a/packages/typegraph/test-d/graph-merge.test-d.ts
+++ b/packages/typegraph/test-d/graph-merge.test-d.ts
@@ -5,8 +5,10 @@ import {
   type AdapterHistoryStore,
   type GraphBackend,
   defineGraph,
+  defineEdge,
   defineNode,
   type Store,
+  type TransactionContext,
 } from "..";
 import {
   applyMergePlan,
@@ -17,6 +19,9 @@ import {
   type MakeBackend,
   type MatchEvidence,
   type MergePlanArtifact,
+  type MergePlanApplyOptions,
+  type MergePlanApplied,
+  type MergePlanReadContext,
   type MergeOptions,
   MergeConstraintConflictError,
   type MergeConstraintConflictErrorDetails,
@@ -192,3 +197,77 @@ if (revalidation.status === "compatible") {
 declare const reviewError: MergeReviewError;
 expectAssignable<MergeError>(reviewError);
 expectType<"GRAPH_MERGE_REVIEW">(reviewError.code);
+// Merge callbacks remain graph-specific and cannot expose an unfenced writer.
+const applyOptions: MergePlanApplyOptions<typeof graph> = {
+  beforeApply: async (reads) => {
+    expectType<MergePlanReadContext<typeof graph>>(reads);
+    await reads.nodes.Person.count();
+    expectError(reads.nodes.Person.create({ birthDate: "2000", name: "Ada" }));
+    expectError(reads.nodes.Person.update);
+    expectError(reads.nodes.Person.delete);
+    expectError(reads.backend);
+    expectError(reads.transaction);
+    expectError(reads.getNodeCollection);
+    expectError(reads.identity);
+    expectError(reads.nodes.Unknown);
+  },
+  afterApply: async (tx, applied) => {
+    expectType<TransactionContext<typeof graph>>(tx);
+    expectType<MergePlanApplied>(applied);
+    expectType<number>(applied.merged.nodes);
+    await tx.nodes.Person.create({ birthDate: "2000", name: "Ada" });
+    expectError(tx.nodes.Person.create({ name: "Missing birth date" }));
+    expectError(tx.nodes.Unknown);
+    expectError(applied.provenance);
+    expectError((applied.merged.nodes = 2));
+  },
+};
+expectType<Promise<Result<MergeReport<typeof graph>, MergeError>>>(
+  applyMergePlan(store, mergePlan, applyOptions),
+);
+expectError(
+  applyMergePlan(store, mergePlan, {
+    beforeApply: async () => ({ success: false, error: new Error("refused") }),
+  }),
+);
+expectError(
+  applyMergePlan(store, mergePlan, {
+    afterApply: async () => ({ success: false, error: new Error("refused") }),
+  }),
+);
+expectError(applyMergePlan(store, mergePlan, { beforeApply: () => {} }));
+declare const transaction: TransactionContext<typeof graph>;
+expectError(applyMergePlan(transaction, mergePlan));
+
+const related = defineEdge("related", { schema: z.object({}) });
+const identityGraph = defineGraph({
+  id: "merge_callbacks_identity_typetest",
+  nodes: { Person: { type: Person } },
+  edges: { related: { type: related, from: [Person], to: [Person] } },
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+declare const identityStore: Store<typeof identityGraph>;
+applyMergePlan(identityStore, mergePlan, {
+  beforeApply: async (reads) => {
+    await reads.edges.related.count();
+    expectError(reads.edges.related.create);
+    expectError(reads.identity.assertSame);
+    expectError(reads.identity.retractAssertion);
+    const people = await reads.nodes.Person.find();
+    if (people[0] !== undefined) {
+      expectType<boolean>(await reads.identity.areSame(people[0], people[0]));
+    }
+  },
+  afterApply: async (tx) => {
+    const first = await tx.nodes.Person.create({
+      name: "First",
+      birthDate: "2000",
+    });
+    const second = await tx.nodes.Person.create({
+      name: "Second",
+      birthDate: "2001",
+    });
+    await tx.edges.related.create(first, second, {});
+    await tx.identity.assertSame(first, second);
+  },
+});

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -57,6 +57,7 @@ import {
   registerEdgePropertyIntegrationTests,
   registerFulltextIntegrationTests,
   registerGraphAnnotationsIntegrationTests,
+  registerGraphMergeCallbackIntegrationTests,
   registerGraphMergePlanIntegrationTests,
   registerGraphMergeReviewIntegrationTests,
   registerHistoricalIdentityTraversalTests,
@@ -310,6 +311,7 @@ export function createIntegrationTestSuite<
     registerAlgorithmIntegrationTests(context);
     registerWeightedShortestPathExtractionIntegrationTests(context);
     registerFulltextIntegrationTests(context);
+    registerGraphMergeCallbackIntegrationTests(context);
     registerGraphMergePlanIntegrationTests(context);
     registerGraphMergeReviewIntegrationTests(context);
     registerImportUniquenessIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/graph-merge-callbacks.ts
+++ b/packages/typegraph/tests/backends/integration/graph-merge-callbacks.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import {
+  asEdgeId,
+  asNodeId,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  recordedInstantRevision,
+  type Store,
+  type TransactionContext,
+} from "../../../src";
+import {
+  applyMergePlan,
+  branch,
+  InvalidMergeOptionsError,
+  isErr,
+  MergeConstraintConflictError,
+  MergeError,
+  type MergePlanReadContext,
+  planMerge,
+  StaleMergePlanError,
+  unwrap,
+} from "../../../src/graph-merge";
+import type { IntegrationTestContext } from "./test-context";
+
+const Item = defineNode("Item", {
+  schema: z.object({ name: z.string() }),
+});
+const Workflow = defineNode("Workflow", {
+  schema: z.object({ state: z.enum(["pending", "accepted"]) }),
+});
+const Acceptance = defineNode("Acceptance", {
+  schema: z.object({ key: z.string() }),
+});
+const accepts = defineEdge("accepts", { schema: z.object({}) });
+const graph = defineGraph({
+  id: "merge_callbacks",
+  nodes: {
+    Item: { type: Item },
+    Workflow: { type: Workflow },
+    Acceptance: {
+      type: Acceptance,
+      unique: [
+        {
+          name: "acceptance_key",
+          fields: ["key"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: { accepts: { type: accepts, from: [Acceptance], to: [Item] } },
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+const ITEM_ID = asNodeId<typeof Item>("candidate");
+const WORKFLOW_ID = asNodeId<typeof Workflow>("workflow");
+const ACCEPTANCE_ID = asNodeId<typeof Acceptance>("acceptance");
+const ACCEPTS_ID = asEdgeId<typeof accepts>("accepts");
+const WORKFLOW_REF = { kind: "Workflow", id: WORKFLOW_ID } as const;
+const PEER_WORKFLOW_REF = {
+  kind: "Workflow",
+  id: asNodeId<typeof Workflow>("workflow-peer"),
+} as const;
+const VALID_TO = "2099-01-01T00:00:00.000Z";
+
+async function preparePlan(
+  context: IntegrationTestContext,
+  target: Store<typeof graph>,
+) {
+  await target.nodes.Workflow.create({ state: "pending" }, { id: WORKFLOW_ID });
+  await target.nodes.Workflow.create(
+    { state: "pending" },
+    { id: PEER_WORKFLOW_REF.id },
+  );
+  const source = unwrap(
+    await branch(target, () => context.createIsolatedBackend()),
+  );
+  await source.store.nodes.Item.create(
+    { name: "Candidate" },
+    {
+      id: ITEM_ID,
+      // Explicit null preserves an open lower bound; omission selects the write time.
+      // eslint-disable-next-line unicorn/no-null
+      validFrom: null,
+      validTo: VALID_TO,
+    },
+  );
+  return unwrap(await planMerge(target, [source]));
+}
+
+async function recordAcceptance(
+  tx: TransactionContext<typeof graph>,
+): Promise<void> {
+  const candidate = await tx.nodes.Item.getById(ITEM_ID);
+  if (candidate === undefined) throw new Error("Plan writes are not visible");
+  await tx.nodes.Workflow.update(WORKFLOW_ID, { state: "accepted" });
+  const acceptance = await tx.nodes.Acceptance.create(
+    { key: "accepted" },
+    { id: ACCEPTANCE_ID },
+  );
+  await tx.edges.accepts.create(acceptance, candidate, {}, { id: ACCEPTS_ID });
+  const identity = await tx.identity.assertSame(
+    WORKFLOW_REF,
+    PEER_WORKFLOW_REF,
+  );
+  expect(identity.action).toBe("created");
+  expect(await tx.identity.areSame(WORKFLOW_REF, PEER_WORKFLOW_REF)).toBe(true);
+}
+
+async function expectUnapplied(target: Store<typeof graph>): Promise<void> {
+  expect(await target.nodes.Item.getById(ITEM_ID)).toBeUndefined();
+  expect(await target.nodes.Workflow.getById(WORKFLOW_ID)).toMatchObject({
+    state: "pending",
+  });
+  expect(await target.nodes.Acceptance.count()).toBe(0);
+  expect(await target.edges.accepts.count()).toBe(0);
+  expect(await target.identity.assertionsOf(WORKFLOW_REF)).toEqual([]);
+  expect(await target.identity.areSame(WORKFLOW_REF, PEER_WORKFLOW_REF)).toBe(
+    false,
+  );
+}
+
+export function registerGraphMergeCallbackIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("graph merge transactional callbacks", () => {
+    it.each([false, true])(
+      "commits typed workflow writes with the plan (history: %s)",
+      async (history) => {
+        const target =
+          history ?
+            await context.createHistoryStore(graph)
+          : await context.createStore(graph, { revisionTracking: true });
+        const plan = await preparePlan(context, target);
+        const beforeRevision = await target.revisionNow();
+        if (beforeRevision === undefined)
+          throw new Error("Missing initial revision");
+        const beforeApply = vi.fn(
+          async (reads: MergePlanReadContext<typeof graph>) => {
+            expect(await reads.nodes.Item.getById(ITEM_ID)).toBeUndefined();
+            const workflow = await reads.nodes.Workflow.getById(WORKFLOW_ID);
+            expect(workflow).toMatchObject({ state: "pending" });
+            expect(await reads.edges.accepts.count()).toBe(0);
+            if (workflow === undefined) throw new Error("Missing workflow");
+            expect(await reads.identity.areSame(workflow, workflow)).toBe(true);
+            expect(Object.keys(reads).toSorted()).toEqual([
+              "edges",
+              "identity",
+              "nodes",
+            ]);
+            expect(Object.keys(reads.nodes.Item).toSorted()).toEqual([
+              "bulkFindByConstraint",
+              "bulkFindByIndex",
+              "count",
+              "find",
+              "findByConstraint",
+              "getById",
+              "getByIds",
+            ]);
+            expect(Object.keys(reads.edges.accepts).toSorted()).toEqual([
+              "bulkFindFrom",
+              "bulkFindTo",
+              "count",
+              "find",
+              "findByEndpoints",
+              "findFrom",
+              "findTo",
+              "getById",
+              "getByIds",
+            ]);
+            expect(Object.keys(reads.identity).toSorted()).toEqual([
+              "areDifferent",
+              "areSame",
+              "assertionsOf",
+              "membersOf",
+              "nodesOf",
+              "representativeOf",
+            ]);
+          },
+        );
+        const result = unwrap(
+          await applyMergePlan(target, plan, {
+            beforeApply,
+            afterApply: async (tx, applied) => {
+              expect(applied).toEqual({
+                merged: {
+                  nodes: 1,
+                  edges: 0,
+                  identity: { asserted: 0, retracted: 0 },
+                },
+              });
+              expect(applied).not.toHaveProperty("provenance");
+              await recordAcceptance(tx);
+            },
+          }),
+        );
+        expect(beforeApply).toHaveBeenCalledOnce();
+        const afterRevision = await target.revisionNow();
+        if (afterRevision === undefined)
+          throw new Error("Missing committed revision");
+        expect(recordedInstantRevision(afterRevision)).toBe(
+          recordedInstantRevision(beforeRevision) + 1,
+        );
+        expect(result.merged).toEqual({
+          nodes: 1,
+          edges: 0,
+          identity: { asserted: 0, retracted: 0 },
+        });
+        expect(await target.nodes.Item.getById(ITEM_ID)).toMatchObject({
+          meta: { validFrom: undefined, validTo: VALID_TO },
+        });
+        expect(await target.nodes.Workflow.getById(WORKFLOW_ID)).toMatchObject({
+          state: "accepted",
+        });
+        expect(
+          await target.nodes.Acceptance.getById(ACCEPTANCE_ID),
+        ).toBeDefined();
+        expect(await target.edges.accepts.count()).toBe(1);
+      },
+    );
+
+    it("records the candidate and callback writes at one revision", async () => {
+      const target = await context.createHistoryStore(graph);
+      const plan = await preparePlan(context, target);
+      const before = await target.recordedNow();
+      if (before === undefined)
+        throw new Error("Missing initial history revision");
+      unwrap(
+        await applyMergePlan(target, plan, {
+          afterApply: async (tx) => recordAcceptance(tx),
+        }),
+      );
+      const after = await target.recordedNow();
+      if (after === undefined)
+        throw new Error("Missing merge history revision");
+      expect(recordedInstantRevision(after)).toBe(
+        recordedInstantRevision(before) + 1,
+      );
+      const beforeView = target.asOfRecorded(before);
+      const afterView = target.asOfRecorded(after);
+      expect(await beforeView.nodes.Item.getById(ITEM_ID)).toBeUndefined();
+      expect(
+        await beforeView.nodes.Acceptance.getById(ACCEPTANCE_ID),
+      ).toBeUndefined();
+      expect(
+        await beforeView.nodes.Workflow.getById(WORKFLOW_ID),
+      ).toMatchObject({ state: "pending" });
+      expect(await afterView.nodes.Item.getById(ITEM_ID)).toMatchObject({
+        meta: { validFrom: undefined, validTo: VALID_TO },
+      });
+      expect(await afterView.nodes.Workflow.getById(WORKFLOW_ID)).toMatchObject(
+        { state: "accepted" },
+      );
+      expect(
+        await afterView.nodes.Acceptance.getById(ACCEPTANCE_ID),
+      ).toBeDefined();
+      expect(await afterView.edges.accepts.getById(ACCEPTS_ID)).toBeDefined();
+      expect(await beforeView.identity.assertionsOf(WORKFLOW_REF)).toEqual([]);
+      expect(
+        await beforeView.identity.areSame(WORKFLOW_REF, PEER_WORKFLOW_REF),
+      ).toBe(false);
+      expect(await afterView.identity.assertionsOf(WORKFLOW_REF)).toHaveLength(
+        1,
+      );
+      expect(
+        await afterView.identity.areSame(WORKFLOW_REF, PEER_WORKFLOW_REF),
+      ).toBe(true);
+    });
+
+    it("aborts before plan writes when an invariant rejects", async () => {
+      const target = await context.createHistoryStore(graph);
+      const plan = await preparePlan(context, target);
+      const before = await target.recordedNow();
+      const failure = new Error("Application invariant failed");
+      const afterApply = vi.fn(() =>
+        Promise.reject(new Error("Callback must not run")),
+      );
+      const result = await applyMergePlan(target, plan, {
+        beforeApply: async (reads) => {
+          expect(await reads.nodes.Workflow.getById(WORKFLOW_ID)).toBeDefined();
+          throw failure;
+        },
+        afterApply,
+      });
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) throw new Error("Expected merge application to fail");
+      expect(result.error.cause).toBe(failure);
+      expect(afterApply).not.toHaveBeenCalled();
+      await expectUnapplied(target);
+      expect(await target.recordedNow()).toEqual(before);
+      unwrap(await applyMergePlan(target, plan));
+    });
+
+    it("checks the revision fence before either callback", async () => {
+      const target = await context.createHistoryStore(graph);
+      const plan = await preparePlan(context, target);
+      await target.nodes.Item.create({ name: "Intervening write" });
+      const before = await target.recordedNow();
+      const beforeApply = vi.fn(() =>
+        Promise.reject(new Error("Callback must not run")),
+      );
+      const afterApply = vi.fn(async (tx: TransactionContext<typeof graph>) =>
+        recordAcceptance(tx),
+      );
+      const result = await applyMergePlan(target, plan, {
+        beforeApply,
+        afterApply,
+      });
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) throw new Error("Expected stale plan refusal");
+      expect(result.error).toBeInstanceOf(StaleMergePlanError);
+      expect(beforeApply).not.toHaveBeenCalled();
+      expect(afterApply).not.toHaveBeenCalled();
+      await expectUnapplied(target);
+      expect(await target.recordedNow()).toEqual(before);
+    });
+
+    it("rolls back the complete aggregate and history after a post-apply rejection", async () => {
+      const target = await context.createHistoryStore(graph);
+      const plan = await preparePlan(context, target);
+      const before = await target.recordedNow();
+      const failure = new Error("Acceptance rejected");
+      const result = await applyMergePlan(target, plan, {
+        afterApply: async (tx) => {
+          await recordAcceptance(tx);
+          throw failure;
+        },
+      });
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) throw new Error("Expected merge application to fail");
+      expect(result.error.cause).toBe(failure);
+      await expectUnapplied(target);
+      expect(await target.recordedNow()).toEqual(before);
+      if (before === undefined)
+        throw new Error("Missing initial history revision");
+      expect(
+        await target.asOfRecorded(before).identity.assertionsOf(WORKFLOW_REF),
+      ).toEqual([]);
+      // Reuse the exact artifact: rollback must restore the revision fence and assertion claim.
+      unwrap(
+        await applyMergePlan(target, plan, {
+          afterApply: async (tx) => recordAcceptance(tx),
+        }),
+      );
+    });
+
+    it.each(["beforeApply", "afterApply"] as const)(
+      "refuses an Err returned from %s by a JavaScript caller",
+      async (callback) => {
+        const target = await context.createHistoryStore(graph);
+        const plan = await preparePlan(context, target);
+        const before = await target.recordedNow();
+        const rejected = {
+          success: false,
+          error: new MergeError("Application refusal"),
+        } as const;
+        // A computed property bypasses callback contextual typing, like an untyped JS caller.
+        const result = await applyMergePlan(target, plan, {
+          [callback]: async (tx: TransactionContext<typeof graph>) => {
+            if (callback === "afterApply") await recordAcceptance(tx);
+            return rejected;
+          },
+        });
+        expect(isErr(result)).toBe(true);
+        if (!isErr(result)) throw new Error("Expected returned result refusal");
+        expect(result.error).toBeInstanceOf(InvalidMergeOptionsError);
+        expect(result.error.cause).toBe(rejected);
+        await expectUnapplied(target);
+        expect(await target.recordedNow()).toEqual(before);
+      },
+    );
+
+    it("preserves typed uniqueness enforcement for callback writes", async () => {
+      const target = await context.createHistoryStore(graph);
+      const plan = await preparePlan(context, target);
+      const before = await target.recordedNow();
+      const result = await applyMergePlan(target, plan, {
+        afterApply: async (tx) => {
+          await recordAcceptance(tx);
+          await tx.nodes.Acceptance.create({ key: "accepted" });
+        },
+      });
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) throw new Error("Expected uniqueness refusal");
+      expect(result.error).toBeInstanceOf(MergeConstraintConflictError);
+      await expectUnapplied(target);
+      expect(await target.recordedNow()).toEqual(before);
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -28,6 +28,7 @@ export type { IntegrationStore } from "./fixtures";
 export { integrationTestGraph } from "./fixtures";
 export { registerFulltextIntegrationTests } from "./fulltext";
 export { registerGraphAnnotationsIntegrationTests } from "./graph-annotations";
+export { registerGraphMergeCallbackIntegrationTests } from "./graph-merge-callbacks";
 export { registerGraphMergePlanIntegrationTests } from "./graph-merge-plan";
 export { registerGraphMergeReviewIntegrationTests } from "./graph-merge-review";
 export { registerIdentityIntegrationTests } from "./identity";

--- a/packages/typegraph/tests/backends/postgres/merge-callback-concurrency.test.ts
+++ b/packages/typegraph/tests/backends/postgres/merge-callback-concurrency.test.ts
@@ -1,0 +1,228 @@
+import {
+  asNodeId,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { createPostgresBackend } from "@nicia-ai/typegraph/adapters/drizzle/postgres";
+import { createLocalSqliteBackend } from "@nicia-ai/typegraph/adapters/drizzle/sqlite/local";
+import {
+  applyMergePlan,
+  asBranchId,
+  branch,
+  isErr,
+  MergePlanCapabilityError,
+  planMerge,
+  StaleMergePlanError,
+  unwrap,
+} from "@nicia-ai/typegraph/graph-merge";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { deriveBackend } from "../../../src/backend/derive-backend";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { requireDefined } from "../../../src/utils/presence";
+import {
+  createGate,
+  raceTimeout,
+  TIMEOUT_SENTINEL,
+} from "../../concurrency-utils";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
+import { runServerSuiteSetup } from "./server-suite-setup";
+
+const databaseUrl = await provisionPostgresTestDatabase(import.meta.url);
+const Resource = defineNode("Resource", {
+  schema: z.object({ owner: z.string() }),
+});
+let pool: Pool | undefined;
+
+beforeAll(async () => {
+  if (!process.env["POSTGRES_URL"]) return;
+  const candidate = new Pool({ connectionString: databaseUrl, max: 2 });
+  await runServerSuiteSetup("merge callbacks", [candidate], async () => {
+    await candidate.query(generatePostgresMigrationSQL());
+  });
+  pool = candidate;
+});
+
+afterAll(async () => {
+  await pool?.end();
+});
+
+async function fixture(id: string, history: boolean) {
+  const activePool = requireDefined(pool);
+  const first = await activePool.connect();
+  const second = await activePool.connect();
+  const local = createLocalSqliteBackend();
+  const graph = defineGraph({
+    id,
+    nodes: { Resource: { type: Resource } },
+    edges: {},
+  });
+  const options =
+    history ? { history: true as const } : { revisionTracking: true };
+  try {
+    const backend = createPostgresBackend(drizzle(first));
+    const [target] = await createStoreWithSchema(graph, backend, options);
+    const [writer] = await createStoreWithSchema(
+      graph,
+      createPostgresBackend(drizzle(second)),
+      options,
+    );
+    const resource = await target.nodes.Resource.create({ owner: "unclaimed" });
+    const source = unwrap(
+      await branch(target, () => Promise.resolve(local.backend), {
+        id: asBranchId("candidate"),
+      }),
+    );
+    await source.store.nodes.Resource.create(
+      { owner: "candidate" },
+      { id: "candidate" },
+    );
+    const plan = unwrap(await planMerge(target, [source]));
+    return {
+      target,
+      backend,
+      graph,
+      writer,
+      resource,
+      plan,
+      close: async () => {
+        await local.backend.close();
+        first.release();
+        second.release();
+      },
+    };
+  } catch (error) {
+    await local.backend.close();
+    first.release();
+    second.release();
+    throw error;
+  }
+}
+
+describe.runIf(process.env["POSTGRES_URL"])(
+  "merge callback concurrency",
+  () => {
+    it.each(["repeatable_read", "serializable"] as const)(
+      "refuses effective %s isolation even if read-committed was requested",
+      async (isolationLevel) => {
+        const { backend, graph, plan, close } = await fixture(
+          `callbacks_isolation_${isolationLevel}`,
+          false,
+        );
+        const overriddenBackend = deriveBackend(backend, {
+          transaction: (fn, options) =>
+            backend.transaction(fn, { ...options, isolationLevel }),
+        });
+        try {
+          const [target] = await createStoreWithSchema(
+            graph,
+            overriddenBackend,
+            { revisionTracking: true },
+          );
+          const beforeApply = vi.fn(() => Promise.resolve());
+          const afterApply = vi.fn(() => Promise.resolve());
+          const result = await applyMergePlan(target, plan, {
+            beforeApply,
+            afterApply,
+          });
+          expect(isErr(result) && result.error).toBeInstanceOf(
+            MergePlanCapabilityError,
+          );
+          expect(isErr(result) && result.error.details).toMatchObject({
+            isolation: isolationLevel,
+          });
+          expect(beforeApply).not.toHaveBeenCalled();
+          expect(afterApply).not.toHaveBeenCalled();
+          expect(
+            await target.nodes.Resource.getById(asNodeId("candidate")),
+          ).toBeUndefined();
+        } finally {
+          await close();
+        }
+      },
+    );
+    for (const history of [false, true]) {
+      it(`holds the fence before application reads against an ordinary conditional writer (history=${history})`, async () => {
+        const { target, writer, resource, plan, close } = await fixture(
+          `callbacks_winner_${history}`,
+          history,
+        );
+        const checked = createGate();
+        const release = createGate();
+        const applying = applyMergePlan(target, plan, {
+          beforeApply: async (reads) => {
+            const current = await reads.nodes.Resource.getById(resource.id);
+            expect(current?.owner).toBe("unclaimed");
+            checked.open();
+            await release.opened;
+          },
+          afterApply: async (tx) => {
+            await tx.nodes.Resource.update(resource.id, { owner: "merge" });
+          },
+        });
+        let competing: Promise<boolean> | undefined;
+        try {
+          expect(await raceTimeout(checked.opened, 3000)).not.toBe(
+            TIMEOUT_SENTINEL,
+          );
+          competing = writer.nodes.Resource.compareAndSet(resource.id, {
+            expected: { owner: "unclaimed" },
+            patch: { owner: "writer" },
+          });
+          expect(await raceTimeout(competing, 200)).toBe(TIMEOUT_SENTINEL);
+          release.open();
+          unwrap(await applying);
+          expect(await competing).toBe(false);
+          const current = await target.nodes.Resource.getById(resource.id);
+          expect(current?.owner).toBe("merge");
+        } finally {
+          release.open();
+          await Promise.allSettled([applying, competing]);
+          await close();
+        }
+      });
+
+      it(`refuses a plan made stale by an ordinary writer before invoking checks (history=${history})`, async () => {
+        const { target, writer, resource, plan, close } = await fixture(
+          `callbacks_loser_${history}`,
+          history,
+        );
+        const written = createGate();
+        const release = createGate();
+        const writing = writer.transaction(async (tx) => {
+          await tx.nodes.Resource.update(resource.id, { owner: "writer" });
+          written.open();
+          await release.opened;
+        });
+        const beforeApply = vi.fn(() => Promise.resolve());
+        let applying: ReturnType<typeof applyMergePlan> | undefined;
+        try {
+          expect(await raceTimeout(written.opened, 3000)).not.toBe(
+            TIMEOUT_SENTINEL,
+          );
+          applying = applyMergePlan(target, plan, { beforeApply });
+          expect(await raceTimeout(applying, 200)).toBe(TIMEOUT_SENTINEL);
+          expect(beforeApply).not.toHaveBeenCalled();
+          release.open();
+          await writing;
+          const result = await applying;
+          expect(isErr(result) && result.error).toBeInstanceOf(
+            StaleMergePlanError,
+          );
+          expect(beforeApply).not.toHaveBeenCalled();
+          expect(
+            await target.nodes.Resource.getById(asNodeId("candidate")),
+          ).toBeUndefined();
+        } finally {
+          release.open();
+          await Promise.allSettled([writing, applying]);
+          await close();
+        }
+      });
+    }
+  },
+);

--- a/packages/typegraph/tests/command-contract.test.ts
+++ b/packages/typegraph/tests/command-contract.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   assertGraphCommandExecutionContext,
   executeAuthoritativeGraphCommand,
+  graphCommandCoordinationIsolation,
   graphCommandExecutionContext,
   mintGraphCommandCoordination,
 } from "../src/backend/command-contract";
@@ -98,6 +99,39 @@ function edgeRow(matchIdentityKey: string): EdgeRow {
 }
 
 describe("authoritative graph command contract", () => {
+  it.each([
+    "read_committed",
+    "serializable",
+    "repeatable_read",
+    "unknown",
+  ] as const)(
+    "reads observed %s isolation only for the owning graph and session",
+    (isolation) => {
+      const port: GraphCommandPort = {
+        session: "transaction",
+        execute: () => Promise.resolve(RESULT),
+      };
+      const otherPort: GraphCommandPort = {
+        session: "transaction",
+        execute: () => Promise.resolve(RESULT),
+      };
+      const coordination = mintGraphCommandCoordination(
+        port,
+        "graph",
+        isolation,
+      );
+      expect(
+        graphCommandCoordinationIsolation(port, "graph", coordination),
+      ).toBe(isolation);
+      expect(
+        graphCommandCoordinationIsolation(port, "other", coordination),
+      ).toBe("unknown");
+      expect(
+        graphCommandCoordinationIsolation(otherPort, "graph", coordination),
+      ).toBe("unknown");
+    },
+  );
+
   it.each(["root", "transaction"] as const)(
     "binds %s commands to the matching session boundary",
     (session) => {

--- a/packages/typegraph/tests/graph-merge/apply-callbacks.test.ts
+++ b/packages/typegraph/tests/graph-merge/apply-callbacks.test.ts
@@ -1,0 +1,151 @@
+import {
+  asNodeId,
+  createStore,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import {
+  applyMergePlan,
+  asBranchId,
+  branch,
+  isErr,
+  MergePlanCapabilityError,
+  planMerge,
+  StaleMergePlanError,
+  unwrap,
+} from "@nicia-ai/typegraph/graph-merge";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { deriveBackend } from "../../src/backend/derive-backend";
+import { disableTransactions } from "../test-utils";
+import { createSqliteMergeBackend } from "./test-utils";
+
+const Item = defineNode("Item", { schema: z.object({ name: z.string() }) });
+const graph = defineGraph({
+  id: "merge_callback_retries",
+  nodes: { Item: { type: Item } },
+  edges: {},
+});
+const cleanups: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+
+function makeBackend() {
+  const fixture = createSqliteMergeBackend();
+  cleanups.push(fixture.cleanup);
+  return fixture.backend;
+}
+
+async function fixture() {
+  const backend = makeBackend();
+  const [store] = await createStoreWithSchema(graph, backend, {
+    history: true,
+  });
+  const source = unwrap(
+    await branch(store, async () => makeBackend(), {
+      id: asBranchId("source"),
+    }),
+  );
+  await source.store.nodes.Item.create({ name: "planned" }, { id: "planned" });
+  const plan = unwrap(await planMerge(store, [source]));
+  return { store, backend, plan };
+}
+
+function conflict() {
+  return Object.assign(new Error("injected serialization failure"), {
+    code: "40001",
+  });
+}
+
+describe("merge callback retry and refusal", () => {
+  it("replays all callbacks after rollback, preserving counts and committing only the final attempt", async () => {
+    const { store, plan } = await fixture();
+    const beforeApply = vi.fn(() => Promise.resolve());
+    let attempts = 0;
+    const result = await applyMergePlan(store, plan, {
+      beforeApply,
+      afterApply: async (tx, applied) => {
+        attempts += 1;
+        expect(await tx.nodes.Item.count()).toBe(1);
+        await tx.nodes.Item.create(
+          { name: "application" },
+          { id: `attempt-${attempts}` },
+        );
+        // Suppressed/JavaScript mutation of the provisional result cannot change the final report.
+        Reflect.set(applied.merged, "nodes", 999);
+        if (attempts === 1) throw conflict();
+      },
+    });
+    expect(beforeApply).toHaveBeenCalledTimes(2);
+    expect(unwrap(result).merged.nodes).toBe(1);
+    expect(
+      await store.nodes.Item.getById(asNodeId("attempt-1")),
+    ).toBeUndefined();
+    expect(await store.nodes.Item.getById(asNodeId("attempt-2"))).toBeDefined();
+  });
+
+  it("bounds retries and leaves every attempt rolled back", async () => {
+    const { store, plan } = await fixture();
+    const revision = await store.revisionNow();
+    const afterApply = vi.fn(async () => {
+      throw conflict();
+    });
+    const result = await applyMergePlan(store, plan, { afterApply });
+    expect(isErr(result)).toBe(true);
+    expect(afterApply).toHaveBeenCalledTimes(3);
+    expect(await store.nodes.Item.count()).toBe(0);
+    expect(await store.revisionNow()).toEqual(revision);
+  });
+
+  it("revalidates the fence after a rolled-back attempt and intervening committed write", async () => {
+    const { backend, plan } = await fixture();
+    const [writer] = await createStoreWithSchema(graph, backend, {
+      history: true,
+    });
+    let attempts = 0;
+    const retryingBackend = deriveBackend(backend, {
+      transaction: async (fn, options) => {
+        attempts += 1;
+        try {
+          return await backend.transaction(fn, options);
+        } catch (error) {
+          if (attempts === 1)
+            await writer.nodes.Item.create({ name: "intervening" });
+          throw error;
+        }
+      },
+    });
+    const store = createStore(graph, retryingBackend, { history: true });
+    const beforeApply = vi.fn(() => Promise.resolve());
+    const afterApply = vi.fn(async () => {
+      throw conflict();
+    });
+    const result = await applyMergePlan(store, plan, {
+      beforeApply,
+      afterApply,
+    });
+    expect(isErr(result) && result.error).toBeInstanceOf(StaleMergePlanError);
+    expect(beforeApply).toHaveBeenCalledTimes(1);
+    expect(afterApply).toHaveBeenCalledTimes(1);
+    expect(await store.nodes.Item.getById(asNodeId("planned"))).toBeUndefined();
+  });
+
+  it("refuses nontransactional targets before invoking callbacks", async () => {
+    const { backend, plan } = await fixture();
+    const store = createStore(graph, disableTransactions(backend));
+    const beforeApply = vi.fn(() => Promise.resolve());
+    const afterApply = vi.fn(() => Promise.resolve());
+    const result = await applyMergePlan(store, plan, {
+      beforeApply,
+      afterApply,
+    });
+    expect(isErr(result) && result.error).toBeInstanceOf(
+      MergePlanCapabilityError,
+    );
+    expect(beforeApply).not.toHaveBeenCalled();
+    expect(afterApply).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Add optional `beforeApply` and `afterApply` callbacks to `applyMergePlan` so application invariants, reviewed plan writes, and related typed graph writes can share one protected transaction. Prechecks receive actual read-only node, edge, and identity collections after the target fence is validated. Post-apply work receives the transaction context and provisional plan counts, excluding callback writes.

Callback failures roll back the combined operation and recorded history before errors become the outer `Result`. Callbacks must resolve without a value; returning an `Err` is explicitly refused. Transaction conflicts replay the entire operation, including both callbacks, for at most three attempts. Revision advancement and history capture remain shared across all writes.

Composed PostgreSQL application uses read-committed isolation under the existing schema and graph fences. The lock's session-bound isolation evidence is checked before callbacks, preventing an older serializable snapshot from reaching application checks after waiting for another writer. Standalone application retains its existing isolation choice, and optional provenance persistence remains a separate post-commit operation.

Document the callback, retry, concurrency, and history contracts; export the option/read/outcome types and add a minor changeset.

Closes #613
