### PR TITLE
ci: run pull-request checks for every base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Every pull request, whatever its base: a stacked PR targets the branch
+  # beneath it and would otherwise run no checks until that branch merges.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
The `pull_request` trigger was filtered to `main`, so a stacked PR that targets the branch beneath it (today: #617 on #607) runs no checks until that branch merges and GitHub retargets it. This removes the base filter; pushes still trigger only on `main`. Once merged, a push to a stacked branch (or closing and reopening its PR) starts its checks.