### PR TITLE
feat(graph-merge): add durable candidate review and revalidation

### DIFF
--- a/.changeset/durable-candidate-review.md
+++ b/.changeset/durable-candidate-review.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+Add durable candidate merge reviews with `planCandidateWriteSetReview()` and `revalidateCandidateWriteSetReview()`. Persist immutable review and approval evidence in the target graph, then compare the retained candidate against current state before applying a fresh revision-fenced plan. Structured compatibility results expose changes requiring review without weakening atomic apply-time concurrency or constraint checks.

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -157,7 +157,7 @@ const planned = await planMerge(base, [sourceA, sourceB], {
 });
 if (!isOk(planned)) throw planned.error;
 
-// Safe to persist or send to a separate review process.
+// Persist outside the target graph, or send to a separate review process.
 const stored = JSON.stringify(planned.data);
 const reviewed = JSON.parse(stored);
 
@@ -208,6 +208,13 @@ review the new digest and proposal, then apply the new artifact; never edit an
 old plan or retry it as though it still represented the target. A successful
 plan is single-use: a second or concurrent application is stale.
 
+Persisting a plan or approval in the target graph also advances this revision.
+For exact-plan approval, use external storage or a separate graph ID; writes to
+that graph do not advance this target's revision. This does not provide atomic
+writes across graphs, and any intervening target write still requires a fresh
+plan. For candidate batches whose review records belong in the target itself,
+use the durable review protocol below.
+
 `merge()` and `mergeIncremental()` remain convenient compatibility wrappers.
 They invoke the same planner and applier contiguously and return the same
 `MergeReport` shape as before, now with match evidence on each resolution. Use
@@ -222,6 +229,167 @@ unrecorded changes. It is **not** a signature, proof of origin, authentication,
 or authorization. Authenticate untrusted storage and authorize the caller before
 passing a plan to `applyMergePlan()`.
 :::
+
+### Durable candidate review in the target graph
+
+`planCandidateWriteSetReview()` separates immutable review evidence from a
+revision-bound execution plan. Its `MergeReviewArtifact` retains the original
+candidate write set, reviewed plan, normalized merge options, explicit policy
+identity/context, and target baseline. You can persist this artifact and later
+approval records in the target before calling
+`revalidateCandidateWriteSetReview()` to compute a fresh execution plan.
+
+V1 supports candidate write sets only. It does not rebase arbitrary artifacts
+from `planMerge()` or `planMergeIncremental()`.
+
+The following continues the [candidate write set example](#constraint-aware-ingestion-branches).
+`Artifact`, `Decision`, and `evidence` are application-defined node/edge kinds;
+`proposal` is an existing node. The target enables `history` or `revisionTracking`.
+
+```typescript
+import {
+  applyMergePlan,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+  unwrap,
+} from "@nicia-ai/typegraph/graph-merge";
+
+const policy = {
+  id: "acceptance-policy-v1",
+  context: { requiredApprovals: 1, resolverVersion: "2026-09-01" },
+};
+const review = unwrap(
+  await planCandidateWriteSetReview({
+    target: store,
+    makeBackend,
+    writeSet,
+    policy,
+  }),
+);
+const artifact = await store.nodes.Artifact.create(
+  { content: JSON.stringify(review) },
+  { id: review.digest.value },
+);
+await store.edges.evidence.create(proposal, artifact, { note: "review" });
+
+// After an authenticated reviewer approves under the application's policy:
+const decision = await store.nodes.Decision.create({
+  approved: true,
+  reviewDigest: review.digest.value,
+});
+await store.edges.evidence.create(decision, artifact, { note: "approval" });
+
+// Later: authenticate the stored artifact and decision, then check current
+// authorization, approval validity, and policy before reusing that approval.
+const persisted = await store.nodes.Artifact.getById(artifact.id);
+if (persisted === undefined) throw new Error("Missing review artifact");
+const checked = unwrap(
+  await revalidateCandidateWriteSetReview({
+    target: store,
+    makeBackend,
+    review: JSON.parse(persisted.content),
+    policy,
+  }),
+);
+if (checked.status !== "compatible") {
+  console.log(checked.differences);
+  throw new Error("Create a new review and obtain a new approval");
+}
+if (checked.reviewDigest.value !== decision.reviewDigest) {
+  throw new Error("Approval does not identify the validated review");
+}
+
+// Keep this fresh execution plan ephemeral: another target write makes it stale.
+const applied = unwrap(await applyMergePlan(store, checked.plan));
+
+// A separate commit AFTER successful apply; see the recovery boundary below.
+await store.nodes.Artifact.create({
+  content: JSON.stringify({
+    reviewDigest: checked.reviewDigest,
+    approvalId: decision.id,
+    executionPlanDigest: checked.plan.digest,
+    executionTarget: checked.plan.target,
+    report: applied,
+  }),
+});
+```
+
+All approval records and links must be committed before final revalidation.
+Do not persist each replacement execution plan in the target: that repeats the
+staleness cycle. Retain the original review, and use the returned `reviewDigest`
+plus the fresh plan's `digest` and `target` fence to relate approval to execution.
+
+Both review APIs return `Result<..., MergeError>`. Revalidation accepts the
+persisted artifact as `unknown` and replans its retained candidate input once
+target, policy, and baseline checks pass.
+Supply current merge `options` and `policy` again; callbacks are never restored
+from serialized data.
+
+| Revalidation status | Meaning and next step |
+| --- | --- |
+| `compatible` | Includes a fresh `plan` and the original `reviewDigest`. Application policy may reuse approval; authorize the action and apply promptly. Compatibility itself grants no permission. |
+| `changed` | `differences` identify changed policy/options, baseline entities/identity, or plan fields. Obtain a new review and approval. A `plan` is included only when fresh planning completed. |
+| `incompatible` | The graph ID, schema identity, or revision origin differs. Approval cannot be reused for this target; resolve the mismatch and create a new review. |
+
+Malformed/unsupported artifacts, mismatched digests, and missing required
+evidence return `MergeReviewError` (`GRAPH_MERGE_REVIEW`). Existing typed planning
+and constraint errors remain errors rather than compatibility statuses. A target
+change during evidence capture/planning returns `MergePlanningStaleError`.
+
+The V1 baseline is deliberately conservative:
+
+- Every original node and edge row, including tombstones and validity metadata,
+  must remain unchanged. Editing an old audit record requires a new review even
+  when the candidate's resolved writes would be identical.
+- Expected absences for candidate/write/guard references must remain absent.
+  Same-ID nodes of other kinds are also guarded, because they can change implicit
+  identity membership. Complete archival identity evidence must remain unchanged.
+- Newly added rows can coexist with approval only when fresh planning produces
+  identical resolved writes, guards, conflicts, evidence, provenance, and other
+  plan content. Candidate-derived anchors and the execution digest/fence are
+  regenerated. There is no exemption for an “audit” kind.
+
+Applicable store constraints still run during atomic application. Compatibility
+does not promise that apply will succeed: new rows may introduce constraint
+conflicts, and any write between revalidation and apply causes
+`StaleMergePlanError`. A failed application commits no partial candidate node,
+edge, or identity writes. Revalidate again after a stale refusal; require reapproval if
+the result changes.
+
+`policy.id` identifies your policy implementation; `policy.context` explicitly
+records every opaque dependency that can change its decision. Include callback
+and resolver versions, model/prompt versions, external configuration or data
+versions, and any application state used to authorize approval reuse. Use an
+empty context only when no such dependencies exist. TypeGraph captures callback
+presence and serializable options, but cannot discover callback code, closure
+state, external reads, or hidden application policy dependencies.
+
+The producer must supply complete evidence, and the application must authenticate
+the entire stored review and its approval. Content addressing and SHA-256 detect
+content changes; anyone able to replace evidence can recompute a digest. A valid
+digest is neither proof that the baseline was complete nor authorization to
+reuse approval. Enforce artifact immutability and access control in your storage
+or application. The review contains candidate data and an entire reviewed plan,
+so protect it with the same care as graph data.
+
+Review capture and revalidation read/fingerprint the complete target graph and
+archival identity ledger. The artifact stores one fingerprint per original row
+plus expected absences. Fresh candidate planning additionally clones the whole
+graph into its disposable working copy. Budget graph-sized reads, memory,
+artifact storage, and cloning for this workflow; it is intended for bounded
+review batches.
+
+The execution receipt above is a separate commit. If its write fails or the
+process stops after apply, the merge may already be committed without a receipt.
+Retain the original review and approval, and reconcile committed history and
+application operation identity before repairing the receipt. Do not treat a
+missing receipt as permission to replay the candidate; applying its old execution
+plan is stale, and replanning is not a duplicate-execution check. Applications
+requiring a receipt atomic with the merge need a separate transaction-composition
+design. This protocol adds no such guarantee.
+
+See the runnable [durable merge review example](https://github.com/nicia-ai/typegraph/blob/main/packages/typegraph/examples/27-durable-merge-review.ts)
+for the complete schema and lifecycle.
 
 ## Scaling branches and interchange
 
@@ -1138,6 +1306,7 @@ subclass you can branch on:
 | `InvalidMergePlanError`      | The input is not a valid plan artifact. More specific subclasses distinguish unsupported versions, digest changes, and target/schema/origin mismatches.                                                                                                                       |
 | `CandidateSourceError`       | A built-in candidate source failed; details identify its source id, entity kind, and operation.                                                                                                                                                                               |
 | `CandidateWriteSetError`     | Code `GRAPH_MERGE_CANDIDATE_WRITE_SET`. Candidate JSON is malformed, targets another graph schema, cannot be staged, or violates the active graph contract. The accepted graph is unchanged.                                                                                  |
+| `MergeReviewError`           | Code `GRAPH_MERGE_REVIEW`. Durable review evidence is malformed, unsupported, incomplete, or inconsistent, or review options cannot be represented safely.                                                                                                                     |
 | `MatchEvidenceError`         | Evidence could not be constructed safely, including a custom scorer returning `NaN` or infinity.                                                                                                                                                                              |
 | `MergeError`                 | Any other merge failure (e.g. comparison-ceiling `"error"`, a non-transactional target). `MERGE_ERROR_CODES` enumerates the codes.                                                                                                                                            |
 

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -3568,6 +3568,7 @@ export const MERGE_ERROR_CODES: {
     readonly candidateSource: "GRAPH_MERGE_CANDIDATE_SOURCE";
     readonly evidence: "GRAPH_MERGE_EVIDENCE";
     readonly candidateWriteSet: "GRAPH_MERGE_CANDIDATE_WRITE_SET";
+    readonly review: "GRAPH_MERGE_REVIEW";
 };
 
 // @public
@@ -3586,6 +3587,9 @@ export const MERGE_PLAN_DIGEST_ALGORITHM: "sha256";
 
 // @public (undocumented)
 export const MERGE_PLAN_FORMAT_VERSION: 1;
+
+// @public (undocumented)
+export const MERGE_REVIEW_FORMAT_VERSION: 1;
 
 // @public
 export type MergeBranch<G extends GraphDef> = GraphBranch<G> | IngestionBranch<G>;
@@ -4021,6 +4025,66 @@ export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
         graphId: string;
         count: number;
     }>;
+}>;
+
+// @public
+export type MergeReviewArtifact = Readonly<{
+    formatVersion: typeof MERGE_REVIEW_FORMAT_VERSION;
+    kind: "candidate-write-set";
+    digest: MergePlanDigest;
+    writeSet: CandidateWriteSet;
+    policy: MergeReviewPolicy;
+    options: JsonValue;
+    plan: MergePlanArtifact;
+    baseline: MergeReviewBaseline;
+}>;
+
+// @public
+export type MergeReviewBaseline = Readonly<{
+    rows: readonly MergeReviewRow[];
+    identityDigest: string;
+}>;
+
+// @public
+export type MergeReviewDifference = Readonly<{
+    category: "target" | "policy" | "baseline" | "plan";
+    path: string;
+    entity?: MergePlanEntityRef & Readonly<{
+        role: "node" | "edge";
+    }>;
+}>;
+
+// @public
+export class MergeReviewError extends MergeError {
+    constructor(message: string, options?: MergeErrorOptions);
+    // (undocumented)
+    readonly code: "GRAPH_MERGE_REVIEW";
+    // (undocumented)
+    protected static readonly errorCategory = "user";
+}
+
+// @public
+export type MergeReviewPolicy = Readonly<{
+    id: string;
+    context: JsonValue;
+}>;
+
+// @public
+export type MergeReviewRevalidation = Readonly<{
+    status: "compatible";
+    reviewDigest: MergePlanDigest;
+    plan: MergePlanArtifact;
+}> | Readonly<{
+    status: "changed" | "incompatible";
+    reviewDigest: MergePlanDigest;
+    differences: readonly MergeReviewDifference[];
+    plan?: MergePlanArtifact;
+}>;
+
+// @public
+export type MergeReviewRow = MergePlanEntityRef & Readonly<{
+    role: "node" | "edge";
+    digest?: string | undefined;
 }>;
 
 // @public
@@ -4567,6 +4631,14 @@ export type PlanCandidateWriteSetArgs<G extends GraphDef> = Readonly<{
     makeBackend: MakeBackend;
     writeSet: unknown;
     options?: Omit<MergeOptions<G>, "target">;
+}>;
+
+// @public
+export function planCandidateWriteSetReview<G extends GraphDef>(args: PlanCandidateWriteSetReviewArgs<G>): Promise<Result<MergeReviewArtifact, MergeError>>;
+
+// @public (undocumented)
+export type PlanCandidateWriteSetReviewArgs<G extends GraphDef> = PlanCandidateWriteSetArgs<G> & Readonly<{
+    policy: MergeReviewPolicy;
 }>;
 
 // @public
@@ -5215,6 +5287,14 @@ export type Result<T, E = Error> = Readonly<{
 }> | Readonly<{
     success: false;
     error: E;
+}>;
+
+// @public
+export function revalidateCandidateWriteSetReview<G extends GraphDef>(args: RevalidateCandidateWriteSetReviewArgs<G>): Promise<Result<MergeReviewRevalidation, MergeError>>;
+
+// @public (undocumented)
+export type RevalidateCandidateWriteSetReviewArgs<G extends GraphDef> = Omit<PlanCandidateWriteSetReviewArgs<G>, "writeSet"> & Readonly<{
+    review: unknown;
 }>;
 
 // @public

--- a/packages/typegraph/examples/27-durable-merge-review.ts
+++ b/packages/typegraph/examples/27-durable-merge-review.ts
@@ -1,0 +1,187 @@
+/**
+ * Example 27: Durable Merge Review
+ *
+ * Persist review and approval records in the target, revalidate the retained
+ * candidate, and apply a fresh execution plan under the normal revision fence.
+ * Authentication and approval policy remain application responsibilities.
+ *
+ * Run from packages/typegraph after building the package:
+ *   node --import tsx examples/27-durable-merge-review.ts
+ */
+import {
+  createStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import {
+  applyMergePlan,
+  captureCandidateWriteSetTarget,
+  isErr,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+  StaleMergePlanError,
+  unwrap,
+} from "@nicia-ai/typegraph/graph-merge";
+import { z } from "zod";
+
+import { createExampleBackend } from "./_helpers";
+
+const Item = defineNode("Item", {
+  schema: z.object({
+    label: z.string(),
+    status: z.enum(["proposed", "accepted"]),
+  }),
+});
+const Artifact = defineNode("Artifact", {
+  schema: z.object({ content: z.string() }),
+});
+const Decision = defineNode("Decision", {
+  schema: z.object({
+    approved: z.boolean(),
+    reviewDigest: z.string(),
+    reviewer: z.string(),
+  }),
+});
+const evidence = defineEdge("evidence", {
+  schema: z.object({ note: z.string() }),
+});
+const graph = defineGraph({
+  id: "durable_merge_review_example",
+  nodes: {
+    Item: { type: Item },
+    Artifact: { type: Artifact },
+    Decision: { type: Decision },
+  },
+  edges: {
+    evidence: { type: evidence, from: [Item, Decision], to: [Artifact] },
+  },
+});
+
+const VALID_FROM = "2026-01-01T00:00:00.000Z";
+const POLICY = {
+  id: "manual-acceptance-v1",
+  context: { requiredApprovals: 1, authorizedReviewers: ["reviewer:maya"] },
+};
+
+function makeBackend(): Promise<ReturnType<typeof createExampleBackend>> {
+  return Promise.resolve(createExampleBackend());
+}
+
+export async function main(): Promise<void> {
+  const backend = createExampleBackend();
+  try {
+    const [store] = await createStoreWithSchema(graph, backend, {
+      history: true,
+    });
+    const proposal = await store.nodes.Item.create(
+      { label: "Reviewed catalog entry", status: "proposed" },
+      { id: "proposal:entry", validFrom: VALID_FROM },
+    );
+    const review = unwrap(
+      await planCandidateWriteSetReview({
+        target: store,
+        makeBackend,
+        policy: POLICY,
+        writeSet: {
+          formatVersion: 1,
+          sourceId: "catalog-review",
+          target: await captureCandidateWriteSetTarget(store),
+          nodes: [
+            {
+              kind: "Item",
+              id: proposal.id,
+              properties: { label: proposal.label, status: "accepted" },
+              validFrom: VALID_FROM,
+            },
+          ],
+          edges: [],
+        },
+      }),
+    );
+
+    // Append new records and links. Mutating an original row (including an
+    // older audit record) would require a new review under the V1 baseline.
+    // Content addressing is an identifier; storage must enforce immutability.
+    const artifact = await store.nodes.Artifact.create(
+      { content: JSON.stringify(review) },
+      { id: review.digest.value },
+    );
+    await store.edges.evidence.create(proposal, artifact, { note: "review" });
+
+    // Simulate an already authenticated reviewer approving this exact review.
+    // Production applications authenticate reviewer requests and stored records.
+    const decision = await store.nodes.Decision.create({
+      approved: true,
+      reviewDigest: review.digest.value,
+      reviewer: "reviewer:maya",
+    });
+    await store.edges.evidence.create(decision, artifact, { note: "approval" });
+
+    const stale = await applyMergePlan(store, review.plan);
+    if (!isErr(stale) || !(stale.error instanceof StaleMergePlanError)) {
+      throw new Error("Expected original plan to be stale after audit writes");
+    }
+    console.log("Original execution plan is stale; durable review is retained.");
+
+    const persisted = await store.nodes.Artifact.getById(artifact.id);
+    const approval = await store.nodes.Decision.getById(decision.id);
+    if (
+      persisted === undefined ||
+      approval === undefined ||
+      !approval.approved ||
+      approval.reviewDigest !== artifact.id ||
+      !POLICY.context.authorizedReviewers.includes(approval.reviewer)
+    ) {
+      throw new Error("No valid approval for this review");
+    }
+    const checked = unwrap(
+      await revalidateCandidateWriteSetReview({
+        target: store,
+        makeBackend,
+        review: JSON.parse(persisted.content),
+        policy: POLICY,
+      }),
+    );
+    if (checked.status !== "compatible") {
+      console.log(checked.status, checked.differences);
+      throw new Error("A new review and approval are required");
+    }
+    if (checked.reviewDigest.value !== approval.reviewDigest) {
+      throw new Error("Approval does not identify the validated review");
+    }
+
+    // Do not persist this ephemeral plan or any new target record before apply.
+    // A concurrent write still produces StaleMergePlanError; constraints also
+    // remain enforced. Compatibility itself is never authorization.
+    const report = unwrap(await applyMergePlan(store, checked.plan));
+    const accepted = await store.nodes.Item.getById(proposal.id);
+    if (accepted?.status !== "accepted") {
+      throw new Error("Expected the reviewed change to be committed");
+    }
+    console.log("Applied the approved change after same-graph audit writes.");
+
+    // Receipt persistence is a SEPARATE commit. If it fails, the merge remains
+    // committed. Reconcile history and application operation identity before
+    // repairing a missing receipt; never infer that the candidate can be retried.
+    await store.nodes.Artifact.create({
+      content: JSON.stringify({
+        reviewDigest: checked.reviewDigest,
+        approvalId: approval.id,
+        executionPlanDigest: checked.plan.digest,
+        executionTarget: checked.plan.target,
+        report,
+      }),
+    });
+    console.log("Recorded the review-to-execution receipt after apply.");
+  } finally {
+    await backend.close();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/packages/typegraph/src/graph-merge/candidate-review.ts
+++ b/packages/typegraph/src/graph-merge/candidate-review.ts
@@ -1,0 +1,317 @@
+import {
+  CandidateWriteSetSchema,
+  planCandidateWriteSet,
+  type PlanCandidateWriteSetArgs,
+} from "./candidate-write-set";
+import {
+  MergeError,
+  MergePlanningStaleError,
+  MergeReviewError,
+} from "./errors";
+import {
+  assertPlanningFenceUnchanged,
+  captureMergePlanTargetFence,
+  sameMergePlanTargetFence,
+} from "./merge";
+import type { MergePlanArtifact, MergePlanTargetFence } from "./plan-schema";
+import { validateMergePlanArtifact } from "./plan-wire";
+import { err, isErr, ok, type Result } from "./result";
+import {
+  captureReviewBaseline,
+  compareReviewBaseline,
+  reviewRowKey,
+  withReviewAbsences,
+} from "./review-baseline";
+import {
+  reviewDigest,
+  reviewJson,
+  reviewOptionEvidence,
+} from "./review-evidence";
+import {
+  MERGE_REVIEW_FORMAT_VERSION,
+  type MergeReviewArtifact,
+  mergeReviewArtifactSchema,
+  type MergeReviewDifference,
+  type MergeReviewPolicy,
+  mergeReviewPolicySchema,
+  type MergeReviewRevalidation,
+} from "./review-schema";
+import type { GraphDef } from "./typegraph-internal";
+
+export type PlanCandidateWriteSetReviewArgs<G extends GraphDef> =
+  PlanCandidateWriteSetArgs<G> &
+    Readonly<{
+      policy: MergeReviewPolicy;
+    }>;
+
+export type RevalidateCandidateWriteSetReviewArgs<G extends GraphDef> = Omit<
+  PlanCandidateWriteSetReviewArgs<G>,
+  "writeSet"
+> &
+  Readonly<{
+    review: unknown;
+  }>;
+
+/** Capture a durable review, with planning and baseline reads under one fence. */
+export async function planCandidateWriteSetReview<G extends GraphDef>(
+  args: PlanCandidateWriteSetReviewArgs<G>,
+): Promise<Result<MergeReviewArtifact, MergeError>> {
+  try {
+    const writeSet = CandidateWriteSetSchema.parse(args.writeSet);
+    const policy = mergeReviewPolicySchema.parse(args.policy);
+    const options = reviewOptionEvidence(args.options);
+    const startingFence = await captureMergePlanTargetFence(args.target);
+    const baseline = await captureReviewBaseline(args.target);
+    const planned = await planCandidateWriteSet({ ...args, writeSet });
+    if (isErr(planned)) return planned;
+    assertReviewPlanFence(startingFence, planned.data);
+    await assertPlanningFenceUnchanged(args.target, startingFence);
+    assertOptionsUnchanged(options, reviewOptionEvidence(args.options));
+    const input = {
+      formatVersion: MERGE_REVIEW_FORMAT_VERSION,
+      kind: "candidate-write-set" as const,
+      writeSet,
+      policy,
+      options,
+      plan: planned.data,
+      baseline: withReviewAbsences(
+        baseline,
+        writeSet,
+        planned.data,
+        args.target.graph,
+      ),
+    };
+    const review: MergeReviewArtifact = {
+      ...input,
+      digest: { algorithm: "sha256", value: await reviewDigest(input) },
+    };
+    mergeReviewArtifactSchema.parse(review);
+    return ok(review);
+  } catch (error) {
+    return err(asReviewError(error));
+  }
+}
+
+/**
+ * Replan the retained input and relate it to its original review. Never writes
+ * the target, edits an old plan, or authorizes execution. Apply a compatible
+ * result with applyMergePlan(), retaining its final transactional revision fence.
+ */
+export async function revalidateCandidateWriteSetReview<G extends GraphDef>(
+  args: RevalidateCandidateWriteSetReviewArgs<G>,
+): Promise<Result<MergeReviewRevalidation, MergeError>> {
+  try {
+    const review = await validateReview(args.review);
+    const policy = mergeReviewPolicySchema.parse(args.policy);
+    const options = reviewOptionEvidence(args.options);
+    const startingFence = await captureMergePlanTargetFence(args.target);
+    const targetDifferences = compareReviewTarget(
+      review.plan.target,
+      startingFence,
+    );
+    if (targetDifferences.length > 0)
+      return ok({
+        status: "incompatible",
+        reviewDigest: review.digest,
+        differences: targetDifferences,
+      });
+    if (
+      withReviewAbsences(
+        review.baseline,
+        review.writeSet,
+        review.plan,
+        args.target.graph,
+      ).rows.length !== review.baseline.rows.length
+    ) {
+      throw new MergeReviewError(
+        "The merge review is missing required baseline evidence.",
+        { details: { reason: "incomplete-baseline" } },
+      );
+    }
+    const policyDifferences = compareFields(
+      "policy",
+      { policy: review.policy, options: review.options },
+      { policy, options },
+    );
+    if (policyDifferences.length > 0)
+      return ok({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: policyDifferences,
+      });
+
+    const baseline = await captureReviewBaseline(args.target);
+    const baselineDifferences = compareReviewBaseline(
+      review.baseline,
+      baseline,
+    );
+    if (baselineDifferences.length > 0) {
+      await assertPlanningFenceUnchanged(args.target, startingFence);
+      return ok({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: baselineDifferences,
+      });
+    }
+    const planned = await planCandidateWriteSet({
+      ...args,
+      writeSet: review.writeSet,
+    });
+    if (isErr(planned)) return planned;
+    assertReviewPlanFence(startingFence, planned.data);
+    await assertPlanningFenceUnchanged(args.target, startingFence);
+    assertOptionsUnchanged(options, reviewOptionEvidence(args.options));
+    const differences = compareFields(
+      "plan",
+      reviewPlanContent(review.plan),
+      reviewPlanContent(planned.data),
+    );
+    return ok(
+      differences.length === 0 ?
+        {
+          status: "compatible",
+          reviewDigest: review.digest,
+          plan: planned.data,
+        }
+      : {
+          status: "changed",
+          reviewDigest: review.digest,
+          differences,
+          plan: planned.data,
+        },
+    );
+  } catch (error) {
+    return err(asReviewError(error));
+  }
+}
+
+async function validateReview(input: unknown): Promise<MergeReviewArtifact> {
+  const review = mergeReviewArtifactSchema.parse(input);
+  // Candidate staging schemas normalize defaults and strip unknown transport
+  // fields. Stored review evidence must already be normalized: otherwise an
+  // added field could disappear before its digest is checked.
+  if (reviewJson(input) !== reviewJson(review)) {
+    throw new MergeReviewError(
+      "Stored merge review evidence must not require normalization.",
+      {
+        details: { reason: "noncanonical-shape" },
+      },
+    );
+  }
+  const { digest, ...content } = review;
+  if (digest.value !== (await reviewDigest(content))) {
+    throw new MergeReviewError(
+      "The merge review digest does not match its content.",
+      { details: { reason: "digest-mismatch" } },
+    );
+  }
+  const plan = await validateMergePlanArtifact(review.plan);
+  if (!plan.success)
+    throw new MergeReviewError("The reviewed execution plan is invalid.", {
+      details: { reason: "invalid-plan", error: plan.error },
+    });
+  const anchors = plan.artifact.anchors;
+  if (
+    plan.artifact.mode !== "incremental" ||
+    anchors.kind !== "incremental" ||
+    anchors.forkPoint.graphId !== review.writeSet.target.graphId ||
+    plan.artifact.target.graphId !== review.writeSet.target.graphId ||
+    plan.artifact.target.schema.version !==
+      review.writeSet.target.schemaVersion ||
+    plan.artifact.target.schema.hash !== review.writeSet.target.schemaHash ||
+    reviewJson(anchors.forkPoint.schema) !==
+      reviewJson(plan.artifact.target.schema) ||
+    anchors.branches.length !== 1 ||
+    anchors.branches[0]?.branchId !== review.writeSet.sourceId ||
+    anchors.branches[0].baseVersion !== anchors.forkPoint.baseVersion
+  ) {
+    throw new MergeReviewError(
+      "The reviewed plan does not describe the retained candidate source and target.",
+      { details: { reason: "incompatible-plan" } },
+    );
+  }
+  if (
+    new Set(review.baseline.rows.map((row) => reviewRowKey(row))).size !==
+    review.baseline.rows.length
+  ) {
+    throw new MergeReviewError(
+      "The merge review contains duplicate baseline references.",
+      { details: { reason: "duplicate-baseline" } },
+    );
+  }
+  return { ...review, plan: plan.artifact };
+}
+
+function assertReviewPlanFence(
+  fence: MergePlanTargetFence,
+  plan: MergePlanArtifact,
+): void {
+  if (!sameMergePlanTargetFence(fence, plan.target)) {
+    throw new MergePlanningStaleError(
+      "The target changed between review evidence capture and planning.",
+    );
+  }
+}
+
+function assertOptionsUnchanged(before: unknown, after: unknown): void {
+  if (reviewJson(before) !== reviewJson(after))
+    throw new MergeReviewError(
+      "Merge options changed while review evidence was being captured.",
+    );
+}
+
+function compareReviewTarget(
+  reviewed: MergePlanTargetFence,
+  current: MergePlanTargetFence,
+): readonly MergeReviewDifference[] {
+  return compareFields(
+    "target",
+    {
+      graphId: reviewed.graphId,
+      schema: reviewed.schema,
+      origin: reviewed.revision.origin,
+    },
+    {
+      graphId: current.graphId,
+      schema: current.schema,
+      origin: current.revision.origin,
+    },
+  );
+}
+
+/**
+ * Only the candidate adapter may replace its target-derived fork/branch anchors:
+ * it recreates them from the retained input on every call. No arbitrary snapshot
+ * or incremental plan is accepted by this protocol. Keep every other field.
+ */
+function reviewPlanContent(
+  plan: MergePlanArtifact,
+): Omit<MergePlanArtifact, "digest" | "target" | "anchors"> {
+  const {
+    digest: _digest,
+    target: _target,
+    anchors: _anchors,
+    ...content
+  } = plan;
+  return content;
+}
+
+function compareFields(
+  category: MergeReviewDifference["category"],
+  reviewed: Readonly<Record<string, unknown>>,
+  current: Readonly<Record<string, unknown>>,
+): readonly MergeReviewDifference[] {
+  return [...new Set([...Object.keys(reviewed), ...Object.keys(current)])]
+    .sort()
+    .filter((key) => reviewJson(reviewed[key]) !== reviewJson(current[key]))
+    .map((key) => ({ category, path: `${category}.${key}` }));
+}
+
+function asReviewError(error: unknown): MergeError {
+  return error instanceof MergeError ? error : (
+      new MergeReviewError(
+        "Unable to validate or capture merge review evidence.",
+        { cause: error },
+      )
+    );
+}

--- a/packages/typegraph/src/graph-merge/errors.ts
+++ b/packages/typegraph/src/graph-merge/errors.ts
@@ -35,6 +35,7 @@ export const MERGE_ERROR_CODES = {
   candidateSource: "GRAPH_MERGE_CANDIDATE_SOURCE",
   evidence: "GRAPH_MERGE_EVIDENCE",
   candidateWriteSet: "GRAPH_MERGE_CANDIDATE_WRITE_SET",
+  review: "GRAPH_MERGE_REVIEW",
 } as const;
 
 /**
@@ -95,6 +96,17 @@ export class InvalidMergeOptionsError extends MergeError {
   constructor(message: string, options: MergeErrorOptions = {}) {
     super(message, options);
     this.name = "InvalidMergeOptionsError";
+  }
+}
+
+/** Invalid, unsupported, or unavailable evidence for durable merge review. */
+export class MergeReviewError extends MergeError {
+  protected static override readonly errorCategory = "user";
+  override readonly code = MERGE_ERROR_CODES.review;
+
+  constructor(message: string, options: MergeErrorOptions = {}) {
+    super(message, options);
+    this.name = "MergeReviewError";
   }
 }
 

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -14,6 +14,14 @@ export type { IngestionImportTarget } from "../interchange/ingestion-import-targ
 export { computeBaseVersion } from "./base-version";
 export { branch } from "./branch";
 export type {
+  PlanCandidateWriteSetReviewArgs,
+  RevalidateCandidateWriteSetReviewArgs,
+} from "./candidate-review";
+export {
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+} from "./candidate-review";
+export type {
   CandidateWriteSet,
   CandidateWriteSetTarget,
   PlanCandidateWriteSetArgs,
@@ -45,6 +53,7 @@ export {
   MergePlanOriginMismatchError,
   MergePlanSchemaMismatchError,
   MergePlanTargetMismatchError,
+  MergeReviewError,
   SimilarityUnavailableError,
   StaleMergePlanError,
   UnsupportedMergePlanVersionError,
@@ -115,6 +124,15 @@ export {
 } from "./provenance-store";
 export type { Result } from "./result";
 export { isErr, isOk, unwrap } from "./result";
+export type {
+  MergeReviewArtifact,
+  MergeReviewBaseline,
+  MergeReviewDifference,
+  MergeReviewPolicy,
+  MergeReviewRevalidation,
+  MergeReviewRow,
+} from "./review-schema";
+export { MERGE_REVIEW_FORMAT_VERSION } from "./review-schema";
 export type {
   BaseNodeLookup,
   CandidateSource,

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -2530,7 +2530,7 @@ function assertPublicPlanCapability<G extends GraphDef>(
   }
 }
 
-async function captureMergePlanTargetFence<G extends GraphDef>(
+export async function captureMergePlanTargetFence<G extends GraphDef>(
   target: Store<G>,
 ): Promise<MergePlanTargetFence> {
   assertPublicPlanCapability(target);
@@ -2551,7 +2551,7 @@ async function captureMergePlanTargetFence<G extends GraphDef>(
   };
 }
 
-function sameMergePlanTargetFence(
+export function sameMergePlanTargetFence(
   left: MergePlanTargetFence,
   right: MergePlanTargetFence,
 ): boolean {
@@ -2565,7 +2565,7 @@ function sameMergePlanTargetFence(
   );
 }
 
-async function assertPlanningFenceUnchanged<G extends GraphDef>(
+export async function assertPlanningFenceUnchanged<G extends GraphDef>(
   target: Store<G>,
   startingFence: MergePlanTargetFence,
 ): Promise<void> {

--- a/packages/typegraph/src/graph-merge/review-baseline.ts
+++ b/packages/typegraph/src/graph-merge/review-baseline.ts
@@ -1,0 +1,153 @@
+import type { CandidateWriteSet } from "./candidate-write-set";
+import { parseRowProps } from "./canonical-props";
+import { compareStrings } from "./node-key";
+import type { MergePlanArtifact, MergePlanEntityRef } from "./plan-schema";
+import { reviewDigest } from "./review-evidence";
+import type {
+  MergeReviewBaseline,
+  MergeReviewDifference,
+  MergeReviewRow,
+} from "./review-schema";
+import { enumerateAllEdges, enumerateAllNodes } from "./state-diff";
+import type { GraphDef, Store } from "./typegraph-internal";
+import {
+  getEdgeKinds,
+  getNodeKinds,
+  storeBackend,
+  storeRuntime,
+} from "./typegraph-internal";
+
+export function reviewRowKey(row: MergeReviewRow): string {
+  return JSON.stringify([row.role, row.kind, row.id]);
+}
+
+/** Caller fences these reads together with planning using one target revision. */
+export async function captureReviewBaseline<G extends GraphDef>(
+  target: Store<G>,
+): Promise<MergeReviewBaseline> {
+  const backend = storeBackend(target);
+  const rows: MergeReviewRow[] = [];
+  for (const kind of getNodeKinds(target.graph)) {
+    for (const row of await enumerateAllNodes(backend, target.graphId, kind)) {
+      rows.push({
+        role: "node",
+        kind,
+        id: row.id,
+        digest: await reviewDigest({ ...row, props: parseRowProps(row.props) }),
+      });
+    }
+  }
+  for (const kind of getEdgeKinds(target.graph)) {
+    for (const row of await enumerateAllEdges(backend, target.graphId, kind)) {
+      rows.push({
+        role: "edge",
+        kind,
+        id: row.id,
+        digest: await reviewDigest({ ...row, props: parseRowProps(row.props) }),
+      });
+    }
+  }
+  const identity = await storeRuntime(target).readCurrentIdentityAssertions(
+    "archival",
+    {
+      includeDeleted: true,
+    },
+  );
+  return {
+    rows: rows.sort((left, right) =>
+      compareStrings(reviewRowKey(left), reviewRowKey(right)),
+    ),
+    identityDigest: await reviewDigest(
+      [...identity].sort((left, right) => compareStrings(left.id, right.id)),
+    ),
+  };
+}
+
+/**
+ * Existing rows are all guarded. Also guard absence for every input/write/guard
+ * reference, so an insertion cannot turn a reviewed create into an overwrite.
+ */
+export function withReviewAbsences<G extends GraphDef>(
+  baseline: MergeReviewBaseline,
+  writeSet: CandidateWriteSet,
+  plan: MergePlanArtifact,
+  graph: G,
+): MergeReviewBaseline {
+  const rows = new Map(baseline.rows.map((row) => [reviewRowKey(row), row]));
+  function addNode(entity: MergePlanEntityRef): void {
+    // Guard same-id peers too: a new kind can join an implicit identity class
+    // without adding an assertion to the identity ledger. Conservatively guard
+    // every kind even when the current identity profile does not fold them.
+    for (const kind of getNodeKinds(graph)) {
+      const row = { role: "node", kind, id: entity.id } as const;
+      if (!rows.has(reviewRowKey(row))) rows.set(reviewRowKey(row), row);
+    }
+  }
+  for (const row of baseline.rows) if (row.role === "node") addNode(row);
+  function addEdge(entity: MergePlanEntityRef): void {
+    // Edge ids are graph-wide, including across edge kinds.
+    for (const kind of getEdgeKinds(graph)) {
+      const row = { role: "edge", kind, id: entity.id } as const;
+      if (!rows.has(reviewRowKey(row))) rows.set(reviewRowKey(row), row);
+    }
+  }
+  for (const node of [
+    ...writeSet.nodes,
+    ...plan.writes.nodeUpserts,
+    ...plan.writes.nodeDeletes,
+    ...plan.guards.deletedNodes,
+  ])
+    addNode(node);
+  for (const edge of [...writeSet.edges, ...plan.writes.edgeUpserts]) {
+    addEdge(edge);
+    addNode(edge.from);
+    addNode(edge.to);
+  }
+  for (const edge of plan.writes.edgeDeletes) addEdge(edge);
+  for (const assertion of [
+    ...(writeSet.identity?.assertions ?? []),
+    ...plan.writes.identityAssertions,
+    ...plan.writes.identityRetractions,
+  ]) {
+    addNode(assertion.a);
+    addNode(assertion.b);
+    if (assertion.endedBy !== undefined) addNode(assertion.endedBy);
+  }
+  for (const mapping of plan.guards.canonicalMappings) {
+    addNode(mapping.member);
+    addNode(mapping.canonical);
+  }
+  for (const retype of plan.guards.retypes) {
+    addNode(retype.entity);
+    addNode({ kind: retype.toKind, id: retype.entity.id });
+  }
+  return {
+    ...baseline,
+    rows: [...rows.values()].sort((left, right) =>
+      compareStrings(reviewRowKey(left), reviewRowKey(right)),
+    ),
+  };
+}
+
+export function compareReviewBaseline(
+  reviewed: MergeReviewBaseline,
+  current: MergeReviewBaseline,
+): readonly MergeReviewDifference[] {
+  const currentRows = new Map(
+    current.rows.map((row) => [reviewRowKey(row), row]),
+  );
+  const differences: MergeReviewDifference[] = [];
+  for (const row of reviewed.rows) {
+    if (row.digest !== currentRows.get(reviewRowKey(row))?.digest) {
+      differences.push({
+        category: "baseline",
+        path: "baseline.rows",
+        entity: { role: row.role, kind: row.kind, id: row.id },
+      });
+    }
+  }
+  if (reviewed.identityDigest !== current.identityDigest) {
+    differences.push({ category: "baseline", path: "baseline.identityDigest" });
+  }
+  return differences;
+}

--- a/packages/typegraph/src/graph-merge/review-evidence.ts
+++ b/packages/typegraph/src/graph-merge/review-evidence.ts
@@ -1,0 +1,80 @@
+import { MergeReviewError } from "./errors";
+import { compareStrings } from "./node-key";
+import { normalizeMergeOptions } from "./options";
+import type { GraphDef, JsonValue } from "./typegraph-internal";
+import { sha256Hex, sortedReplacer } from "./typegraph-internal";
+import type { MergeOptions } from "./types";
+
+/** Canonical content identity shared by review wire validation and row evidence. */
+export function reviewJson(value: unknown): string {
+  // Missing optional fields must compare distinctly from every JSON value.
+  if (value === undefined) return "undefined";
+  return JSON.stringify(value, sortedReplacer);
+}
+
+export async function reviewDigest(value: unknown): Promise<string> {
+  return sha256Hex(reviewJson(value), 32);
+}
+
+/**
+ * Preserve every normalized option, including Maps and the presence of callbacks.
+ * Callback code/closure identity is deliberately supplied by MergeReviewPolicy.
+ * Tagged values keep a literal object from impersonating a callback or Map.
+ */
+export function reviewOptionEvidence<G extends GraphDef>(
+  options: Omit<MergeOptions<G>, "target"> | undefined,
+): JsonValue {
+  return encodeOption(normalizeMergeOptions(options), new Set());
+}
+
+function encodeOption(value: unknown, ancestors: Set<object>): JsonValue {
+  if (value === undefined) return ["undefined"];
+  if (typeof value === "function") return ["callback"];
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean"
+  ) {
+    return ["literal", value];
+  }
+  if (typeof value === "number" && Number.isFinite(value))
+    return ["number", value];
+  if (typeof value !== "object" || ancestors.has(value)) {
+    throw new MergeReviewError(
+      "Merge options contain unsupported or cyclic review evidence.",
+    );
+  }
+  const nextAncestors = new Set([...ancestors, value]);
+  if (Array.isArray(value)) {
+    return [
+      "array",
+      value.map((item: unknown) => encodeOption(item, nextAncestors)),
+    ];
+  }
+  if (value instanceof Map) {
+    const entries = [...(value as ReadonlyMap<unknown, unknown>)].map(
+      ([key, entry]) => [
+        encodeOption(key, nextAncestors),
+        encodeOption(entry, nextAncestors),
+      ],
+    );
+    entries.sort((left, right) =>
+      compareStrings(reviewJson(left), reviewJson(right)),
+    );
+    return ["map", entries];
+  }
+  if (
+    Object.getPrototypeOf(value) !== Object.prototype &&
+    Object.getPrototypeOf(value) !== null
+  ) {
+    throw new MergeReviewError(
+      "Merge options contain a non-JSON object without a review representation.",
+    );
+  }
+  return [
+    "object",
+    Object.entries(value)
+      .sort(([left], [right]) => compareStrings(left, right))
+      .map(([key, entry]) => [key, encodeOption(entry, nextAncestors)]),
+  ];
+}

--- a/packages/typegraph/src/graph-merge/review-schema.ts
+++ b/packages/typegraph/src/graph-merge/review-schema.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+
+import {
+  type CandidateWriteSet,
+  CandidateWriteSetSchema,
+} from "./candidate-write-set";
+import type {
+  MergePlanArtifact,
+  MergePlanDigest,
+  MergePlanEntityRef,
+} from "./plan-schema";
+import { mergePlanArtifactV1Schema } from "./plan-schema";
+import type { JsonValue } from "./typegraph-internal";
+
+export const MERGE_REVIEW_FORMAT_VERSION = 1 as const;
+
+/** Application-owned identity of policy code and all opaque/external dependencies. */
+export type MergeReviewPolicy = Readonly<{
+  id: string;
+  /** Explicit evidence; use an empty object only when there are no such dependencies. */
+  context: JsonValue;
+}>;
+
+/** A fingerprint of an observed row, or an expected absence. */
+export type MergeReviewRow = MergePlanEntityRef &
+  Readonly<{
+    role: "node" | "edge";
+    /** Absent means this reference did not exist at review time. */
+    digest?: string | undefined;
+  }>;
+
+/** Conservative baseline: all original rows and the complete identity ledger. */
+export type MergeReviewBaseline = Readonly<{
+  rows: readonly MergeReviewRow[];
+  identityDigest: string;
+}>;
+
+/**
+ * Immutable review evidence, distinct from its single-use execution plan.
+ * V1 supports candidate write sets only. Authenticate stored artifacts separately.
+ */
+export type MergeReviewArtifact = Readonly<{
+  formatVersion: typeof MERGE_REVIEW_FORMAT_VERSION;
+  kind: "candidate-write-set";
+  digest: MergePlanDigest;
+  writeSet: CandidateWriteSet;
+  policy: MergeReviewPolicy;
+  options: JsonValue;
+  plan: MergePlanArtifact;
+  baseline: MergeReviewBaseline;
+}>;
+
+/** Structured reason to refuse approval reuse; paths name fields in the review. */
+export type MergeReviewDifference = Readonly<{
+  category: "target" | "policy" | "baseline" | "plan";
+  path: string;
+  entity?: MergePlanEntityRef & Readonly<{ role: "node" | "edge" }>;
+}>;
+
+/** Compatibility is evidence for application policy, never an authorization decision. */
+export type MergeReviewRevalidation =
+  | Readonly<{
+      status: "compatible";
+      reviewDigest: MergePlanDigest;
+      plan: MergePlanArtifact;
+    }>
+  | Readonly<{
+      status: "changed" | "incompatible";
+      reviewDigest: MergePlanDigest;
+      differences: readonly MergeReviewDifference[];
+      /** Present when a fresh plan was computed; it requires a new review. */
+      plan?: MergePlanArtifact;
+    }>;
+
+const digestSchema = z.string().regex(/^[\da-f]{64}$/u);
+
+export const mergeReviewPolicySchema = z
+  .object({
+    id: z.string().min(1),
+    context: z.json(),
+  })
+  .strict();
+
+export const mergeReviewArtifactSchema = z
+  .object({
+    formatVersion: z.literal(MERGE_REVIEW_FORMAT_VERSION),
+    kind: z.literal("candidate-write-set"),
+    digest: z
+      .object({ algorithm: z.literal("sha256"), value: digestSchema })
+      .strict(),
+    writeSet: CandidateWriteSetSchema,
+    policy: mergeReviewPolicySchema,
+    options: z.json(),
+    plan: mergePlanArtifactV1Schema,
+    baseline: z
+      .object({
+        rows: z.array(
+          z
+            .object({
+              role: z.enum(["node", "edge"]),
+              kind: z.string().min(1),
+              id: z.string().min(1),
+              digest: digestSchema.optional(),
+            })
+            .strict(),
+        ),
+        identityDigest: digestSchema,
+      })
+      .strict(),
+  })
+  .strict();

--- a/packages/typegraph/test-d/graph-merge.test-d.ts
+++ b/packages/typegraph/test-d/graph-merge.test-d.ts
@@ -22,6 +22,9 @@ import {
   type MergeConstraintConflictErrorDetails,
   MergeError,
   type MergeReport,
+  type MergeReviewArtifact,
+  type MergeReviewRevalidation,
+  MergeReviewError,
   type ReconcileTypesMode,
   type Result,
   type WorkingCopyStrategy,
@@ -34,6 +37,8 @@ import {
   openProvenanceStore,
   planMerge,
   planMergeIncremental,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
   type ProvenanceGraph,
   unwrap,
 } from "../dist/graph-merge";
@@ -152,3 +157,38 @@ expectType<"GRAPH_MERGE_CONSTRAINT_CONFLICT">(constraintConflict.code);
 expectType<"constraint">(constraintConflict.category);
 expectType<MergeConstraintConflictErrorDetails>(constraintConflict.details);
 expectType<string>(constraintConflict.details.constraintCode);
+
+const reviewPolicy = { id: "review-v1", context: {} } as const;
+expectType<Promise<Result<MergeReviewArtifact, MergeError>>>(
+  planCandidateWriteSetReview({
+    target: store,
+    makeBackend,
+    writeSet: {} as unknown,
+    policy: reviewPolicy,
+  }),
+);
+expectType<Promise<Result<MergeReviewRevalidation, MergeError>>>(
+  revalidateCandidateWriteSetReview({
+    target: store,
+    makeBackend,
+    review: {} as unknown,
+    policy: reviewPolicy,
+  }),
+);
+expectError(
+  planCandidateWriteSetReview({ target: store, makeBackend, writeSet: {} }),
+);
+declare const reviewed: MergeReviewArtifact;
+expectError((reviewed.digest = mergePlan.digest));
+expectError(
+  reviewed.baseline.rows.push({ role: "node", kind: "Person", id: "x" }),
+);
+declare const revalidation: MergeReviewRevalidation;
+if (revalidation.status === "compatible") {
+  expectType<MergePlanArtifact>(revalidation.plan);
+} else {
+  expectType<MergePlanArtifact | undefined>(revalidation.plan);
+}
+declare const reviewError: MergeReviewError;
+expectAssignable<MergeError>(reviewError);
+expectType<"GRAPH_MERGE_REVIEW">(reviewError.code);

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -58,6 +58,7 @@ import {
   registerFulltextIntegrationTests,
   registerGraphAnnotationsIntegrationTests,
   registerGraphMergePlanIntegrationTests,
+  registerGraphMergeReviewIntegrationTests,
   registerHistoricalIdentityTraversalTests,
   registerIdentityImportIntegrationTests,
   registerIdentityIntegrationTests,
@@ -310,6 +311,7 @@ export function createIntegrationTestSuite<
     registerWeightedShortestPathExtractionIntegrationTests(context);
     registerFulltextIntegrationTests(context);
     registerGraphMergePlanIntegrationTests(context);
+    registerGraphMergeReviewIntegrationTests(context);
     registerImportUniquenessIntegrationTests(context);
     registerIdentityIntegrationTests(context);
     registerIdentityImportIntegrationTests(context);

--- a/packages/typegraph/tests/backends/integration/graph-merge-review.ts
+++ b/packages/typegraph/tests/backends/integration/graph-merge-review.ts
@@ -1,0 +1,581 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  asNodeId,
+  createAdapterStoreWithSchema,
+  defineEdge,
+  defineGraph,
+  defineNode,
+  defineNodeIndex,
+  type Store,
+} from "../../../src";
+import { defineGraphExtension } from "../../../src/graph-extension";
+import {
+  applyMergePlan,
+  type CandidateWriteSet,
+  CandidateWriteSetError,
+  captureCandidateWriteSetTarget,
+  type MergeOptions,
+  planCandidateWriteSet,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+  StaleMergePlanError,
+} from "../../../src/graph-merge";
+import { captureMergePlanTargetFence } from "../../../src/graph-merge/merge";
+import { isErr, unwrap } from "../../../src/graph-merge/result";
+import { requireDefined } from "../../../src/utils/presence";
+import type { IntegrationTestContext } from "./test-context";
+
+const Item = defineNode("Item", {
+  schema: z.object({
+    label: z.string(),
+    status: z.enum(["proposed", "accepted", "rejected"]),
+    group: z.string(),
+  }),
+});
+const Artifact = defineNode("Artifact", {
+  schema: z.object({ content: z.string() }),
+});
+const Decision = defineNode("Decision", {
+  schema: z.object({ approved: z.boolean(), reviewDigest: z.string() }),
+});
+const evidence = defineEdge("evidence", {
+  schema: z.object({ note: z.string() }),
+});
+const primary = defineEdge("primary", { schema: z.object({}) });
+const graph = defineGraph({
+  id: "durable_merge_review",
+  identity: { sameIdAcrossKinds: "fold" },
+  indexes: [defineNodeIndex(Item, { name: "item_group", fields: ["group"] })],
+  nodes: {
+    Item: { type: Item },
+    Artifact: { type: Artifact },
+    Decision: { type: Decision },
+  },
+  edges: {
+    evidence: { type: evidence, from: [Item, Decision], to: [Artifact] },
+    primary: {
+      type: primary,
+      from: [Item],
+      to: [Artifact],
+      cardinality: "one",
+    },
+  },
+});
+const policy = {
+  id: "review-policy-v1",
+  context: { minimumApprovals: 1 },
+} as const;
+const validFrom = "2026-01-01T00:00:00.000Z";
+type ReviewStore = Store<typeof graph>;
+
+async function candidate(target: ReviewStore): Promise<CandidateWriteSet> {
+  return {
+    formatVersion: 1,
+    sourceId: "review-source",
+    target: await captureCandidateWriteSetTarget(target),
+    nodes: [
+      {
+        kind: "Item",
+        id: "candidate",
+        properties: {
+          label: "Reviewed item",
+          status: "accepted",
+          group: "reviewed",
+        },
+        validFrom,
+      },
+    ],
+    edges: [],
+  };
+}
+
+export function registerGraphMergeReviewIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  function makeBackend() {
+    return context.createIsolatedBackend();
+  }
+  async function setup() {
+    const target = await context.createHistoryStore(graph);
+    return { target, writeSet: await candidate(target), makeBackend, policy };
+  }
+  describe("durable merge review", () => {
+    it("persists immutable review and approval evidence in the target before applying the fresh plan", async () => {
+      const args = await setup();
+      const proposed = await args.target.nodes.Item.create(
+        { label: "Reviewed item", status: "proposed", group: "reviewed" },
+        { id: "candidate", validFrom },
+      );
+      const before = await captureMergePlanTargetFence(args.target);
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      expect(await captureMergePlanTargetFence(args.target)).toEqual(before);
+      expect(await args.target.nodes.Item.getById(proposed.id)).toMatchObject({
+        status: "proposed",
+      });
+      const artifact = await args.target.nodes.Artifact.create(
+        { content: JSON.stringify(review) },
+        { id: review.digest.value, validFrom },
+      );
+      await args.target.edges.evidence.create(
+        proposed,
+        artifact,
+        { note: "proposed change" },
+        { validFrom },
+      );
+      const decision = await args.target.nodes.Decision.create(
+        { approved: true, reviewDigest: review.digest.value },
+        { validFrom },
+      );
+      await args.target.edges.evidence.create(
+        decision,
+        artifact,
+        { note: "human approval" },
+        { validFrom },
+      );
+      const persisted = requireDefined(
+        await args.target.nodes.Artifact.getById(artifact.id),
+      );
+      const stale = await applyMergePlan(args.target, review.plan);
+      expect(isErr(stale) && stale.error).toBeInstanceOf(StaleMergePlanError);
+      const beforeRevalidation = await captureMergePlanTargetFence(args.target);
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({
+          ...args,
+          review: JSON.parse(persisted.content) as unknown,
+        }),
+      );
+      expect(result.status).toBe("compatible");
+      if (result.status !== "compatible")
+        throw new Error("Expected compatible review");
+      expect(result.reviewDigest).toEqual(review.digest);
+      expect(result.plan.digest).not.toEqual(review.plan.digest);
+      expect(result.plan.writes).toEqual(review.plan.writes);
+      expect(result.plan.target).toEqual(beforeRevalidation);
+      expect(await captureMergePlanTargetFence(args.target)).toEqual(
+        beforeRevalidation,
+      );
+      unwrap(await applyMergePlan(args.target, result.plan));
+      expect(await args.target.nodes.Item.getById(proposed.id)).toMatchObject({
+        status: "accepted",
+      });
+      expect(await args.target.nodes.Artifact.getById(artifact.id)).toEqual(
+        persisted,
+      );
+      expect(
+        await args.target.nodes.Decision.getById(decision.id),
+      ).toMatchObject({ approved: true, reviewDigest: review.digest.value });
+      expect(await args.target.edges.evidence.count()).toBe(2);
+    });
+
+    it("requires reapproval when an original row changes even if both plans write the same accepted value", async () => {
+      const args = await setup();
+      const item = await args.target.nodes.Item.create(
+        { label: "Reviewed item", status: "proposed", group: "reviewed" },
+        { id: "candidate", validFrom },
+      );
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.nodes.Item.update(item.id, { status: "rejected" });
+      const fresh = unwrap(await planCandidateWriteSet(args));
+      expect(fresh.writes).toEqual(review.plan.writes);
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [
+          {
+            category: "baseline",
+            path: "baseline.rows",
+            entity: { role: "node", kind: "Item", id: "candidate" },
+          },
+        ],
+      });
+      expect(await args.target.nodes.Item.getById(item.id)).toMatchObject({
+        status: "rejected",
+      });
+    });
+
+    it("guards a candidate id that was absent when reviewed", async () => {
+      const args = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.nodes.Item.create(
+        { label: "Reviewed item", status: "accepted", group: "reviewed" },
+        { id: "candidate", validFrom },
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [
+          {
+            category: "baseline",
+            path: "baseline.rows",
+            entity: { role: "node", kind: "Item", id: "candidate" },
+          },
+        ],
+      });
+    });
+
+    it("requires reapproval when a same-id node joins an implicit identity class without ledger changes", async () => {
+      const args = await setup();
+      await args.target.nodes.Item.create(
+        { label: "Reviewed item", status: "proposed", group: "reviewed" },
+        { id: "candidate", validFrom },
+      );
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.nodes.Artifact.create(
+        { content: "same-id audit evidence" },
+        { id: "candidate", validFrom },
+      );
+      const fresh = unwrap(await planCandidateWriteSetReview(args));
+      expect(fresh.plan.writes).toEqual(review.plan.writes);
+      expect(fresh.baseline.identityDigest).toBe(
+        review.baseline.identityDigest,
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [
+          {
+            category: "baseline",
+            path: "baseline.rows",
+            entity: { role: "node", kind: "Artifact", id: "candidate" },
+          },
+        ],
+      });
+      expect(
+        await args.target.nodes.Item.getById(asNodeId("candidate")),
+      ).toMatchObject({ status: "proposed" });
+    });
+
+    it("allows unrelated additions of the candidate kind when fresh planning preserves all evidence", async () => {
+      const args = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.nodes.Item.create(
+        { label: "Audit item", status: "accepted", group: "audit" },
+        { id: "audit", validFrom },
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result.status).toBe("compatible");
+      if (result.status !== "compatible")
+        throw new Error("Expected compatible review");
+      expect(result.plan.writes).toEqual(review.plan.writes);
+      unwrap(await applyMergePlan(args.target, result.plan));
+      expect(await args.target.nodes.Item.count()).toBe(2);
+    });
+
+    it("does not exclude an audit addition from candidate resolution", async () => {
+      const args = await setup();
+      const options = {
+        resolve: {
+          Item: {
+            blockIndex: "item_group",
+            similarity: { kind: "custom", score: () => 1 },
+            threshold: 1,
+          },
+        },
+      } satisfies MergeOptions<typeof graph>;
+      const review = unwrap(
+        await planCandidateWriteSetReview({ ...args, options }),
+      );
+      await args.target.nodes.Item.create(
+        { label: "Audit item", status: "accepted", group: "reviewed" },
+        { id: "audit", validFrom },
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, options, review }),
+      );
+      expect(result.status).toBe("changed");
+      if (result.status !== "changed")
+        throw new Error("Expected changed review");
+      expect(result.differences).toContainEqual({
+        category: "plan",
+        path: "plan.writes",
+      });
+      expect(result.differences).toContainEqual({
+        category: "plan",
+        path: "plan.review",
+      });
+      expect(result.plan?.writes).not.toEqual(review.plan.writes);
+      expect(
+        await args.target.nodes.Item.getById(asNodeId("candidate")),
+      ).toBeUndefined();
+    });
+
+    it("detects identity ledger changes without requiring node property changes", async () => {
+      const args = await setup();
+      const first = await args.target.nodes.Item.create(
+        { label: "First", status: "accepted", group: "audit" },
+        { id: "first", validFrom },
+      );
+      const second = await args.target.nodes.Item.create(
+        { label: "Second", status: "accepted", group: "audit" },
+        { id: "second", validFrom },
+      );
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.identity.assertDifferent(first, second, { validFrom });
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [
+          { category: "baseline", path: "baseline.identityDigest" },
+        ],
+      });
+      expect(await args.target.nodes.Item.getById(first.id)).toEqual(first);
+      expect(await args.target.nodes.Item.getById(second.id)).toEqual(second);
+    });
+
+    it("detects changes to an original edge", async () => {
+      const args = await setup();
+      const item = await args.target.nodes.Item.create(
+        { label: "Original", status: "accepted", group: "audit" },
+        { id: "original", validFrom },
+      );
+      const artifact = await args.target.nodes.Artifact.create(
+        { content: "original" },
+        { id: "original-artifact", validFrom },
+      );
+      const edge = await args.target.edges.evidence.create(
+        item,
+        artifact,
+        { note: "original" },
+        { id: "original-edge", validFrom },
+      );
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.edges.evidence.update(edge.id, { note: "revised" });
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [
+          {
+            category: "baseline",
+            path: "baseline.rows",
+            entity: { role: "edge", kind: "evidence", id: "original-edge" },
+          },
+        ],
+      });
+    });
+
+    it("includes original tombstones in the review baseline", async () => {
+      const args = await setup();
+      const item = await args.target.nodes.Item.create(
+        { label: "Deleted", status: "rejected", group: "audit" },
+        { id: "deleted", validFrom },
+      );
+      await args.target.nodes.Item.delete(item.id);
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      const tombstone = requireDefined(
+        review.baseline.rows.find(
+          (row) =>
+            row.role === "node" && row.kind === "Item" && row.id === "deleted",
+        ),
+      );
+      expect(tombstone.digest).toMatch(/^[\da-f]{64}$/u);
+      await args.target.nodes.Item.hardDelete(item.id);
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [
+          {
+            category: "baseline",
+            path: "baseline.rows",
+            entity: { role: "node", kind: "Item", id: "deleted" },
+          },
+        ],
+      });
+    });
+
+    it("refuses approval reuse after schema evolution", async () => {
+      const args = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.evolve(
+        defineGraphExtension({
+          nodes: { Annotation: { properties: { text: { type: "string" } } } },
+        }),
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result).toEqual({
+        status: "incompatible",
+        reviewDigest: review.digest,
+        differences: [{ category: "target", path: "target.schema" }],
+      });
+    });
+
+    it("refuses a review from an independently initialized target", async () => {
+      const args = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      const [independent] = await createAdapterStoreWithSchema(
+        graph,
+        await context.createIsolatedBackend(),
+        { history: true },
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({
+          ...args,
+          target: independent,
+          review,
+        }),
+      );
+      expect(result).toEqual({
+        status: "incompatible",
+        reviewDigest: review.digest,
+        differences: [{ category: "target", path: "target.origin" }],
+      });
+    });
+
+    it("requires explicit reapproval when policy context or merge options change", async () => {
+      const args = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      const changedPolicy = unwrap(
+        await revalidateCandidateWriteSetReview({
+          ...args,
+          policy: { ...policy, context: { minimumApprovals: 2 } },
+          review,
+        }),
+      );
+      expect(changedPolicy).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [{ category: "policy", path: "policy.policy" }],
+      });
+      const changedOptions = unwrap(
+        await revalidateCandidateWriteSetReview({
+          ...args,
+          options: { provenance: false },
+          review,
+        }),
+      );
+      expect(changedOptions).toEqual({
+        status: "changed",
+        reviewDigest: review.digest,
+        differences: [{ category: "policy", path: "policy.options" }],
+      });
+      expect(await args.target.nodes.Item.count()).toBe(0);
+    });
+
+    it("rechecks cardinality after audit additions without partially writing the candidate", async () => {
+      const args = await setup();
+      const item = await args.target.nodes.Item.create(
+        { label: "Reviewed item", status: "accepted", group: "reviewed" },
+        { id: "candidate", validFrom },
+      );
+      const writeSet: CandidateWriteSet = {
+        ...args.writeSet,
+        nodes: [
+          ...args.writeSet.nodes,
+          {
+            kind: "Artifact",
+            id: "candidate-artifact",
+            properties: { content: "reviewed attachment" },
+            validFrom,
+          },
+        ],
+        edges: [
+          {
+            kind: "primary",
+            id: "candidate-primary",
+            from: { kind: "Item", id: item.id },
+            to: { kind: "Artifact", id: "candidate-artifact" },
+            properties: {},
+            validFrom,
+          },
+        ],
+      };
+      const review = unwrap(
+        await planCandidateWriteSetReview({ ...args, writeSet }),
+      );
+      const audit = await args.target.nodes.Artifact.create(
+        { content: "audit attachment" },
+        { id: "audit-artifact", validFrom },
+      );
+      await args.target.edges.primary.create(
+        item,
+        audit,
+        {},
+        { id: "audit-primary", validFrom },
+      );
+      const beforeRevalidation = await captureMergePlanTargetFence(args.target);
+      const result = await revalidateCandidateWriteSetReview({
+        ...args,
+        review,
+      });
+      expect(isErr(result)).toBe(true);
+      if (!isErr(result)) throw new Error("Expected cardinality refusal");
+      expect(result.error).toBeInstanceOf(CandidateWriteSetError);
+      expect(result.error.details).toEqual({
+        errors: [
+          {
+            entityType: "edge",
+            kind: "primary",
+            id: "candidate-primary",
+            error:
+              'Cardinality violation: "primary" from Item/candidate allows "one" but 1 edge(s) already exist',
+          },
+        ],
+      });
+      expect(await captureMergePlanTargetFence(args.target)).toEqual(
+        beforeRevalidation,
+      );
+      expect(
+        await args.target.nodes.Artifact.getById(
+          asNodeId("candidate-artifact"),
+        ),
+      ).toBeUndefined();
+      expect(await args.target.edges.primary.find()).toEqual([
+        expect.objectContaining({ id: "audit-primary" }),
+      ]);
+      expect(await args.target.nodes.Item.getById(item.id)).toEqual(item);
+    });
+
+    it("retains the atomic revision fence after successful revalidation", async () => {
+      const args = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      await args.target.nodes.Artifact.create(
+        { content: JSON.stringify(review) },
+        { validFrom },
+      );
+      const result = unwrap(
+        await revalidateCandidateWriteSetReview({ ...args, review }),
+      );
+      expect(result.status).toBe("compatible");
+      if (result.status !== "compatible")
+        throw new Error("Expected compatible review");
+      await args.target.nodes.Artifact.create(
+        { content: "intervening write" },
+        { validFrom },
+      );
+      const beforeApply = await captureMergePlanTargetFence(args.target);
+      const applied = await applyMergePlan(args.target, result.plan);
+      expect(isErr(applied) && applied.error).toBeInstanceOf(
+        StaleMergePlanError,
+      );
+      expect(await captureMergePlanTargetFence(args.target)).toEqual(
+        beforeApply,
+      );
+      expect(
+        await args.target.nodes.Item.getById(asNodeId("candidate")),
+      ).toBeUndefined();
+    });
+  });
+}

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -29,6 +29,7 @@ export { integrationTestGraph } from "./fixtures";
 export { registerFulltextIntegrationTests } from "./fulltext";
 export { registerGraphAnnotationsIntegrationTests } from "./graph-annotations";
 export { registerGraphMergePlanIntegrationTests } from "./graph-merge-plan";
+export { registerGraphMergeReviewIntegrationTests } from "./graph-merge-review";
 export { registerIdentityIntegrationTests } from "./identity";
 export { registerCurrentIdentityTraversalTests } from "./identity-current-traversal";
 export { registerHistoricalIdentityTraversalTests } from "./identity-historical-traversal";

--- a/packages/typegraph/tests/backends/postgres/merge-review-race.test.ts
+++ b/packages/typegraph/tests/backends/postgres/merge-review-race.test.ts
@@ -1,0 +1,153 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { createStoreWithSchema, defineGraph, defineNode } from "../../../src";
+import { generatePostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import { createPostgresBackend } from "../../../src/backend/postgres";
+import { createLocalSqliteBackend } from "../../../src/backend/sqlite/local";
+import {
+  applyMergePlan,
+  captureCandidateWriteSetTarget,
+  isErr,
+  isOk,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+  StaleMergePlanError,
+  unwrap,
+} from "../../../src/graph-merge";
+import { requireDefined } from "../../../src/utils/presence";
+import {
+  createGate,
+  raceTimeout,
+  TIMEOUT_SENTINEL,
+} from "../../concurrency-utils";
+import { provisionPostgresTestDatabase } from "../../postgres-test-database";
+import { runServerSuiteSetup } from "./server-suite-setup";
+
+const databaseUrl = await provisionPostgresTestDatabase(import.meta.url);
+const Item = defineNode("Item", { schema: z.object({ value: z.string() }) });
+const Artifact = defineNode("Artifact", {
+  schema: z.object({ content: z.string() }),
+});
+const policy = { id: "append-v1", context: {} } as const;
+let firstPool: Pool | undefined;
+let secondPool: Pool | undefined;
+
+async function setup(id: string) {
+  const graph = defineGraph({
+    id,
+    nodes: { Item: { type: Item }, Artifact: { type: Artifact } },
+    edges: {},
+  });
+  const [first] = await createStoreWithSchema(
+    graph,
+    createPostgresBackend(drizzle(requireDefined(firstPool))),
+    { history: true },
+  );
+  const [second] = await createStoreWithSchema(
+    graph,
+    createPostgresBackend(drizzle(requireDefined(secondPool))),
+    { history: true },
+  );
+  const args = {
+    target: first,
+    makeBackend: () => Promise.resolve(createLocalSqliteBackend().backend),
+    policy,
+    writeSet: {
+      formatVersion: 1 as const,
+      sourceId: "source",
+      target: await captureCandidateWriteSetTarget(first),
+      nodes: [
+        {
+          kind: "Item",
+          id: "candidate",
+          properties: { value: "approved" },
+          validFrom: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      edges: [],
+    },
+  };
+  const review = unwrap(await planCandidateWriteSetReview(args));
+  await second.nodes.Artifact.create({ content: JSON.stringify(review) });
+  const revalidated = unwrap(
+    await revalidateCandidateWriteSetReview({ ...args, review }),
+  );
+  if (revalidated.status !== "compatible")
+    throw new Error("Expected a compatible execution plan");
+  return { first, second, plan: revalidated.plan };
+}
+
+describe.runIf(process.env["POSTGRES_URL"])(
+  "durable merge review with independent PostgreSQL sessions",
+  () => {
+    beforeAll(async () => {
+      const first = new Pool({ connectionString: databaseUrl, max: 1 });
+      const second = new Pool({ connectionString: databaseUrl, max: 1 });
+      await runServerSuiteSetup("merge review", [first, second], async () => {
+        await first.query(generatePostgresMigrationSQL());
+        const [left, right] = await Promise.all([
+          first.query<{ pid: number }>("select pg_backend_pid() as pid"),
+          second.query<{ pid: number }>("select pg_backend_pid() as pid"),
+        ]);
+        if (
+          requireDefined(left.rows[0]).pid === requireDefined(right.rows[0]).pid
+        )
+          throw new Error("Expected independent PostgreSQL sessions");
+      });
+      firstPool = first;
+      secondPool = second;
+    });
+
+    afterAll(async () => {
+      await Promise.all([firstPool?.end(), secondPool?.end()]);
+    });
+
+    it("allows only one concurrent application of the fresh execution plan", async () => {
+      const { first, second, plan } = await setup("review_concurrent_apply");
+      const results = await Promise.all([
+        applyMergePlan(first, plan),
+        applyMergePlan(second, plan),
+      ]);
+      expect(results.filter((result) => isOk(result))).toHaveLength(1);
+      const failure = results.find((result) => isErr(result));
+      expect(failure).toBeDefined();
+      expect(failure?.error).toBeInstanceOf(StaleMergePlanError);
+      expect(await first.nodes.Item.count()).toBe(1);
+    }, 20_000);
+
+    it("rechecks the fence after waiting for an in-flight writer and leaves no candidate writes", async () => {
+      const { first, second, plan } = await setup("review_waiting_apply");
+      const writerReady = createGate();
+      const releaseWriter = createGate();
+      const writing = second.transaction(async (tx) => {
+        await tx.nodes.Artifact.create({ content: "concurrent decision" });
+        writerReady.open();
+        await releaseWriter.opened;
+      });
+      try {
+        expect(await raceTimeout(writerReady.opened, 5000)).not.toBe(
+          TIMEOUT_SENTINEL,
+        );
+        const applying = applyMergePlan(first, plan);
+        try {
+          expect(await raceTimeout(applying, 200)).toBe(TIMEOUT_SENTINEL);
+        } finally {
+          releaseWriter.open();
+        }
+        await writing;
+        const afterWriter = await first.revisionNow();
+        const result = await applying;
+        if (!isErr(result)) throw new Error("Expected a stale-plan refusal");
+        expect(result.error).toBeInstanceOf(StaleMergePlanError);
+        expect(await first.nodes.Item.count()).toBe(0);
+        expect(await first.revisionNow()).toBe(afterWriter);
+      } finally {
+        releaseWriter.open();
+        await writing;
+      }
+    }, 20_000);
+  },
+);

--- a/packages/typegraph/tests/graph-merge/candidate-review.test.ts
+++ b/packages/typegraph/tests/graph-merge/candidate-review.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
+import { createLocalSqliteBackend } from "../../src/backend/sqlite/local";
+import {
+  asBranchId,
+  captureCandidateWriteSetTarget,
+  isErr,
+  MergePlanningStaleError,
+  MergeReviewError,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+  unwrap,
+} from "../../src/graph-merge";
+import { constructMergePlanArtifact } from "../../src/graph-merge/plan-wire";
+import {
+  reviewDigest,
+  reviewOptionEvidence,
+} from "../../src/graph-merge/review-evidence";
+import type { MergeReviewArtifact } from "../../src/graph-merge/review-schema";
+import { storeBackend } from "../../src/store/runtime-port";
+
+const Item = defineNode("Item", { schema: z.object({ name: z.string() }) });
+const Artifact = defineNode("Artifact", {
+  schema: z.object({ content: z.string() }),
+});
+const graph = defineGraph({
+  id: "candidate-review-unit",
+  nodes: { Item: { type: Item }, Artifact: { type: Artifact } },
+  edges: {},
+});
+const policy = { id: "review-policy-v1", context: {} } as const;
+
+const disposers: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  for (const dispose of disposers.splice(0)) await dispose();
+});
+
+async function setup() {
+  const { backend } = createLocalSqliteBackend();
+  disposers.push(() => backend.close());
+  const [target] = await createStoreWithSchema(graph, backend, {
+    history: true,
+  });
+  const makeBackend = async () => createLocalSqliteBackend().backend;
+  const writeSet = {
+    formatVersion: 1 as const,
+    sourceId: "source",
+    target: await captureCandidateWriteSetTarget(target),
+    nodes: [
+      {
+        kind: "Item",
+        id: "candidate",
+        properties: { name: "New" },
+        validFrom: "2026-01-01T00:00:00.000Z",
+      },
+    ],
+    edges: [],
+  };
+  const args = { target, makeBackend, writeSet, policy };
+  return { args, backend: storeBackend(target) };
+}
+
+async function rehash(
+  review: MergeReviewArtifact,
+): Promise<MergeReviewArtifact> {
+  const { digest: _digest, ...content } = review;
+  return {
+    ...content,
+    digest: { algorithm: "sha256", value: await reviewDigest(content) },
+  };
+}
+
+describe("candidate review wire and coherent capture", () => {
+  it("produces deterministic JSON evidence and validates it after persistence", async () => {
+    const { args } = await setup();
+    const first = unwrap(await planCandidateWriteSetReview(args));
+    const second = unwrap(await planCandidateWriteSetReview(args));
+    expect(second).toEqual(first);
+    const serialized = JSON.stringify(first);
+    await args.target.nodes.Artifact.create({ content: serialized });
+    const revalidated = unwrap(
+      await revalidateCandidateWriteSetReview({
+        ...args,
+        review: JSON.parse(serialized),
+      }),
+    );
+    expect(revalidated.status).toBe("compatible");
+    expect(revalidated.reviewDigest).toEqual(first.digest);
+    if (revalidated.status === "compatible")
+      expect(revalidated.plan.digest).not.toEqual(first.plan.digest);
+    expect(JSON.stringify(first)).toBe(serialized);
+  });
+
+  it.each([
+    "format",
+    "kind",
+    "digest",
+    "policy",
+    "missing-baseline",
+    "duplicate-baseline",
+    "input",
+    "anchors",
+    "plan-digest",
+    "unknown-input-field",
+  ])(
+    "refuses invalid or insufficient %s evidence before planning",
+    async (mutation) => {
+      const { args } = await setup();
+      const review = unwrap(await planCandidateWriteSetReview(args));
+      const changed: unknown = await mutateReview(review, mutation);
+      const makeBackend = vi.fn(args.makeBackend);
+      const result = await revalidateCandidateWriteSetReview({
+        ...args,
+        makeBackend,
+        review: changed,
+      });
+      expect(isErr(result)).toBe(true);
+      if (isErr(result)) expect(result.error).toBeInstanceOf(MergeReviewError);
+      expect(makeBackend).not.toHaveBeenCalled();
+      expect(await args.target.nodes.Item.count()).toBe(0);
+    },
+  );
+
+  it("refuses a mixed-revision baseline even when the inner planner sees a stable newer target", async () => {
+    const { args, backend } = await setup();
+    const findNodes = backend.findNodesByKind;
+    vi.spyOn(backend, "findNodesByKind").mockImplementationOnce(
+      async (query) => {
+        const rows = await findNodes(query);
+        await args.target.nodes.Artifact.create({
+          content: "write during baseline enumeration",
+        });
+        return rows;
+      },
+    );
+    const result = await planCandidateWriteSetReview(args);
+    expect(isErr(result)).toBe(true);
+    if (isErr(result))
+      expect(result.error).toBeInstanceOf(MergePlanningStaleError);
+    expect(await args.target.nodes.Item.count()).toBe(0);
+  });
+
+  it("refuses a write during revalidation baseline enumeration", async () => {
+    const { args, backend } = await setup();
+    const review = unwrap(await planCandidateWriteSetReview(args));
+    const findNodes = backend.findNodesByKind;
+    vi.spyOn(backend, "findNodesByKind").mockImplementationOnce(
+      async (query) => {
+        const rows = await findNodes(query);
+        await args.target.nodes.Artifact.create({
+          content: "write during revalidation",
+        });
+        return rows;
+      },
+    );
+    const result = await revalidateCandidateWriteSetReview({ ...args, review });
+    expect(isErr(result)).toBe(true);
+    if (isErr(result))
+      expect(result.error).toBeInstanceOf(MergePlanningStaleError);
+  });
+
+  it("rejects non-JSON policy context instead of silently dropping it", async () => {
+    const { args } = await setup();
+    const result = await planCandidateWriteSetReview({
+      ...args,
+      policy: { id: "opaque", context: undefined } as unknown as typeof policy,
+    });
+    expect(isErr(result)).toBe(true);
+    if (isErr(result)) expect(result.error).toBeInstanceOf(MergeReviewError);
+  });
+
+  it("records callback presence and canonical Map options without serializing closures", () => {
+    const canonical = () => {
+      throw new Error("evidence must not call policy");
+    };
+    expect(reviewOptionEvidence({ canonical })).not.toEqual(
+      reviewOptionEvidence(undefined),
+    );
+    expect(() => reviewOptionEvidence({ canonical })).not.toThrow();
+    expect(
+      reviewOptionEvidence({
+        provenanceWeights: new Map([
+          [asBranchId("a"), 1],
+          [asBranchId("b"), 2],
+        ]),
+      }),
+    ).toEqual(
+      reviewOptionEvidence({
+        provenanceWeights: new Map([
+          [asBranchId("b"), 2],
+          [asBranchId("a"), 1],
+        ]),
+      }),
+    );
+  });
+});
+
+async function mutateReview(
+  review: MergeReviewArtifact,
+  mutation: string,
+): Promise<unknown> {
+  switch (mutation) {
+    case "unknown-input-field": {
+      return {
+        ...review,
+        writeSet: { ...review.writeSet, unreviewedCondition: true },
+      };
+    }
+    case "format": {
+      return { ...review, formatVersion: 99 };
+    }
+    case "kind": {
+      return { ...review, kind: "snapshot" };
+    }
+    case "digest": {
+      return { ...review, policy: { ...policy, id: "changed" } };
+    }
+    case "policy": {
+      return { ...review, policy: { id: "missing-context" } };
+    }
+    case "missing-baseline": {
+      return rehash({ ...review, baseline: { ...review.baseline, rows: [] } });
+    }
+    case "duplicate-baseline": {
+      return rehash({
+        ...review,
+        baseline: {
+          ...review.baseline,
+          rows: [...review.baseline.rows, ...review.baseline.rows],
+        },
+      });
+    }
+    case "input": {
+      return rehash({
+        ...review,
+        writeSet: { ...review.writeSet, sourceId: "other-source" },
+      });
+    }
+    case "anchors": {
+      const { digest: _digest, ...plan } = review.plan;
+      return rehash({
+        ...review,
+        plan: await constructMergePlanArtifact({
+          ...plan,
+          anchors: {
+            ...plan.anchors,
+            branches: [{ branchId: "source", baseVersion: "other" }],
+          },
+        }),
+      });
+    }
+    case "plan-digest": {
+      return rehash({
+        ...review,
+        plan: {
+          ...review.plan,
+          digest: { algorithm: "sha256", value: "0".repeat(64) },
+        },
+      });
+    }
+    default: {
+      throw new Error(`Unknown mutation: ${mutation}`);
+    }
+  }
+}


### PR DESCRIPTION
Persisting a merge plan or its approval in the target graph advances the revision and correctly makes that execution plan stale. Add `planCandidateWriteSetReview()` and `revalidateCandidateWriteSetReview()` so applications can persist immutable review evidence, commit approval records, and then obtain a fresh execution plan related explicitly to that review.

The versioned, digest-checked review retains the candidate input, original plan, policy identity/context, normalized option evidence, and target baseline. Revalidation requires unchanged original rows, expected absences, and archival identity evidence, then replans through the existing candidate pipeline and compares the complete resolved result. It returns structured compatible, changed, or incompatible outcomes. This detects changed transitions even when both plans propose the same assignment, and guards implicit identity changes caused by inserting another kind with an existing ID. Unknown, malformed, or incomplete evidence is refused.

V1 supports candidate write sets and deliberately uses a conservative whole-target baseline; updating an existing audit record also requires new review. New records receive no exemption from planning or constraint checks. Applications remain responsible for authenticating evidence, supplying opaque policy/callback dependency versions, and deciding whether approval is still valid. `applyMergePlan()` retains its existing transactional revision fence and atomic write behavior. Documentation and a runnable example cover same-graph review/approval persistence and the separate, non-atomic execution receipt boundary.

The regression checks were verified by temporarily disabling the baseline comparison and observing the changed-value case incorrectly become compatible, and by disabling the apply revision check and observing both independent-session PostgreSQL concurrency cases fail. Both protections were restored and the cases passed.

Closes #612
