### PR TITLE
ci: reduce database fixture overhead and duplicate backend runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run unit tests
+        env:
+          TYPEGRAPH_LIBSQL_TMPDIR: /dev/shm
         run: pnpm turbo run test:unit -- --shard=${{ matrix.shard }}
 
   test-sqlite-property:
@@ -223,6 +225,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run coverage shard
+        env:
+          TYPEGRAPH_LIBSQL_TMPDIR: /dev/shm
         run: >-
           pnpm --filter @nicia-ai/typegraph exec vitest run --coverage
           --shard=${{ matrix.shard }}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -80,6 +80,14 @@ whole schema (including strategy-owned indexes) and resets session settings
 before returning the engine to the pool. The file's `afterAll` closes the pool.
 Keep this lifecycle when adding cases to these suites.
 
+The libSQL adapter and integration suite uses temporary database files. CI sets
+`TYPEGRAPH_LIBSQL_TMPDIR=/dev/shm` for unit and coverage jobs, placing these
+disposable files on the Linux runner's RAM-backed filesystem. This preserves
+file-client behavior, close/reopen persistence, and default journal/synchronous
+settings while avoiding variable disk flush latency. Locally the suite defaults
+to the OS temporary directory; the override must name an existing directory.
+It affects only this suite's database files, not other tools' temporary files.
+
 The **adapter test suite** (`adapter-test-suite.ts`) defines a shared contract that all backends must satisfy:
 
 ```typescript

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -72,7 +72,8 @@ Location: `packages/typegraph/tests/backends/`
 
 Tests that exercise complete workflows with real database backends.
 
-The identity-universe, incremental-merge, and ingestion-branch suites reuse idle
+The identity-universe, incremental-merge, ingestion-branch, identity-merge,
+provenance-store, and identity-law property suites reuse idle
 PGlite engines through `tests/graph-merge/pglite-fixture-pool.ts`. Every live
 fixture still owns a separate engine, so base and branch transactions remain
 independent. Each lease creates a fresh backend and schema; cleanup drops the
@@ -180,6 +181,17 @@ PostgreSQL example runner intentionally uses `POSTGRES_URL` so it can exercise
 the same caller-supplied connection configuration shown to users.
 
 ### Per-suite PostgreSQL databases
+
+`pnpm test:postgres` selects the server-only graph-merge matrix with
+`TYPEGRAPH_TEST_BACKEND=postgres` and excludes the dedicated `pglite-*.test.ts`
+files. SQLite and PGlite still run in the normal unit/property/coverage lanes.
+Mixed-backend files remain loaded so their server-specific cases are retained.
+The lane coverage guard checks exclusions as well as file inclusion, and allows
+excluded files only when the default PGlite project collects them.
+
+Direct Vitest runs with `POSTGRES_URL` still include all three merge backends
+unless the selector is set. Selecting `postgres` without a URL, or supplying an
+unknown selector, fails immediately instead of silently dropping test coverage.
 
 Every server-PostgreSQL suite owns the graph tables it operates on: `beforeEach`
 hooks `TRUNCATE` them, `beforeAll` hooks re-run the migration SQL, and a few

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,6 +81,12 @@ whole schema (including strategy-owned indexes) and resets session settings
 before returning the engine to the pool. The file's `afterAll` closes the pool.
 Keep this lifecycle when adding cases to these suites.
 
+The PGlite integration suite also uses this pool for physically isolated merge
+branches and review targets. Its primary fixture still shares one engine and
+resets data before each test; serialized-backend tests intentionally use that
+primary engine. Isolated fixtures are released by the shared integration suite's
+cleanup hook, and the file closes both the primary engine and pool at completion.
+
 The libSQL adapter and integration suite uses temporary database files. CI sets
 `TYPEGRAPH_LIBSQL_TMPDIR=/dev/shm` for unit and coverage jobs, placing these
 disposable files on the Linux runner's RAM-backed filesystem. This preserves

--- a/packages/typegraph/scripts/test-postgres.sh
+++ b/packages/typegraph/scripts/test-postgres.sh
@@ -87,6 +87,7 @@ echo "Running PostgreSQL tests ($MAX_WORKERS workers)..."
 vitest_args=(
   run
   --maxWorkers="$MAX_WORKERS"
+  --exclude=tests/backends/postgres/pglite-*.test.ts
 )
 
 # GitHub's non-TTY default reporter prints every successful test, and expected
@@ -129,4 +130,6 @@ vitest_args+=(
   tests/perf/identity-historical-traversal-scaling.test.ts
 )
 
-POSTGRES_URL="$POSTGRES_URL" vitest "${vitest_args[@]}"
+# PGlite-only files and local merge-matrix entries already run in the default
+# lanes. Keep mixed files loaded so their server-specific cases still execute.
+TYPEGRAPH_TEST_BACKEND=postgres POSTGRES_URL="$POSTGRES_URL" vitest "${vitest_args[@]}"

--- a/packages/typegraph/tests/backends/postgres/pglite-integration-suite.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-integration-suite.test.ts
@@ -13,15 +13,16 @@
  */
 import { afterAll, beforeAll, beforeEach } from "vitest";
 
-import { createLocalPgliteBackend } from "../../../src/backend/postgres/pglite";
 import { sql } from "../../../src/query/sql-fragment";
 import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { createPgliteFixturePool } from "../../graph-merge/pglite-fixture-pool";
 import { createIntegrationTestSuite } from "../integration-test-suite";
 import {
   setupSharedPgliteEngine,
   type SharedPgliteEngine,
 } from "./pglite-correctness-harness";
 
+const isolatedPool = createPgliteFixturePool();
 let engine: SharedPgliteEngine;
 
 beforeAll(async () => {
@@ -29,20 +30,23 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  const leakedWorkingTables = await engine.makeBackend().execute(
-    asCompiledRowsSql(sql`
-      SELECT relation.relname
-      FROM pg_catalog.pg_class relation
-      WHERE relation.relpersistence = 't'
-        AND relation.relname LIKE 'typegraph_iterative_%'
-    `),
-  );
-  if (leakedWorkingTables.length > 0) {
-    throw new Error(
-      `Iterative graph operations leaked temporary tables: ${JSON.stringify(leakedWorkingTables)}`,
+  try {
+    const leakedWorkingTables = await engine.makeBackend().execute(
+      asCompiledRowsSql(sql`
+        SELECT relation.relname
+        FROM pg_catalog.pg_class relation
+        WHERE relation.relpersistence = 't'
+          AND relation.relname LIKE 'typegraph_iterative_%'
+      `),
     );
+    if (leakedWorkingTables.length > 0) {
+      throw new Error(
+        `Iterative graph operations leaked temporary tables: ${JSON.stringify(leakedWorkingTables)}`,
+      );
+    }
+  } finally {
+    await Promise.all([engine.dispose(), isolatedPool.dispose()]);
   }
-  await engine.dispose();
 });
 
 // The integration suite builds the store in its own `beforeEach`, so the
@@ -71,9 +75,8 @@ createIntegrationTestSuite(
       }),
   }),
   {
-    createIsolatedBackend: async () => {
-      const { backend } = await createLocalPgliteBackend();
-      return { backend, cleanup: () => backend.close() };
-    },
+    // Branches and review targets need independent transactions. Reuse an
+    // engine only after its fixture schema has been dropped at test cleanup.
+    createIsolatedBackend: () => isolatedPool.makeFixture(),
   },
 );

--- a/packages/typegraph/tests/backends/sqlite/libsql-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/libsql-backend.test.ts
@@ -42,12 +42,15 @@ const concurrencyGraph = defineGraph({
 // (In-memory databases also work — local clients frame transactions with raw
 // BEGIN/COMMIT instead of client.transaction(), which would abandon the
 // connection: tursodatabase/libsql-client-ts#229 — see the specific tests.)
+// CI uses a RAM-backed directory for these disposable files. Keep file-client
+// semantics and default SQLite pragmas without paying the runner's disk fsync
+// latency on every schema statement and autocommit write.
 
 const temporaryFiles: string[] = [];
 
 function createTemporaryDbPath(): string {
   const dbPath = path.join(
-    tmpdir(),
+    process.env["TYPEGRAPH_LIBSQL_TMPDIR"] ?? tmpdir(),
     `typegraph-libsql-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.db`,
   );
   temporaryFiles.push(dbPath);
@@ -117,6 +120,33 @@ createIntegrationTestSuite("libsql", async () => {
 // ============================================================
 
 describe("libsql Backend - Specific", () => {
+  it("preserves committed data when a fixture file is closed and reopened", async () => {
+    const dbPath = createTemporaryDbPath();
+    const client = createClient({ url: `file:${dbPath}` });
+    try {
+      await client.execute("CREATE TABLE fixture_probe (value TEXT)");
+      await client.execute("INSERT INTO fixture_probe VALUES ('committed')");
+    } finally {
+      client.close();
+    }
+
+    const reopened = createClient({ url: `file:${dbPath}` });
+    try {
+      expect(reopened.protocol).toBe("file");
+      expect(
+        (await reopened.execute("SELECT value FROM fixture_probe")).rows,
+      ).toEqual([{ value: "committed" }]);
+      expect((await reopened.execute("PRAGMA synchronous")).rows).toEqual([
+        { synchronous: 2 },
+      ]);
+      expect((await reopened.execute("PRAGMA journal_mode")).rows).toEqual([
+        { journal_mode: "delete" },
+      ]);
+    } finally {
+      reopened.close();
+    }
+  });
+
   it("exposes the Drizzle database instance", async () => {
     const client = createClient({ url: "file::memory:" });
     const { backend, db } = await createLibsqlBackend(client);

--- a/packages/typegraph/tests/backends/sqlite/libsql-backend.test.ts
+++ b/packages/typegraph/tests/backends/sqlite/libsql-backend.test.ts
@@ -133,15 +133,14 @@ describe("libsql Backend - Specific", () => {
     const reopened = createClient({ url: `file:${dbPath}` });
     try {
       expect(reopened.protocol).toBe("file");
-      expect(
-        (await reopened.execute("SELECT value FROM fixture_probe")).rows,
-      ).toEqual([{ value: "committed" }]);
-      expect((await reopened.execute("PRAGMA synchronous")).rows).toEqual([
-        { synchronous: 2 },
-      ]);
-      expect((await reopened.execute("PRAGMA journal_mode")).rows).toEqual([
-        { journal_mode: "delete" },
-      ]);
+      const persisted = await reopened.execute(
+        "SELECT value FROM fixture_probe",
+      );
+      const synchronous = await reopened.execute("PRAGMA synchronous");
+      const journalMode = await reopened.execute("PRAGMA journal_mode");
+      expect(persisted.rows).toEqual([{ value: "committed" }]);
+      expect(synchronous.rows).toEqual([{ synchronous: 2 }]);
+      expect(journalMode.rows).toEqual([{ journal_mode: "delete" }]);
     } finally {
       reopened.close();
     }

--- a/packages/typegraph/tests/graph-merge/identity-merge.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-merge.test.ts
@@ -6,7 +6,7 @@ import {
   disjointWith,
   subClassOf,
 } from "@nicia-ai/typegraph";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
@@ -46,6 +46,7 @@ import type { BranchId } from "../../src/graph-merge/types";
 import { asBranchId } from "../../src/graph-merge/types";
 import { storeRuntime } from "../../src/store/runtime-port";
 import { requireDefined } from "../../src/utils/presence";
+import { createPgliteFixturePool } from "./pglite-fixture-pool";
 import { backendMatrix, getStoreBackend } from "./test-utils";
 
 const Person = defineNode("Person", {
@@ -100,6 +101,11 @@ function narrowedAssertionWarning(assertionId: string): string {
   return `Identity assertion ${JSON.stringify(assertionId)} was narrowed from [2020-01-01T00:00:00.000Z, open) to [2022-01-01T00:00:00.000Z, open) to fit its remapped endpoint windows.`;
 }
 
+const pglitePool = createPgliteFixturePool();
+afterAll(async () => {
+  await pglitePool.dispose();
+});
+
 describe.each(backendMatrix())("identity merge [$name]", (entry) => {
   let cleanups: (() => Promise<void>)[];
 
@@ -112,7 +118,10 @@ describe.each(backendMatrix())("identity merge [$name]", (entry) => {
   });
 
   async function makeBackend(): Promise<GraphBackend> {
-    const fixture = await entry.make();
+    const fixture =
+      entry.name === "PGlite" ?
+        await pglitePool.makeFixture()
+      : await entry.make();
     cleanups.push(fixture.cleanup);
     return fixture.backend;
   }

--- a/packages/typegraph/tests/graph-merge/pglite-fixture-pool.ts
+++ b/packages/typegraph/tests/graph-merge/pglite-fixture-pool.ts
@@ -7,13 +7,13 @@ import {
 import { generatePostgresMigrationSQL } from "../../src/backend/drizzle/ddl";
 import { tables as defaultTables } from "../../src/backend/drizzle/postgres";
 
-export type PgliteFixture = Readonly<{
-  backend: ReturnType<typeof createPostgresBackend>;
-  cleanup: () => Promise<void>;
-}>;
-
 export type PgliteFixturePool = Readonly<{
-  makeFixture: () => Promise<PgliteFixture>;
+  makeFixture: () => Promise<
+    Readonly<{
+      backend: ReturnType<typeof createPostgresBackend>;
+      cleanup: () => Promise<void>;
+    }>
+  >;
   dispose: () => Promise<void>;
 }>;
 

--- a/packages/typegraph/tests/graph-merge/pglite-fixture-pool.ts
+++ b/packages/typegraph/tests/graph-merge/pglite-fixture-pool.ts
@@ -6,10 +6,14 @@ import {
 
 import { generatePostgresMigrationSQL } from "../../src/backend/drizzle/ddl";
 import { tables as defaultTables } from "../../src/backend/drizzle/postgres";
-import type { MergeBackendFixture } from "./test-utils";
+
+export type PgliteFixture = Readonly<{
+  backend: ReturnType<typeof createPostgresBackend>;
+  cleanup: () => Promise<void>;
+}>;
 
 export type PgliteFixturePool = Readonly<{
-  makeFixture: () => Promise<MergeBackendFixture>;
+  makeFixture: () => Promise<PgliteFixture>;
   dispose: () => Promise<void>;
 }>;
 

--- a/packages/typegraph/tests/graph-merge/provenance-store.test.ts
+++ b/packages/typegraph/tests/graph-merge/provenance-store.test.ts
@@ -67,7 +67,7 @@ import {
   defineGraph,
   defineNode,
 } from "@nicia-ai/typegraph";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import {
@@ -97,6 +97,7 @@ import {
   asCompiledStatementSql,
 } from "../../src/query/sql-intent";
 import { requireDefined } from "../../src/utils/presence";
+import { createPgliteFixturePool } from "./pglite-fixture-pool";
 import { backendMatrix, getBackendProperty } from "./test-utils";
 
 const Patient = defineNode("Patient", {
@@ -504,6 +505,11 @@ type Fixture = Readonly<{
   branches: readonly GraphBranch<CareGraph>[];
 }>;
 
+const pglitePool = createPgliteFixturePool();
+afterAll(async () => {
+  await pglitePool.dispose();
+});
+
 describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
   let cleanups: (() => Promise<void>)[] = [];
 
@@ -515,7 +521,10 @@ describe.each(backendMatrix())("provenance persistence [$name]", (entry) => {
   });
 
   async function makeBackend(): Promise<GraphBackend> {
-    const fixture = await entry.make();
+    const fixture =
+      entry.name === "PGlite" ?
+        await pglitePool.makeFixture()
+      : await entry.make();
     cleanups.push(fixture.cleanup);
     return fixture.backend;
   }

--- a/packages/typegraph/tests/graph-merge/test-utils.test.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.test.ts
@@ -8,7 +8,7 @@ import {
   TypeGraphError,
   UniquenessError,
 } from "@nicia-ai/typegraph";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import {
@@ -45,6 +45,48 @@ const graph = defineGraph({
   id: "merge-test-utils",
   nodes: { Person: { type: Person } },
   edges: {},
+});
+
+describe("backend matrix selection", () => {
+  beforeEach(() => {
+    vi.stubEnv("POSTGRES_URL", undefined);
+    vi.stubEnv("TYPEGRAPH_TEST_BACKEND", undefined);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("keeps both local backends in the default lane", () => {
+    expect(backendMatrix().map((entry) => entry.name)).toEqual([
+      "SQLite",
+      "PGlite",
+    ]);
+  });
+  it("adds the server when a URL is supplied without a selector", () => {
+    vi.stubEnv("POSTGRES_URL", "postgresql://localhost/test");
+    expect(backendMatrix().map((entry) => entry.name)).toEqual([
+      "SQLite",
+      "PGlite",
+      "Postgres",
+    ]);
+  });
+  it("selects only the server for the dedicated lane", () => {
+    vi.stubEnv("POSTGRES_URL", "postgresql://localhost/test");
+    vi.stubEnv("TYPEGRAPH_TEST_BACKEND", "postgres");
+    expect(backendMatrix().map((entry) => entry.name)).toEqual(["Postgres"]);
+  });
+  it.each([undefined, ""])(
+    "refuses server selection without a URL (%s)",
+    (url) => {
+      vi.stubEnv("POSTGRES_URL", url);
+      vi.stubEnv("TYPEGRAPH_TEST_BACKEND", "postgres");
+      expect(() => backendMatrix()).toThrow("requires POSTGRES_URL");
+    },
+  );
+  it("refuses an unknown selector", () => {
+    vi.stubEnv("TYPEGRAPH_TEST_BACKEND", "typo");
+    expect(() => backendMatrix()).toThrow("Unsupported TYPEGRAPH_TEST_BACKEND");
+  });
 });
 
 describe("graph-merge Result module", () => {

--- a/packages/typegraph/tests/graph-merge/test-utils.ts
+++ b/packages/typegraph/tests/graph-merge/test-utils.ts
@@ -35,18 +35,20 @@ export function getBackendProperty(
 /**
  * Backend test fixtures for the graph-merge suite.
  *
- * Two backends run fully in-process and ALWAYS run under plain `pnpm test`:
+ * Two backends run fully in-process under plain `pnpm test`:
  * SQLite via better-sqlite3 (`createLocalSqliteBackend`) and Postgres via
  * PGlite + pgvector (`createLocalPgliteBackend`) — no Docker, no
  * `POSTGRES_URL`, no 5432 dependency.
  *
- * When `POSTGRES_URL` IS set (the `pnpm test:postgres` lane), a third entry
- * runs every suite against the real server-Postgres backend (node-postgres
+ * When `POSTGRES_URL` IS set, a third entry runs every suite against the real
+ * server-Postgres backend (node-postgres
  * `Pool` + Drizzle) — the production driver and transaction wiring PGlite
  * cannot exercise. Each fixture gets its own throwaway schema on the shared
  * server (merge fixtures must be EMPTY and several live simultaneously per
  * test: a base plus its branches), created on `make()` and dropped by
  * `cleanup()`.
+ * The `test:postgres` script selects only that server entry; the normal unit,
+ * property and coverage lanes retain SQLite and PGlite.
  */
 
 /**
@@ -359,13 +361,28 @@ export type BackendMatrixEntry = Readonly<{
 }>;
 
 /**
- * Returns the backend matrix. The in-process SQLite and PGlite entries always
- * run; the server-Postgres entry (production `pg` driver over Docker/CI
- * Postgres) joins only when `POSTGRES_URL` is set — the `pnpm test:postgres`
- * lane. SQLite's synchronous factory is wrapped so every entry shares the
- * async `make()` signature.
+ * Returns the default local matrix, adding the server when POSTGRES_URL is
+ * set. TYPEGRAPH_TEST_BACKEND=postgres selects only the server for the dedicated
+ * lane and refuses to run without a URL. SQLite's synchronous factory is
+ * wrapped so every entry shares the async make() signature.
  */
 export function backendMatrix(): readonly BackendMatrixEntry[] {
+  const selectedBackend = process.env["TYPEGRAPH_TEST_BACKEND"];
+  if (selectedBackend !== undefined && selectedBackend !== "postgres") {
+    throw new Error(`Unsupported TYPEGRAPH_TEST_BACKEND: ${selectedBackend}`);
+  }
+  const postgresUrl = process.env["POSTGRES_URL"];
+  if (selectedBackend === "postgres") {
+    if (postgresUrl === undefined || postgresUrl === "") {
+      throw new Error("TYPEGRAPH_TEST_BACKEND=postgres requires POSTGRES_URL");
+    }
+    return [
+      {
+        name: "Postgres",
+        make: () => createServerPostgresMergeBackend(postgresUrl),
+      },
+    ];
+  }
   const entries: BackendMatrixEntry[] = [
     {
       name: "SQLite",
@@ -376,7 +393,6 @@ export function backendMatrix(): readonly BackendMatrixEntry[] {
       make: () => createPgliteMergeBackend(),
     },
   ];
-  const postgresUrl = process.env["POSTGRES_URL"];
   if (postgresUrl !== undefined && postgresUrl !== "") {
     entries.push({
       name: "Postgres",

--- a/packages/typegraph/tests/postgres-lane-coverage.test.ts
+++ b/packages/typegraph/tests/postgres-lane-coverage.test.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { requireDefined } from "../src/utils/presence";
+import { PGLITE_GLOBS } from "../vitest.pglite-project";
 
 const PACKAGE_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -95,12 +96,42 @@ function isCoveredByLane(
   file: string,
   laneTargets: readonly string[],
 ): boolean {
-  return laneTargets.some((target) =>
-    target.endsWith("/") ? file.startsWith(target) : file === target,
+  const excluded = readLaneExclusions().some((pattern) =>
+    path.matchesGlob(file, pattern),
+  );
+  return (
+    !excluded &&
+    laneTargets.some((target) =>
+      target.endsWith("/") ? file.startsWith(target) : file === target,
+    )
+  );
+}
+
+function readLaneExclusions(): readonly string[] {
+  const script = readFileSync(
+    path.join(PACKAGE_ROOT, LANE_SCRIPT_RELATIVE_PATH),
+    "utf8",
+  );
+  return [...script.matchAll(/^\s*--exclude=(\S+)\s*$/gm)].map((match) =>
+    requireDefined(match[1]),
   );
 }
 
 describe("test:postgres lane coverage", () => {
+  it("excludes only files collected by the default PGlite project", () => {
+    const exclusions = readLaneExclusions();
+    expect(exclusions.length).toBeGreaterThan(0);
+    const excluded = listTestFiles().filter((file) =>
+      exclusions.some((pattern) => path.matchesGlob(file, pattern)),
+    );
+    expect(excluded.length).toBeGreaterThan(0);
+    expect(
+      excluded.filter(
+        (file) =>
+          !PGLITE_GLOBS.some((pattern) => path.matchesGlob(file, pattern)),
+      ),
+    ).toEqual([]);
+  });
   it("runs every suite that provisions a PostgreSQL database", () => {
     const laneTargets = readLaneTargets();
     const suites = suitesWithPostgresLeg();

--- a/packages/typegraph/tests/property/graph-merge/identity-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/identity-laws.test.ts
@@ -64,7 +64,7 @@ import {
   defineNode,
 } from "@nicia-ai/typegraph";
 import fc from "fast-check";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { asEdgeId, asNodeId } from "../../../src/core/types";
@@ -96,6 +96,7 @@ import { importGraph } from "../../../src/interchange";
 import { storeBackend, storeRuntime } from "../../../src/store/runtime-port";
 import { canonicalizeDatabaseTimestamp } from "../../../src/utils/date";
 import { requireDefined } from "../../../src/utils/presence";
+import { createPgliteFixturePool } from "../../graph-merge/pglite-fixture-pool";
 import { backendMatrix } from "../../graph-merge/test-utils";
 
 const Agent = defineNode("Agent", {
@@ -1279,10 +1280,13 @@ async function expectLawfulOutcome(args: {
   }
 }
 
-// Per-fixture backends (no shared PGlite engine): the shared engine renames
-// only the CORE table set, so an identity-enabled graph would provision its
-// assertion/closure tables under the default names once per engine — leaking
-// ledger rows across property iterations.
+// Each property iteration releases whole fixture schemas, including identity
+// ledgers. Live branches keep separate engines and independent transactions.
+const pglitePool = createPgliteFixturePool();
+afterAll(async () => {
+  await pglitePool.dispose();
+});
+
 describe.each(backendMatrix())("identity merge laws [$name]", (entry) => {
   type Fixture = Readonly<{
     forkPoint: Store<LawGraph>;
@@ -1371,7 +1375,10 @@ describe.each(backendMatrix())("identity merge laws [$name]", (entry) => {
         fc.asyncProperty(snapshotScenarioArb(lane.ops), async (scenario) => {
           const cleanups: (() => Promise<void>)[] = [];
           async function makeBackend(): Promise<GraphBackend> {
-            const fixture = await entry.make();
+            const fixture =
+              entry.name === "PGlite" ?
+                await pglitePool.makeFixture()
+              : await entry.make();
             cleanups.push(fixture.cleanup);
             return fixture.backend;
           }
@@ -1430,10 +1437,9 @@ describe.each(backendMatrix())("identity merge laws [$name]", (entry) => {
           numRuns: LAW_RUNS,
         },
       );
-      // Coverage-instrumented CI shards run each PGlite boot several times
-      // slower than a bare run; the default 60s test timeout is not sized
-      // for LAW_RUNS × per-iteration store fixtures (same allowance as
-      // merge-laws.test.ts).
+      // Coverage instrumentation and property shrinking can multiply the
+      // per-iteration workload even with pooled engines. Keep the extended
+      // law-suite timeout (same allowance as merge-laws.test.ts).
     }, 300_000);
   }
 
@@ -1443,7 +1449,10 @@ describe.each(backendMatrix())("identity merge laws [$name]", (entry) => {
       fc.asyncProperty(incrementalScenarioArb, async (scenario) => {
         const cleanups: (() => Promise<void>)[] = [];
         async function makeBackend(): Promise<GraphBackend> {
-          const fixture = await entry.make();
+          const fixture =
+            entry.name === "PGlite" ?
+              await pglitePool.makeFixture()
+            : await entry.make();
           cleanups.push(fixture.cleanup);
           return fixture.backend;
         }

--- a/turbo.json
+++ b/turbo.json
@@ -12,11 +12,13 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["TYPEGRAPH_LIBSQL_TMPDIR"]
     },
     "test:unit": {
       "dependsOn": ["^build"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["TYPEGRAPH_LIBSQL_TMPDIR"]
     },
     "test:property": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Coverage shard 2 spent 19m30s in the libSQL adapter/integration file, extending the job to 26m25s while the other coverage shards finished in 8m40s–11m54s. The same file took 96 seconds in the preceding run. Its disposable file databases repeatedly flush schema changes and autocommit writes to the runner disk.

Place this suite’s temporary database files on `/dev/shm` in GitHub-hosted unit and coverage jobs. The `TYPEGRAPH_LIBSQL_TMPDIR` override reaches both Turbo test tasks; local runs keep the OS temporary directory by default. Keep file-client behavior, fresh per-test databases, normal cleanup, and default SQLite journal/synchronous settings.

A Linux Node 24 probe using the installed libSQL client version and 500 autocommit inserts took 951–964ms on disk versus 15ms on tmpfs across two repetitions, with `synchronous=FULL` and `journal_mode=DELETE` in both cases. The subsequent GitHub-hosted run measured the full libSQL file at 40.56 seconds (previously 1,169.80 seconds), coverage shard 2 at 9m01s (previously 26m25s), and the slowest remaining coverage shard at 11m22s. All test and coverage jobs passed; these are single-run measurements, so runner variability still applies.

Add a close/reopen persistence assertion to protect the fixture semantics. Replacing its file path with an in-memory database makes the assertion fail because the reopened database has no table.

Reuse isolated PGlite engines in identity-merge, provenance-store, and identity-law property suites. Each live fixture keeps its own engine and each lease gets a fresh backend and schema, including identity ledgers; property iterations release their fixtures before reuse. The same three suites, using the CI property-run budget with coverage, took 140.04 seconds of test time before and 24.45 seconds after locally (153 passing tests in each run).

Select only server-PostgreSQL entries in the dedicated lane’s shared graph-merge matrix and exclude dedicated PGlite files already covered by the default project. Mixed-backend files remain loaded. Direct Vitest runs with POSTGRES_URL retain the full matrix unless TYPEGRAPH_TEST_BACKEND=postgres is selected; missing URLs and unknown selectors fail immediately. The graph-merge collection drops from 1,263 to 605 cases in the server lane, with every original case retained in the union of the local and server inventories.

Extend the PostgreSQL lane coverage guard to account for exclusions and verify that excluded files are covered by the default PGlite project. Broadening the exclusion to all PostgreSQL backend files makes both the server-coverage and default-project assertions fail. Disabling the server-only selection branch likewise makes the matrix-selection assertions fail; restoring it returns them to green.

Reuse the same isolated-engine pool for the PGlite integration suite’s merge branches and review targets. Profiling found 34 isolated-engine boots consumed 21.70 seconds of a 69.82-second local coverage run, despite the primary fixture already sharing an engine. Pooling those isolated fixtures reduced test time to 52.91 seconds with the same 845 passing cases and one skip. The primary and serialized fixtures retain their shared engine, and final cleanup closes both resource owners even if the temporary-table leak assertion fails. The subsequent hosted run measured the integration file at 98.24 seconds (previously 174.62 seconds), coverage shard 3 at 6m27s (previously 9m01s), and total job span at 9m35s (previously 9m56s); coverage shard 1 became the critical path at 8m49s. These single-run comparisons include runner variability.
