### PR TITLE
refactor(backend): resolve the extension-install lock through the fence plan

### DIFF
--- a/.changeset/extension-ddl-fence.md
+++ b/.changeset/extension-ddl-fence.md
@@ -1,0 +1,5 @@
+---
+"@nicia-ai/typegraph": patch
+---
+
+The PostgreSQL backend's database-extension install now resolves the write-fence plan and spells its advisory lock through the backend's `fenceSql`, like every other lock site, instead of hardcoding `pg_advisory_xact_lock(hashtext(...), 0)` inline. A custom or derived PostgreSQL profile whose resolved plan is `engine-serialized` or `unfenced` installs extensions without taking that lock and relies solely on the duplicate-key retry, which was already the fence's correctness owner in that case. The bundled PostgreSQL backend's behavior and emitted SQL are unchanged.

--- a/packages/typegraph/src/backend/drizzle/postgres-fence-sql.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres-fence-sql.ts
@@ -4,10 +4,11 @@
  * `pg_advisory_xact_lock`, `hashtext(`, `LOCK TABLE`, or
  * `current_setting('transaction_isolation')` itself. The lock-fence inventory
  * test ratchets those tokens out of the lock-site files, including trusted
- * import's table lock, which now resolves the same plan every other lock
- * site does and consumes `fence.sql.lockTables(...)` instead of spelling
- * `LOCK TABLE` itself; only the PostgreSQL profile's extension-DDL lock
- * still spells its own and is outside that ratchet.
+ * import's table lock and the PostgreSQL profile's extension-DDL lock, both
+ * of which now resolve the same plan every other lock site does and consume
+ * `fence.sql.lockTables(...)` / `fence.sql.advisoryLock(...)` instead of
+ * spelling `LOCK TABLE` / `pg_advisory_xact_lock` themselves — this module is
+ * the only one left spelling any of these four tokens.
  *
  * Built from `SqlFragment` (`../../query/sql-fragment`), not `drizzle-orm`,
  * so this module stays outside the Drizzle zone and is safe to import from

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -117,6 +117,7 @@ import {
   registerFirstPartyProfile,
   requireWriteFence,
   resolveWriteFencePlan,
+  type WriteFencePlan,
   type WriteFenceTarget,
 } from "../capabilities/write-fence";
 import { deriveBackend } from "../derive-backend";
@@ -1094,26 +1095,36 @@ export function buildPostgresEngineProfile(
    * objects still race on `pg_extension_name_index`. Two fences answer that,
    * and both are here because they answer different halves of it:
    *
-   *  - the advisory lock serializes same-key installers inside this process
-   *    group so the common case never raises at all (#475). It is keyed on the
-   *    extension so installing `vector` does not queue behind `pg_trgm`;
+   *  - the resolved write-fence plan's advisory lock — spelled through
+   *    `fencePlan.sql.advisoryLock`, like every other lock site, rather than
+   *    inline — serializes same-key installers inside this process group so
+   *    the common case never raises at all (#475). It is keyed on the
+   *    extension so installing `vector` does not queue behind `pg_trgm`. This
+   *    is the one lock site that DEGRADES instead of refusing: a plan that
+   *    resolves `engine-serialized` or `unfenced` takes no lock and falls
+   *    through to the same retry-only path as the non-interactive branch
+   *    below, because the retry — not the lock — is what makes a concurrent
+   *    install correct;
    *  - {@link withConcurrentCreateRetry} clears the 23505 an installer that did
-   *    NOT take this lock can still hand us — a peer on an older version, whose
-   *    lock key differs, or a `capabilities.execution.interactiveTransactions: false` backend which
-   *    has no transaction to hang a `pg_advisory_xact_lock` on (#446).
+   *    NOT take the lock can still hand us — a peer on an older version, whose
+   *    lock key differs, a `capabilities.execution.interactiveTransactions: false`
+   *    backend which has no transaction to hang the lock on (#446), or a
+   *    backend whose resolved plan takes no lock at all.
    *
    * The lock runs in its own transaction on purpose: a 23505 poisons an
    * enclosing transaction (the next statement fails `25P02`), so the retry is
    * sound only when the failed unit of work is one this function owns
    * end-to-end.
    */
-  // Takes `capabilities` explicitly rather than closing over a head-level
-  // constant: this backend's finalized capabilities are `createSqlBackend`'s
+  // Takes `capabilities` and `fencePlan` explicitly rather than closing over
+  // head-level constants: this backend's finalized capabilities and its
+  // resolved write-fence plan are `createSqlBackend`'s
   // (`EngineOperationsContext.capabilities` / `EngineAssemblyContext
-  // .capabilities`), and this function's only caller — `lateMembers.extensions`
-  // — already has that value on `ctx`.
+  // .fencePlan`), and this function's only caller — `lateMembers.extensions`
+  // — already has both values on `ctx`.
   async function ensureDatabaseExtension(
     capabilities: BackendCapabilities,
+    fencePlan: WriteFencePlan,
     name: DatabaseExtensionName,
   ): Promise<void> {
     // The name reaches DDL by interpolation, so the allowlist — not the
@@ -1131,14 +1142,20 @@ export function buildPostgresEngineProfile(
       );
     }
     const ddl = `CREATE EXTENSION IF NOT EXISTS "${validated}";`;
-    if (!capabilities.execution.interactiveTransactions) {
+    if (
+      !capabilities.execution.interactiveTransactions ||
+      fencePlan.kind !== "lock"
+    ) {
       await executeConcurrentCreateDdl(ddl);
       return;
     }
     await withConcurrentCreateRetry(async () => {
       await db.transaction(async (tx) => {
         await tx.execute(
-          sql`SELECT pg_advisory_xact_lock(hashtext(${extensionDdlLockKey(validated)}), 0)`,
+          toDrizzleSql(
+            fencePlan.sql.advisoryLock(extensionDdlLockKey(validated), 0),
+            "postgres",
+          ),
         );
         await tx.execute(sql.raw(ddl));
       });
@@ -1922,9 +1939,10 @@ export function buildPostgresEngineProfile(
       : {}),
 
       extensions: {
-        ensureExtension: (name) => ensureDatabaseExtension(capabilities, name),
+        ensureExtension: (name) =>
+          ensureDatabaseExtension(capabilities, fencePlan, name),
         ensureTrigramExtension(): Promise<void> {
-          return ensureDatabaseExtension(capabilities, "pg_trgm");
+          return ensureDatabaseExtension(capabilities, fencePlan, "pg_trgm");
         },
         async claimIndexMaterialization(
           params: ClaimIndexMaterializationParams,

--- a/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
@@ -56,23 +56,26 @@
  *     ratchets cannot disagree about what a dialect literal is.
  *  3. The four PostgreSQL lock-statement tokens (`pg_advisory_xact_lock`,
  *     `hashtext(`, `LOCK TABLE`, `current_setting('transaction_isolation')`)
- *     appear nowhere in the ten files this ratchet scans
+ *     appear nowhere in the eleven files this ratchet scans
  *     ({@link FENCE_TOKEN_SCANNED_FILES}), including
  *     `backend/drizzle/trusted-import.ts` (J18, which now resolves the fence
  *     plan and calls `fence.sql.lockTables(...)` instead of spelling
- *     `LOCK TABLE` itself) and `backend/drizzle/operations/schema.ts` —
- *     every one of those consumes a resolved plan's `fence.sql.*` (or, for
- *     the one PostgreSQL-only builder that lives outside the plan, calls
- *     the resolved fence target's own `advisoryLockExpression` /
+ *     `LOCK TABLE` itself), `backend/drizzle/operations/schema.ts`, and
+ *     `backend/drizzle/postgres.ts` (the extension-DDL advisory lock, which
+ *     now resolves the same plan every other lock site does and calls
+ *     `fence.sql.advisoryLock(...)` instead of spelling the statement
+ *     inline) — every one of those consumes a resolved plan's `fence.sql.*`
+ *     (or, for the one PostgreSQL-only builder that lives outside the plan,
+ *     calls the resolved fence target's own `advisoryLockExpression` /
  *     `isolationFactExpression` members) instead of spelling the statement
  *     itself — and DOES appear in
  *     `backend/drizzle/postgres-fence-sql.ts`, the one module that owns the
  *     spelling. This ratchet's file list is deliberately narrower than "all
- *     of `src/`": `backend/drizzle/postgres.ts` (the one-off extension-DDL
- *     advisory lock documented as the remaining leftover in #622, and a
- *     one-argument advisory lock keyed on a deliberately different lock
- *     space than every namespaced two-argument lock) still spells one of
- *     these tokens inline and is not one of the sites this model covers.
+ *     of `src/`": `backend/capabilities/write-fence.ts` names
+ *     `pg_advisory_xact_lock` and `LOCK TABLE` twice inside the prose of a
+ *     refusal-message string (documentation of the capability to declare,
+ *     not a competing statement spelling) and is not one of the sites this
+ *     model covers.
  *
  * *Mutation*: re-inline a dialect check at any lock site → fails naming the
  * file (both the "no resolveWriteFencePlan call added" half and the
@@ -475,17 +478,22 @@ const FENCE_MODULE_FILE = "backend/drizzle/postgres-fence-sql.ts";
  * the tokens when the PostgreSQL-only one relocated), that relocated
  * builder's own module, `graph-template-sql.ts` (whose `is_active`
  * literal was the only thing it ever spelled outside a resolved plan, and
- * that was never one of these four tokens), and `backend/drizzle/trusted-
+ * that was never one of these four tokens), `backend/drizzle/trusted-
  * import.ts` (J18: its table lock now resolves the same plan and calls
- * `fence.sql.lockTables(...)` instead of spelling `LOCK TABLE` itself) —
- * ten files in all — every one of these consumes `fence.sql.*` (or, for the fused schema+graph
- * statement, the resolved fence target's own `advisoryLockExpression` /
- * `isolationFactExpression` members) rather than spelling a token itself. Deliberately narrower
- * than "all of `src/`": `backend/drizzle/postgres.ts` (the one-off
- * extension-DDL advisory lock documented as the remaining leftover in #622,
- * and a lock space deliberately kept separate from every namespaced lock)
- * still spells one of these tokens inline and is not one of the sites this
- * ratchet covers.
+ * `fence.sql.lockTables(...)` instead of spelling `LOCK TABLE` itself), and
+ * `backend/drizzle/postgres.ts` (the extension-DDL advisory lock, once the
+ * remaining leftover documented in #622, now resolves the SAME plan
+ * `lateMembers` builds for every other lock site and calls
+ * `fence.sql.advisoryLock(...)` instead of spelling the statement inline) —
+ * eleven files in all — every one of these consumes `fence.sql.*` (or, for
+ * the fused schema+graph statement, the resolved fence target's own
+ * `advisoryLockExpression` / `isolationFactExpression` members) rather than
+ * spelling a token itself. Deliberately narrower than "all of `src/`":
+ * `backend/capabilities/write-fence.ts` names `pg_advisory_xact_lock` and
+ * `LOCK TABLE` twice, inside the prose of `unfencedRefusalMessage`'s two
+ * dialect-description strings — documentation naming the capability a
+ * backend should declare, not a competing spelling of the lock statement
+ * itself — and is not one of the files this ratchet scans.
  */
 const FENCE_TOKEN_SCANNED_FILES: readonly string[] = [
   "store/recorded-capture/clock.ts",
@@ -493,6 +501,7 @@ const FENCE_TOKEN_SCANNED_FILES: readonly string[] = [
   "identity/service-read.ts",
   "identity/schema-transition.ts",
   "graph-merge/provenance-store.ts",
+  "backend/drizzle/postgres.ts",
   "backend/drizzle/contribution-materializations.ts",
   "backend/drizzle/operations/schema.ts",
   "backend/drizzle/postgres-schema-write-fence.ts",

--- a/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
@@ -56,26 +56,16 @@
  *     ratchets cannot disagree about what a dialect literal is.
  *  3. The four PostgreSQL lock-statement tokens (`pg_advisory_xact_lock`,
  *     `hashtext(`, `LOCK TABLE`, `current_setting('transaction_isolation')`)
- *     appear nowhere in the eleven files this ratchet scans
- *     ({@link FENCE_TOKEN_SCANNED_FILES}), including
- *     `backend/drizzle/trusted-import.ts` (J18, which now resolves the fence
- *     plan and calls `fence.sql.lockTables(...)` instead of spelling
- *     `LOCK TABLE` itself), `backend/drizzle/operations/schema.ts`, and
- *     `backend/drizzle/postgres.ts` (the extension-DDL advisory lock, which
- *     now resolves the same plan every other lock site does and calls
- *     `fence.sql.advisoryLock(...)` instead of spelling the statement
- *     inline) — every one of those consumes a resolved plan's `fence.sql.*`
- *     (or, for the one PostgreSQL-only builder that lives outside the plan,
- *     calls the resolved fence target's own `advisoryLockExpression` /
- *     `isolationFactExpression` members) instead of spelling the statement
- *     itself — and DOES appear in
- *     `backend/drizzle/postgres-fence-sql.ts`, the one module that owns the
- *     spelling. This ratchet's file list is deliberately narrower than "all
- *     of `src/`": `backend/capabilities/write-fence.ts` names
- *     `pg_advisory_xact_lock` and `LOCK TABLE` twice inside the prose of a
- *     refusal-message string (documentation of the capability to declare,
- *     not a competing statement spelling) and is not one of the sites this
- *     model covers.
+ *     appear in exactly one module under all of `src/`,
+ *     `backend/drizzle/postgres-fence-sql.ts`, which owns the spelling.
+ *     Every lock site — the J-rows above, `backend/drizzle/trusted-import.ts`
+ *     (J18), and the extension-install lock in `backend/drizzle/postgres.ts`
+ *     — consumes a resolved plan's `fence.sql.*` instead, and the one
+ *     PostgreSQL-only builder that lives outside the plan composes the
+ *     resolved fence target's own `advisoryLockExpression` /
+ *     `isolationFactExpression` members. The whole tree is scanned; the only
+ *     permitted mentions outside the owning module are the prose rows in
+ *     {@link FENCE_TOKEN_PROSE_EXEMPTIONS}, asserted both directions.
  *
  * *Mutation*: re-inline a dialect check at any lock site → fails naming the
  * file (both the "no resolveWriteFencePlan call added" half and the
@@ -474,39 +464,30 @@ const FENCE_TOKENS: readonly string[] = [
 const FENCE_MODULE_FILE = "backend/drizzle/postgres-fence-sql.ts";
 
 /**
- * The nine sites' six files, `operations/schema.ts` (whose two builders lost
- * the tokens when the PostgreSQL-only one relocated), that relocated
- * builder's own module, `graph-template-sql.ts` (whose `is_active`
- * literal was the only thing it ever spelled outside a resolved plan, and
- * that was never one of these four tokens), `backend/drizzle/trusted-
- * import.ts` (J18: its table lock now resolves the same plan and calls
- * `fence.sql.lockTables(...)` instead of spelling `LOCK TABLE` itself), and
- * `backend/drizzle/postgres.ts` (the extension-DDL advisory lock, once the
- * remaining leftover documented in #622, now resolves the SAME plan
- * `lateMembers` builds for every other lock site and calls
- * `fence.sql.advisoryLock(...)` instead of spelling the statement inline) —
- * eleven files in all — every one of these consumes `fence.sql.*` (or, for
- * the fused schema+graph statement, the resolved fence target's own
- * `advisoryLockExpression` / `isolationFactExpression` members) rather than
- * spelling a token itself. Deliberately narrower than "all of `src/`":
- * `backend/capabilities/write-fence.ts` names `pg_advisory_xact_lock` and
- * `LOCK TABLE` twice, inside the prose of `unfencedRefusalMessage`'s two
- * dialect-description strings — documentation naming the capability a
- * backend should declare, not a competing spelling of the lock statement
- * itself — and is not one of the files this ratchet scans.
+ * The only string or template literals anywhere under `src/`, outside
+ * {@link FENCE_MODULE_FILE}, that mention one of {@link FENCE_TOKENS} — and
+ * every one is prose, not a spelling: `unfencedRefusalMessage`'s two
+ * dialect-description strings name the capability a backend should declare
+ * ("an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"). The
+ * whole source tree is scanned, so a new file that spells a lock statement
+ * itself fails here; a new prose mention is declared as a row, with its
+ * reason, or it fails too. Asserted both directions.
  */
-const FENCE_TOKEN_SCANNED_FILES: readonly string[] = [
-  "store/recorded-capture/clock.ts",
-  "store/recorded-capture/guards.ts",
-  "identity/service-read.ts",
-  "identity/schema-transition.ts",
-  "graph-merge/provenance-store.ts",
-  "backend/drizzle/postgres.ts",
-  "backend/drizzle/contribution-materializations.ts",
-  "backend/drizzle/operations/schema.ts",
-  "backend/drizzle/postgres-schema-write-fence.ts",
-  "backend/drizzle/graph-template-sql.ts",
-  "backend/drizzle/trusted-import.ts",
+const FENCE_TOKEN_PROSE_EXEMPTIONS: readonly InventoryEntry[] = [
+  {
+    file: "backend/capabilities/write-fence.ts",
+    line: '"an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"',
+    site: "prose",
+    reason:
+      "The PostgreSQL half of the unfenced refusal's dialect description — names the capability to declare, spells no statement.",
+  },
+  {
+    file: "backend/capabilities/write-fence.ts",
+    line: '"an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"',
+    site: "prose",
+    reason:
+      "The same description for the other dialect's recommendation line in that message.",
+  },
 ];
 
 /** String and template-literal AST tokens — comments and identifiers never match. */
@@ -580,23 +561,35 @@ function scanForFenceTokens(
 }
 
 describe("T17 — the four PostgreSQL lock-statement tokens have exactly one owner", () => {
-  const scannedFound = scanFiles(FENCE_TOKEN_SCANNED_FILES, scanForFenceTokens);
+  const treeFound = scanSourceTree(scanForFenceTokens).filter(
+    (site) => site.file !== FENCE_MODULE_FILE,
+  );
+  const proseDiff = diffAgainstInventory(
+    treeFound,
+    FENCE_TOKEN_PROSE_EXEMPTIONS,
+  );
   const schemaFound = scanFiles(
     ["backend/drizzle/operations/schema.ts"],
     scanForFenceTokens,
   );
   const moduleFound = scanFiles([FENCE_MODULE_FILE], scanForFenceTokens);
 
-  it("has zero fence lock-statement tokens across the scanned files", () => {
-    const reported = scannedFound.map(
+  it(`has no fence lock-statement token anywhere under src/ outside ${FENCE_MODULE_FILE} beyond the declared prose rows`, () => {
+    const reported = proseDiff.undeclared.map(
       (site) => `${site.file}:${String(site.lineNumber)}  ${site.line}`,
     );
     if (reported.length > 0) {
       throw new Error(
-        `A PostgreSQL lock-statement token remains outside ${FENCE_MODULE_FILE} — the lock spelling has re-acquired a second owner:\n\n${reported.join("\n")}`,
+        `A PostgreSQL lock-statement token appears outside ${FENCE_MODULE_FILE} and is not a declared prose row — the lock spelling has re-acquired a second owner:\n\n${reported.join("\n")}`,
       );
     }
     expect(reported).toEqual([]);
+  });
+
+  it("declares no prose row that the tree no longer contains", () => {
+    expect(
+      proseDiff.stale.map((entry) => `${entry.file}  ${entry.line}`),
+    ).toEqual([]);
   });
 
   it("operations/schema.ts specifically contains none of the four tokens", () => {

--- a/packages/typegraph/tests/postgres-trigram-extension-lock.test.ts
+++ b/packages/typegraph/tests/postgres-trigram-extension-lock.test.ts
@@ -6,9 +6,17 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { type FenceSql } from "../src/backend/capabilities/write-fence";
 import { deriveBackend } from "../src/backend/derive-backend";
+import {
+  createSqlBackend,
+  deriveEngineProfile,
+} from "../src/backend/drizzle/engine";
 import { type AnyPgDatabase } from "../src/backend/drizzle/execution/postgres-execution";
-import { createPostgresBackend } from "../src/backend/drizzle/postgres";
+import {
+  buildPostgresEngineProfile,
+  createPostgresBackend,
+} from "../src/backend/drizzle/postgres";
 import {
   type BackendCatalogProbes,
   type GraphBackend,
@@ -16,19 +24,36 @@ import {
 import { defineGraph } from "../src/core/define-graph";
 import { defineNode } from "../src/core/node";
 import { defineNodeIndex } from "../src/indexes";
+import {
+  sql as portableSql,
+  type SqlFragment,
+} from "../src/query/sql-fragment";
 import { createStore, createStoreWithSchema } from "../src/store/store";
 import { requireDefined } from "../src/utils/presence";
 import { createTestBackend } from "./test-utils";
 
+/**
+ * Renders one Drizzle `SQL` chunk to text. `sql\`...\`` (drizzle-orm's own
+ * tag) embeds a literal template segment as a bare `StringChunk` — `.value`
+ * IS the string array — but `toDrizzleSql`'s conversion of a portable
+ * `SqlFragment` builds each text segment via `drizzleSql.raw(...)`, which
+ * wraps that same `StringChunk` inside its own nested `SQL` object. This
+ * recurses through that nesting so both shapes flatten to the same text; a
+ * `Param` chunk has no `queryChunks` and falls through to its bound value.
+ */
+function chunkText(chunk: unknown): string {
+  const nested = (chunk as { queryChunks?: readonly unknown[] }).queryChunks;
+  if (Array.isArray(nested)) {
+    return nested.map((inner) => chunkText(inner)).join("");
+  }
+  const value = (chunk as { value?: unknown }).value;
+  return Array.isArray(value) ? value.join("") : String(value ?? chunk);
+}
+
 function statementText(statement: unknown): string {
   const chunks =
     (statement as { queryChunks?: readonly unknown[] }).queryChunks ?? [];
-  return chunks
-    .map((chunk) => {
-      const value = (chunk as { value?: unknown }).value;
-      return Array.isArray(value) ? value.join("") : String(value ?? chunk);
-    })
-    .join("");
+  return chunks.map((chunk) => chunkText(chunk)).join("");
 }
 
 function stubTransactionalDatabase(): Readonly<{
@@ -58,6 +83,47 @@ function duplicateKeyError(): Error {
     code: "23505",
   });
 }
+
+/**
+ * A derived profile's custom lock spelling: ONE `hashtext(...)` call over a
+ * concatenated string, unlike the bundled two-argument
+ * `pg_advisory_xact_lock(hashtext($namespace), $key)` form the extension
+ * install otherwise emits. Mirrors `engine-profile-derivation.test.ts`'s own
+ * `customFenceSql`, kept local rather than imported so this suite's fixture
+ * does not depend on that file's internal (unexported) helpers.
+ */
+function customExtensionAdvisoryLockExpression(
+  namespace: string,
+  key: string | number,
+): SqlFragment {
+  const keyText = typeof key === "number" ? String(key) : key;
+  return portableSql`pg_advisory_xact_lock(hashtext(${namespace} || ':' || ${keyText}))`;
+}
+
+function customExtensionLockTables(): SqlFragment {
+  throw new Error("not exercised by the extension-install lock");
+}
+
+function customExtensionIsolationFactExpression(): SqlFragment {
+  return portableSql`current_setting('transaction_isolation')`;
+}
+
+const customExtensionFenceSql: FenceSql = {
+  lockTables: customExtensionLockTables,
+  advisoryLockExpression: customExtensionAdvisoryLockExpression,
+  isolationFactExpression: customExtensionIsolationFactExpression,
+};
+
+/**
+ * The custom spelling's signature — never produced by the bundled
+ * `postgresFenceSql`. This suite's stub reconstructs statement text straight
+ * from the Drizzle `SQL` chunk tree (`statementText` above), which embeds
+ * each bound value's own text rather than a `$1`-style placeholder — unlike
+ * `engine-profile-derivation.test.ts`'s live-PGlite capture, which observes
+ * the placeholder form the wire protocol actually sends.
+ */
+const CUSTOM_EXTENSION_LOCK_PATTERN =
+  /pg_advisory_xact_lock\(hashtext\(.+ \|\| ':' \|\| .+\)\)/;
 
 const Document = defineNode("Document", {
   schema: z.object({ title: z.string() }),
@@ -244,5 +310,62 @@ describe("Postgres pg_trgm extension prerequisite", () => {
     expect(events[0]).toBe("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
     expect(events[1]).toBe("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
     expect(events[2]).toContain("CREATE INDEX CONCURRENTLY IF NOT EXISTS");
+  });
+
+  // The extension-install lock now resolves the SAME write-fence plan every
+  // other lock site does, so a derived profile's own `fenceSql` backs it —
+  // never the bundled spelling unconditionally.
+  it("emits a derived profile's custom fenceSql spelling for the extension-install lock, not the bundled one", async () => {
+    const { db, statements } = stubTransactionalDatabase();
+    const baseProfile = buildPostgresEngineProfile(db, { vector: false });
+    const derivedProfile = deriveEngineProfile(baseProfile, {
+      fenceSql: customExtensionFenceSql,
+    });
+    const backend = createSqlBackend(derivedProfile);
+
+    await requireDefined(backend.ensureExtension)("pg_trgm");
+
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toMatch(CUSTOM_EXTENSION_LOCK_PATTERN);
+    expect(statements[0]).toContain("typegraph:extension-ddl:pg_trgm");
+    expect(statements[1]).toContain('CREATE EXTENSION IF NOT EXISTS "pg_trgm"');
+  });
+
+  // A plan that resolves `engine-serialized` (or `unfenced`) takes no lock at
+  // all: this is the one lock site that DEGRADES instead of refusing,
+  // because the duplicate-key retry — not the lock — is what makes a
+  // concurrent install correct on such a backend.
+  it("takes no lock when the resolved plan is engine-serialized, and still retries a first duplicate-key rejection", async () => {
+    const statements: string[] = [];
+    const db = {
+      $client: { query: () => Promise.resolve({ rows: [] }) },
+      execute(
+        statement: unknown,
+      ): Promise<Readonly<{ rows: readonly unknown[] }>> {
+        statements.push(statementText(statement));
+        if (statements.length === 1) return Promise.reject(duplicateKeyError());
+        return Promise.resolve({ rows: [] });
+      },
+    } as unknown as AnyPgDatabase;
+    const baseProfile = buildPostgresEngineProfile(db, { vector: false });
+    const derivedProfile = deriveEngineProfile(baseProfile, {
+      fenceSql: undefined,
+      declaredCapabilities: {
+        ...baseProfile.declaredCapabilities,
+        pessimisticLocks: {
+          advisoryLocks: false,
+          tableLocks: false,
+          serializedWriters: true,
+        },
+      },
+    });
+    const backend = createSqlBackend(derivedProfile);
+
+    await requireDefined(backend.ensureExtension)("pg_trgm");
+
+    expect(statements).toHaveLength(2);
+    expect(new Set(statements)).toEqual(
+      new Set(['CREATE EXTENSION IF NOT EXISTS "pg_trgm";']),
+    );
   });
 });


### PR DESCRIPTION
Folds the last self-spelled PostgreSQL lock into the write-fence plan and widens the token ratchet to all of `src/`.

## The extension-install lock consumes the fence plan

`ensureDatabaseExtension` takes the resolved plan its caller already holds and, in the `lock` arm, spells its advisory lock as `fence.sql.advisoryLock(key, 0)` inside the same own-transaction and retry structure as before; the bundled statement renders byte-identical (`SELECT pg_advisory_xact_lock(hashtext($1), 0)`). Under `engine-serialized` or `unfenced` it skips the lock and runs the DDL through the duplicate-key retry, exactly as the non-interactive path already does: the retry, not the lock, is what makes concurrent installs sound, so this fence degrades rather than refuses. Tests pin a derived profile's custom spelling reaching the lock, and a serialized-writers profile taking no lock and still retrying a first-attempt 23505.

## The token ratchet covers the whole tree

With no lock site left spelling its own statement, `tests/lock-fence-plan-inventory.test.ts` scans all of `src/` for the four fence tokens instead of an allowlist of files. `postgres-fence-sql.ts` must contain them; every other mention is a declared prose row (the two dialect-description strings in the unfenced refusal message), asserted in both directions. Mutation-checked by adding a self-spelled lock to an unrelated module and watching the ratchet name it.

This completes the follow-ups listed in #622. The issue stays open as the tracking reference the API-surface ledger cites for `FenceSql`'s required-as-a-set members.
