### PR TITLE
feat(backend)!: one declared write-fence mechanism, a drain fact, and caller-serialized

### DIFF
--- a/.changeset/dialect-seam-catalog-member.md
+++ b/.changeset/dialect-seam-catalog-member.md
@@ -43,24 +43,21 @@ SQL, capabilities, or behavior changes.
 **Behavior change:** trusted import's PostgreSQL table lock now resolves the same write-fence plan
 every other lock site does, instead of unconditionally taking `LOCK TABLE ... ACCESS EXCLUSIVE`.
 Trusted import now refuses up front, before any statement runs, when a custom PostgreSQL backend's
-`pessimisticLocks` declaration resolves `unfenced` (absent, present but declaring all three of
-`advisoryLocks`/`tableLocks`/`serializedWriters` false, or declaring `{ advisoryLocks: false,
-tableLocks: true, serializedWriters: false }` — table locks alone, which the plan model has no arm
-for and resolves `unfenced` exactly like the other two shapes) or resolves a `lock` plan with
-`tableLocks: false` — this now also catches an advisory-only declaration (`{ advisoryLocks: true,
-tableLocks: false }`), which previously took the table lock anyway. Every refusal that reaches an
-`unfenced` plan now names which of the three shapes it declared, rather than one message broad
-enough to cover all of them. `createPostgresBackend` itself rejects a `pessimisticLocks.
-serializedWriters: true` capability override at construction (`ConfigurationError`, "PostgreSQL
-backend capability overrides cannot claim serialized writers"), so a declaration resolving
-`engine-serialized` is reachable only through a custom `SqlEngineProfile` or a hand-built
-PostgreSQL-dialect backend for an engine that genuinely serializes writers; for one, trusted import
-now takes no relation lock at all, where it previously took `LOCK TABLE ... ACCESS EXCLUSIVE` — the
-declaration states the engine serializes writers, so trusted import's own transaction is fence
-enough on its own. The `WRITE_FENCE_SQL_UNAVAILABLE` code applies only to the narrower case of an
-`advisoryLocks: true` declaration with no `fenceSql` to spell the lock; every other refusal above is
-`WRITE_FENCE_UNAVAILABLE`. Declare both `advisoryLocks: true` and `tableLocks: true` — the bundled
-`createPostgresBackend` default, which also supplies `fenceSql` — to restore the lock.
+`writeFence` declaration resolves `unfenced` (no declaration present) or resolves a `lock` plan
+with `drain: "none"` — this now also catches an advisory-only declaration (`{ mechanism:
+"advisory", drain: "none" }`), which previously took the table lock anyway. Every refusal names
+the drain that could not be satisfied. `createPostgresBackend` itself rejects a `writeFence.
+mechanism: "engine-serialized"` capability override at construction (`ConfigurationError`,
+'PostgreSQL backend capability overrides cannot declare writeFence.mechanism: "engine-serialized"'),
+so a declaration resolving `engine-serialized` is reachable only through a custom
+`SqlEngineProfile` or a hand-built PostgreSQL-dialect backend for an engine that genuinely
+serializes writers; for one, trusted import now takes no relation lock at all, where it previously
+took `LOCK TABLE ... ACCESS EXCLUSIVE` — the declaration states the engine serializes writers, so
+trusted import's own transaction is fence enough on its own. The `WRITE_FENCE_SQL_UNAVAILABLE`
+code applies only to the narrower case of a `mechanism: "advisory"` declaration with no `fenceSql`
+to spell the lock; every other refusal above is `WRITE_FENCE_UNAVAILABLE`. Declare `writeFence: {
+mechanism: "advisory", drain: "table-lock" }` — the bundled `createPostgresBackend` default, which
+also supplies `fenceSql` — to restore the lock.
 
 **Author-facing:** `CommonOperationStrategy` no longer carries `dynamicEdgeConvergence`. That field
 was required, so every external `SqlEngineProfile.strategy` literal now fails to typecheck; delete

--- a/.changeset/sql-engine-profile-entrypoint.md
+++ b/.changeset/sql-engine-profile-entrypoint.md
@@ -12,15 +12,15 @@ unchanged for every configuration the two factories accepted before.
 Two construction-time narrowings apply to the bundled factories as well as
 to third-party profiles, because both now run through `createSqlBackend`:
 
-- A backend whose resolved capabilities carry no `pessimisticLocks`
+- A backend whose resolved capabilities carry no `writeFence`
   declaration is refused with a `ConfigurationError`
   (`ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION`) that prints the one
-  declaration line to add. Omitting `pessimisticLocks` from a `capabilities`
+  declaration line to add. Omitting `writeFence` from a `capabilities`
   override is unaffected (the factory's own declaration applies); passing
-  `capabilities: { pessimisticLocks: undefined }` explicitly, which previously
+  `capabilities: { writeFence: undefined }` explicitly, which previously
   built a backend that resolved every write fence through a dialect fallback,
   now throws at construction.
-- A backend that declares `pessimisticLocks` as all `false` no longer earns
+- A backend whose declaration resolves `unfenced` no longer earns
   the schema-fenced-insert eligibility mark, so a schema-managed first write
   on it now refuses with `WRITE_FENCE_UNAVAILABLE` instead of fusing the
   insert. Schema commits on such a backend already refused, so a working

--- a/.changeset/write-fence-mechanism.md
+++ b/.changeset/write-fence-mechanism.md
@@ -1,0 +1,45 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+`capabilities.writeFence` replaces the three `pessimisticLocks` booleans as the write-fence
+declaration: `{ mechanism: "advisory" | "engine-serialized" | "caller-serialized"; drain:
+"table-lock" | "quiescent" | "none" }`. `mechanism` is the exclusion primitive a backend
+provides; `drain` is the separate fact of whether a caller that already excluded other writers
+can additionally take a relation-wide lock on a resource a few sites protect. `pessimisticLocks`
+stays accepted — deprecated, not removed — and `resolveWriteFencePlan` maps it to the new shape
+through one function: `advisoryLocks: true` becomes `{ mechanism: "advisory", drain: tableLocks ?
+"table-lock" : "none" }`; `serializedWriters: true` becomes `{ mechanism: "engine-serialized",
+drain: "table-lock" }`. Declaring both `writeFence` and `pessimisticLocks` on the same backend is
+refused with a new `ConfigurationError` code, `WRITE_FENCE_DECLARATION_CONFLICT`, naming both
+declarations. Both bundled backends keep declaring `pessimisticLocks` in this release, so nothing
+built against them changes: same emitted SQL, same capabilities, same resolved plan.
+
+The resolved `WriteFencePlan`'s `lock` arm gains `drain`, with `tableLocks: boolean` kept as a
+deprecated alias derived from it (`drain === "table-lock"`) — read `drain` in new code, since it
+distinguishes a declaration that cannot drain a site at all (`"none"`) from one that drains it
+without a statement (`"quiescent"`), a distinction `tableLocks: false` collapses to one case. A
+new arm, `{ kind: "caller-serialized" }`, joins the plan's union for a deployment-level promise
+that no other client writes to the backend's database while it is open. **This is an additive
+change to a released discriminated union**: any code outside this package that exhaustively
+switches on `WriteFencePlan["kind"]` must add a `"caller-serialized"` case, or its `default`
+branch (if any) now sees it too. `requireWriteFence`'s behavior is unchanged for
+`"advisory-lock"`; for `"table-lock"` it now refuses only when the resolved plan's `drain` is
+`"none"` (previously: whenever `tableLocks` was `false`), and `"engine-serialized"` /
+`"caller-serialized"` satisfy either requirement without consulting `drain`.
+
+`createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized", drain }` — a claim
+about the deployment, not the engine — while continuing to refuse the legacy
+`pessimisticLocks.serializedWriters: true` outright, since that boolean claims the engine itself
+serializes writers. The promise splits into two halves: in process, TypeGraph now enforces its
+own half by routing every write unit issued through a `caller-serialized` backend — collection
+writes, `store.transaction`, schema commits, identity and contribution maintenance, index
+materialization, import — through one per-backend serialized queue, so two concurrent calls
+through the same pool cannot race each other; outside the process, the deployment still has to
+hold up its half (no other client writing to the same database) since TypeGraph cannot observe
+that.
+
+`WriteFenceDeclaration` is exported directly from `@nicia-ai/typegraph/backend`.
+`pessimisticLockDeclarationLine` stays as a deprecated (but permanently supported) alias printing
+the legacy declaration line; new refusal messages recommend `writeFence` first and the legacy
+shape second.

--- a/.changeset/write-fence-mechanism.md
+++ b/.changeset/write-fence-mechanism.md
@@ -2,27 +2,38 @@
 "@nicia-ai/typegraph": minor
 ---
 
-`capabilities.writeFence` is the write-fence declaration: `{ mechanism: "advisory" |
-"engine-serialized" | "caller-serialized"; drain: "table-lock" | "quiescent" | "none" }`.
-`mechanism` is the exclusion primitive a backend provides; `drain` is the separate fact of
-whether a caller that already excluded other writers can additionally take a relation-wide lock
-on a resource a few sites protect. Both bundled backends declare it directly
-(`SQLITE_CAPABILITIES`: `{ mechanism: "engine-serialized", drain: "table-lock" }`;
-`POSTGRES_CAPABILITIES`: `{ mechanism: "advisory", drain: "table-lock" }`), so nothing built
-against them changes: same emitted SQL, same resolved plan.
+`capabilities.writeFence` is the write-fence declaration, a discriminated union on `mechanism`:
+`{ mechanism: "advisory"; drain: "table-lock" | "quiescent" | "none" }` |
+`{ mechanism: "engine-serialized" }` | `{ mechanism: "caller-serialized" }`. `mechanism` is the
+exclusion primitive a backend provides; `drain` — a field of the `"advisory"` shape only — is the
+separate fact of whether a caller that already excluded other writers can additionally take a
+relation-wide lock on a resource a few sites protect. Both bundled backends declare it directly
+(`SQLITE_CAPABILITIES`: `{ mechanism: "engine-serialized" }`; `POSTGRES_CAPABILITIES`:
+`{ mechanism: "advisory", drain: "table-lock" }`), so nothing built against them changes: same
+emitted SQL, same resolved plan. `resolveWriteFencePlan` validates a declared `writeFence` at
+runtime — an unrecognized `mechanism`, an unrecognized `drain`, or a `drain` attached to a
+serialized mechanism — and refuses with `WRITE_FENCE_DECLARATION_INVALID` naming the field and
+(where applicable) the accepted values, since a plain-JavaScript backend author is not held to the
+discriminated-union type the way a TypeScript caller is.
 
 A new arm, `{ kind: "caller-serialized" }`, joins `WriteFencePlan`'s union for a deployment-level
 promise that no other client writes to the backend's database while it is open.
-`createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized", drain }` — a claim
-about the deployment, not the engine — while continuing to refuse `mechanism:
-"engine-serialized"` outright, since that claims the engine itself serializes writers. The
-promise splits into two halves: in process, TypeGraph enforces its own half by routing every
-write unit issued through a `caller-serialized` backend — collection writes,
-`store.transaction`, schema commits, identity and contribution maintenance, index
-materialization, import — through one per-backend serialized queue, so two concurrent calls
-through the same pool cannot race each other; outside the process, the deployment still has to
-hold up its half (no other client writing to the same database) since TypeGraph cannot observe
-that.
+`createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized" }` — a claim about
+the deployment, not the engine — while continuing to refuse `mechanism: "engine-serialized"`
+outright, since that claims the engine itself serializes writers. The promise splits into two
+halves. In process, TypeGraph enforces its own half: every root member the backend classifies in a
+mutation-capable class — graph-entity and sidecar writes, backend-owned bulk import, derived-data
+maintenance, schema commits, table/DDL provisioning, `clearGraph`, and the raw-SQL members that can
+carry an arbitrary write (`execute`, `executeRaw`, `executeStatement`,
+`executeTemporaryStatement`) — plus `transaction` and `transactionWithNative`, runs through one
+per-backend serialized queue, so two concurrent calls through the same pool cannot race each other;
+a root write awaited from inside a `store.transaction` callback is refused
+(`SERIALIZED_QUEUE_REENTRANT_SUBMISSION`) rather than left to deadlock. Adopting an externally
+owned transaction (`adoptTransaction`, backing `store.withTransaction(externalTx)`) is refused
+outright (`CALLER_SERIALIZED_REFUSES_ADOPTION`): its lifetime belongs to the caller, not to this
+backend's queue, so there is no honest way to hold a queue slot open for it. Outside the process,
+the deployment still has to hold up its half (no other client writing to the same database) since
+TypeGraph cannot observe that.
 
 `requireWriteFence` takes `requires: "keyed" | "drain"`: `"keyed"` is satisfied by every
 non-`unfenced` arm; `"drain"` refuses only when the resolved plan's `drain` is `"none"`, and
@@ -44,3 +55,9 @@ non-`unfenced` arm; `"drain"` refuses only when the resolved plan's `drain` is `
   branch, if any, now sees it too).
 - `WRITE_FENCE_DECLARATION_CONFLICT` is removed — `writeFence` is the only declaration, so no two
   declarations can conflict.
+- `WriteFenceDeclaration` is now a discriminated union on `mechanism`, not one flat shape: `drain`
+  is a field of `{ mechanism: "advisory" }` only. Declaring `drain` alongside
+  `mechanism: "engine-serialized"` or `mechanism: "caller-serialized"` — accepted (and ignored) by
+  earlier commits on this same feature branch — is now refused with
+  `WRITE_FENCE_DECLARATION_INVALID`. Read `declaration.drain` only after narrowing
+  `declaration.mechanism === "advisory"`.

--- a/.changeset/write-fence-mechanism.md
+++ b/.changeset/write-fence-mechanism.md
@@ -2,44 +2,45 @@
 "@nicia-ai/typegraph": minor
 ---
 
-`capabilities.writeFence` replaces the three `pessimisticLocks` booleans as the write-fence
-declaration: `{ mechanism: "advisory" | "engine-serialized" | "caller-serialized"; drain:
-"table-lock" | "quiescent" | "none" }`. `mechanism` is the exclusion primitive a backend
-provides; `drain` is the separate fact of whether a caller that already excluded other writers
-can additionally take a relation-wide lock on a resource a few sites protect. `pessimisticLocks`
-stays accepted — deprecated, not removed — and `resolveWriteFencePlan` maps it to the new shape
-through one function: `advisoryLocks: true` becomes `{ mechanism: "advisory", drain: tableLocks ?
-"table-lock" : "none" }`; `serializedWriters: true` becomes `{ mechanism: "engine-serialized",
-drain: "table-lock" }`. Declaring both `writeFence` and `pessimisticLocks` on the same backend is
-refused with a new `ConfigurationError` code, `WRITE_FENCE_DECLARATION_CONFLICT`, naming both
-declarations. Both bundled backends keep declaring `pessimisticLocks` in this release, so nothing
-built against them changes: same emitted SQL, same capabilities, same resolved plan.
+`capabilities.writeFence` is the write-fence declaration: `{ mechanism: "advisory" |
+"engine-serialized" | "caller-serialized"; drain: "table-lock" | "quiescent" | "none" }`.
+`mechanism` is the exclusion primitive a backend provides; `drain` is the separate fact of
+whether a caller that already excluded other writers can additionally take a relation-wide lock
+on a resource a few sites protect. Both bundled backends declare it directly
+(`SQLITE_CAPABILITIES`: `{ mechanism: "engine-serialized", drain: "table-lock" }`;
+`POSTGRES_CAPABILITIES`: `{ mechanism: "advisory", drain: "table-lock" }`), so nothing built
+against them changes: same emitted SQL, same resolved plan.
 
-The resolved `WriteFencePlan`'s `lock` arm gains `drain`, with `tableLocks: boolean` kept as a
-deprecated alias derived from it (`drain === "table-lock"`) — read `drain` in new code, since it
-distinguishes a declaration that cannot drain a site at all (`"none"`) from one that drains it
-without a statement (`"quiescent"`), a distinction `tableLocks: false` collapses to one case. A
-new arm, `{ kind: "caller-serialized" }`, joins the plan's union for a deployment-level promise
-that no other client writes to the backend's database while it is open. **This is an additive
-change to a released discriminated union**: any code outside this package that exhaustively
-switches on `WriteFencePlan["kind"]` must add a `"caller-serialized"` case, or its `default`
-branch (if any) now sees it too. `requireWriteFence`'s behavior is unchanged for
-`"advisory-lock"`; for `"table-lock"` it now refuses only when the resolved plan's `drain` is
-`"none"` (previously: whenever `tableLocks` was `false`), and `"engine-serialized"` /
-`"caller-serialized"` satisfy either requirement without consulting `drain`.
-
+A new arm, `{ kind: "caller-serialized" }`, joins `WriteFencePlan`'s union for a deployment-level
+promise that no other client writes to the backend's database while it is open.
 `createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized", drain }` — a claim
-about the deployment, not the engine — while continuing to refuse the legacy
-`pessimisticLocks.serializedWriters: true` outright, since that boolean claims the engine itself
-serializes writers. The promise splits into two halves: in process, TypeGraph now enforces its
-own half by routing every write unit issued through a `caller-serialized` backend — collection
-writes, `store.transaction`, schema commits, identity and contribution maintenance, index
+about the deployment, not the engine — while continuing to refuse `mechanism:
+"engine-serialized"` outright, since that claims the engine itself serializes writers. The
+promise splits into two halves: in process, TypeGraph enforces its own half by routing every
+write unit issued through a `caller-serialized` backend — collection writes,
+`store.transaction`, schema commits, identity and contribution maintenance, index
 materialization, import — through one per-backend serialized queue, so two concurrent calls
 through the same pool cannot race each other; outside the process, the deployment still has to
 hold up its half (no other client writing to the same database) since TypeGraph cannot observe
 that.
 
-`WriteFenceDeclaration` is exported directly from `@nicia-ai/typegraph/backend`.
-`pessimisticLockDeclarationLine` stays as a deprecated (but permanently supported) alias printing
-the legacy declaration line; new refusal messages recommend `writeFence` first and the legacy
-shape second.
+`requireWriteFence` takes `requires: "keyed" | "drain"`: `"keyed"` is satisfied by every
+non-`unfenced` arm; `"drain"` refuses only when the resolved plan's `drain` is `"none"`, and
+`"engine-serialized"` / `"caller-serialized"` satisfy it without consulting `drain` at all.
+
+## Breaking
+
+- `capabilities.pessimisticLocks` and its `PessimisticLockCapabilities` type are removed — declare
+  `capabilities.writeFence` instead.
+- `requireWriteFence`'s `requires` parameter is renamed: `"advisory-lock"` becomes `"keyed"`,
+  `"table-lock"` becomes `"drain"`.
+- `WriteFencePlan`'s `lock` arm drops `tableLocks` and `advisoryLocks` — read `drain` instead
+  (`"table-lock"` means what `tableLocks: true` used to).
+- `WriteFencePlan`'s `unfenced` arm drops `reason` — declaring `writeFence` leaves no shape that
+  resolves `unfenced` for a reason other than an absent declaration, so there is nothing left to
+  distinguish.
+- `WriteFencePlan` gained the `caller-serialized` arm as a permanent part of the union — an
+  external exhaustive switch on `WriteFencePlan["kind"]` must add a case for it (or its `default`
+  branch, if any, now sees it too).
+- `WRITE_FENCE_DECLARATION_CONFLICT` is removed — `writeFence` is the only declaration, so no two
+  declarations can conflict.

--- a/.changeset/write-fence-sql-seam.md
+++ b/.changeset/write-fence-sql-seam.md
@@ -3,7 +3,7 @@
 ---
 
 `GraphBackend` gains an optional `fenceSql` member: the lock spelling a backend supplies
-alongside `capabilities.pessimisticLocks`, as `FenceSql` — three builders,
+alongside `capabilities.writeFence`, as `FenceSql` — three builders,
 `advisoryLockExpression`, `isolationFactExpression`, and `lockTables`. `resolveWriteFencePlan`'s
 `lock` arm carries `sql: FenceStatements`: those three plus the standalone `advisoryLock`,
 `advisoryLockWithIsolation`, and `isolationFact` statements, which `resolveFenceStatements`
@@ -15,7 +15,7 @@ The bundled PostgreSQL spelling is exported as `postgresFenceSql` from
 `@nicia-ai/typegraph/adapters/drizzle/postgres`. `createPostgresBackend` supplies it
 automatically; `createSqliteBackend` supplies no `fenceSql` since its fence is
 `engine-serialized` and takes no lock. A backend that declares
-`capabilities.pessimisticLocks.advisoryLocks: true` but supplies no `fenceSql` is now refused at
+`capabilities.writeFence.mechanism: "advisory"` but supplies no `fenceSql` is now refused at
 construction with a typed `ConfigurationError` (`WRITE_FENCE_SQL_UNAVAILABLE`) naming the member
 to supply, rather than reaching a lock site with nothing to spell the statement.
 
@@ -25,8 +25,8 @@ namespace as a parameter instead of an inline string literal (`hashtext` hashes 
 either way), and insignificant whitespace in three statements changed with the move.
 
 Two behavior changes reach custom `dialect: "postgres"` backends. A backend declaring
-`pessimisticLocks.advisoryLocks: true` without `fenceSql` is refused at construction (above).
-A backend declaring only `serializedWriters: true` and no `fenceSql` is refused when a
+`writeFence.mechanism: "advisory"` without `fenceSql` is refused at construction (above).
+A backend declaring only `mechanism: "engine-serialized"` and no `fenceSql` is refused when a
 history-capturing transaction reads its isolation level, which previously ran a hard-coded
 `current_setting('transaction_isolation')` read; supply `fenceSql` (or `postgresFenceSql`) to
 restore it.

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -17,9 +17,12 @@
   },
 
   // MD033 - Inline HTML
-  // Allow HTML elements that are commonly needed
+  // Allow HTML elements that are commonly needed. `a` is for a bare `<a
+  // id="...">` anchor that keeps an old heading slug reachable after a
+  // rename, so a permanent external link (e.g. a shipped CHANGELOG entry)
+  // does not 404.
   "MD033": {
-    "allowed_elements": ["br", "sup", "sub", "details", "summary"],
+    "allowed_elements": ["a", "br", "sup", "sub", "details", "summary"],
   },
 
   // MD041 - First line should be top-level heading

--- a/apps/docs/src/content/docs/backend-authoring.md
+++ b/apps/docs/src/content/docs/backend-authoring.md
@@ -221,8 +221,9 @@ resolves a write-fence plan eagerly, and a profile whose resolved
 `writeFence.mechanism` is still `"advisory"` with no `fenceSql` refuses
 with `WRITE_FENCE_SQL_UNAVAILABLE`. Pair it with a `declaredCapabilities`
 override that stops claiming `"advisory"` (for example, declaring
-`writeFence: { mechanism: "engine-serialized", drain: "table-lock" }`
-instead) to actually resolve an `engine-serialized` plan that needs no
+`writeFence: { mechanism: "engine-serialized" }`
+instead — no `drain` key: that field applies only to `mechanism: "advisory"`)
+to actually resolve an `engine-serialized` plan that needs no
 lock spelling at all.
 
 ## Refusals you may meet
@@ -231,6 +232,8 @@ lock spelling at all.
 | --- | --- |
 | `ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION` | The profile's resolved capabilities omit `writeFence` — `createSqlBackend` has no write-fence decision to resolve and refuses outright, naming the one capabilities line to add. |
 | `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved capabilities declare `mechanism: "advisory"` but the profile's `fenceSql` is missing the member that mechanism/drain combination needs. |
+| `WRITE_FENCE_DECLARATION_INVALID` | The declared `writeFence` carries an unrecognized `mechanism` or `drain` string, or a `drain` key on a mechanism other than `"advisory"` — `resolveWriteFencePlan` validates the raw value (a plain-JavaScript author is not held to the discriminated-union type) before shaping a plan from it. |
+| `CALLER_SERIALIZED_REFUSES_ADOPTION` | `adoptTransaction` was called on a backend whose resolved write-fence plan is `caller-serialized` — an externally owned transaction's lifetime cannot be held by the backend's in-process write-unit queue. |
 | `CATALOG_UNAVAILABLE` | A store path that needs the backend's catalog probes (index materialization, the recorded-time schema check, the recorded-time migration's column read) finds `catalog` absent — a profile whose `provisioning.catalog` is unset builds a backend with no `catalog` member at all. |
 | `ENGINE_PROFILE_OVERRIDE_UNSUPPORTED` | `deriveEngineProfile`'s `overrides` names a key outside the derivable set, or one of the three adapter-backed sub-fields with a changed value (see [the carve-out](#the-adapter-backed-carve-out)). |
 | `ENGINE_ASSEMBLY_UNRECOGNIZED` | The profile's `assembly` is not a value `assembleEngine` produced — a profile built by hand rather than obtained from a bundled builder (optionally adapted with `deriveEngineProfile`). |

--- a/apps/docs/src/content/docs/backend-authoring.md
+++ b/apps/docs/src/content/docs/backend-authoring.md
@@ -76,7 +76,7 @@ consistently.
 
 | Field | What overriding it changes |
 | --- | --- |
-| `declaredCapabilities` | The capabilities `finalizeEngineCapabilities` derives the rest of the backend's advertised capabilities from — for example, declaring `pessimisticLocks` differently changes which write-fence plan resolves. |
+| `declaredCapabilities` | The capabilities `finalizeEngineCapabilities` derives the rest of the backend's advertised capabilities from — for example, declaring `writeFence` (or the deprecated `pessimisticLocks`) differently changes which write-fence plan resolves. |
 | `fenceSql` | The lock-statement spelling the resolved fence plan carries; pass `undefined` to remove it entirely (see [Removing `fenceSql`](#removing-fencesql) below). |
 | `resourceAudit` | The serialized-resource verdict `createSqlBackend` records before the backend escapes. |
 | `autocommit` | Whether a single statement outside an explicit transaction is durable — gates the root-autocommit mark. |
@@ -108,9 +108,10 @@ which is not itself derivable. Deriving from a SQLite base refuses the same
 override even though `buildSqliteEngineProfile`'s operation backend reads
 `maxBindParameters` off the resolved capabilities directly and would honor
 a changed value — the check does not distinguish the two dialects. Every
-other sub-field on both objects — `pessimisticLocks`, `windowFunctions`,
-`clearValidTo`, `returning`, `claims`, `graphAnalytics`, `resourceAudit`'s
-`resource` / `identityLeaseResource`, and so on — stays freely derivable.
+other sub-field on both objects — `writeFence`, `pessimisticLocks`,
+`windowFunctions`, `clearValidTo`, `returning`, `claims`, `graphAnalytics`,
+`resourceAudit`'s `resource` / `identityLeaseResource`, and so on — stays
+freely derivable.
 
 ## What you cannot override
 
@@ -216,11 +217,13 @@ this same derivation can override (see the table above).
 `fenceSql` is the one field a derived profile can clear: pass
 `fenceSql: undefined` to drop the bundled spelling entirely. That alone
 is not enough to reach a working profile — `createSqlBackend` still
-resolves a write-fence plan eagerly, and a profile whose
-`declaredCapabilities.pessimisticLocks.advisoryLocks` is still `true`
-with no `fenceSql` refuses with `WRITE_FENCE_SQL_UNAVAILABLE`. Pair it
-with a `declaredCapabilities` override that stops claiming
-`advisoryLocks` (for example, declaring `serializedWriters: true`
+resolves a write-fence plan eagerly, and a profile whose resolved
+`writeFence.mechanism` (or the deprecated
+`declaredCapabilities.pessimisticLocks.advisoryLocks`) is still
+`"advisory"` (or `true`) with no `fenceSql` refuses with
+`WRITE_FENCE_SQL_UNAVAILABLE`. Pair it with a `declaredCapabilities`
+override that stops claiming `"advisory"` (for example, declaring
+`writeFence: { mechanism: "engine-serialized", drain: "table-lock" }`
 instead) to actually resolve an `engine-serialized` plan that needs no
 lock spelling at all.
 
@@ -228,8 +231,9 @@ lock spelling at all.
 
 | Code | When |
 | --- | --- |
-| `ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION` | The profile's resolved capabilities omit `pessimisticLocks` entirely — `createSqlBackend` has no write-fence decision to resolve and refuses outright, naming the one capabilities line to add. |
-| `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved capabilities declare `pessimisticLocks.advisoryLocks: true` but the profile supplies no `fenceSql` to spell the lock with. |
+| `ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION` | The profile's resolved capabilities omit both `writeFence` and the deprecated `pessimisticLocks` — `createSqlBackend` has no write-fence decision to resolve and refuses outright, naming the one capabilities line to add. |
+| `WRITE_FENCE_DECLARATION_CONFLICT` | The profile's resolved capabilities declare BOTH `writeFence` and `pessimisticLocks` — exactly one write-fence declaration is allowed. |
+| `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved capabilities declare `mechanism: "advisory"` (or the legacy `pessimisticLocks.advisoryLocks: true`) but the profile's `fenceSql` is missing the member that mechanism/drain combination needs. |
 | `CATALOG_UNAVAILABLE` | A store path that needs the backend's catalog probes (index materialization, the recorded-time schema check, the recorded-time migration's column read) finds `catalog` absent — a profile whose `provisioning.catalog` is unset builds a backend with no `catalog` member at all. |
 | `ENGINE_PROFILE_OVERRIDE_UNSUPPORTED` | `deriveEngineProfile`'s `overrides` names a key outside the derivable set, or one of the three adapter-backed sub-fields with a changed value (see [the carve-out](#the-adapter-backed-carve-out)). |
 | `ENGINE_ASSEMBLY_UNRECOGNIZED` | The profile's `assembly` is not a value `assembleEngine` produced — a profile built by hand rather than obtained from a bundled builder (optionally adapted with `deriveEngineProfile`). |
@@ -243,19 +247,19 @@ forward, even when every field is copied from a first-party profile
 unchanged. That costs a derived profile's backend two things:
 
 - **No dialect-derivation fallback.** `resolveWriteFencePlan`'s fallback
-  for a profile with no `pessimisticLocks` declaration is sound only for
-  the two bundled dialects, so it never applies to a derived profile
-  regardless — irrelevant in practice as long as `declaredCapabilities`
-  is kept, since both bundled declarations already carry
-  `pessimisticLocks` explicitly.
+  for a profile with neither `writeFence` nor `pessimisticLocks` declared
+  is sound only for the two bundled dialects, so it never applies to a
+  derived profile regardless — irrelevant in practice as long as
+  `declaredCapabilities` is kept, since both bundled declarations already
+  carry a write-fence declaration explicitly.
 - **No lazy per-transaction schema-fence lease.** The lease
   `store/operations/write-transaction.ts` takes out under
   `isFirstPartyFactory` is closed to a derived profile's backend; each
   managed write takes its own fence instead.
 
-Every gate `createSqlBackend` runs — the `pessimisticLocks` refusal, the
-`advisoryLocks` without `fenceSql` refusal, the schema-fenced-insert and
-autocommit marks — still applies to a derived profile exactly as it does
+Every gate `createSqlBackend` runs — the write-fence-declaration refusal, the
+`mechanism: "advisory"` without `fenceSql` refusal, the schema-fenced-insert
+and autocommit marks — still applies to a derived profile exactly as it does
 to a bundled one.
 
 A bundled profile object is frozen once its builder returns it: mutating a

--- a/apps/docs/src/content/docs/backend-authoring.md
+++ b/apps/docs/src/content/docs/backend-authoring.md
@@ -76,7 +76,7 @@ consistently.
 
 | Field | What overriding it changes |
 | --- | --- |
-| `declaredCapabilities` | The capabilities `finalizeEngineCapabilities` derives the rest of the backend's advertised capabilities from — for example, declaring `writeFence` (or the deprecated `pessimisticLocks`) differently changes which write-fence plan resolves. |
+| `declaredCapabilities` | The capabilities `finalizeEngineCapabilities` derives the rest of the backend's advertised capabilities from — for example, declaring `writeFence` differently changes which write-fence plan resolves. |
 | `fenceSql` | The lock-statement spelling the resolved fence plan carries; pass `undefined` to remove it entirely (see [Removing `fenceSql`](#removing-fencesql) below). |
 | `resourceAudit` | The serialized-resource verdict `createSqlBackend` records before the backend escapes. |
 | `autocommit` | Whether a single statement outside an explicit transaction is durable — gates the root-autocommit mark. |
@@ -108,7 +108,7 @@ which is not itself derivable. Deriving from a SQLite base refuses the same
 override even though `buildSqliteEngineProfile`'s operation backend reads
 `maxBindParameters` off the resolved capabilities directly and would honor
 a changed value — the check does not distinguish the two dialects. Every
-other sub-field on both objects — `writeFence`, `pessimisticLocks`,
+other sub-field on both objects — `writeFence`,
 `windowFunctions`, `clearValidTo`, `returning`, `claims`, `graphAnalytics`,
 `resourceAudit`'s `resource` / `identityLeaseResource`, and so on — stays
 freely derivable.
@@ -218,10 +218,8 @@ this same derivation can override (see the table above).
 `fenceSql: undefined` to drop the bundled spelling entirely. That alone
 is not enough to reach a working profile — `createSqlBackend` still
 resolves a write-fence plan eagerly, and a profile whose resolved
-`writeFence.mechanism` (or the deprecated
-`declaredCapabilities.pessimisticLocks.advisoryLocks`) is still
-`"advisory"` (or `true`) with no `fenceSql` refuses with
-`WRITE_FENCE_SQL_UNAVAILABLE`. Pair it with a `declaredCapabilities`
+`writeFence.mechanism` is still `"advisory"` with no `fenceSql` refuses
+with `WRITE_FENCE_SQL_UNAVAILABLE`. Pair it with a `declaredCapabilities`
 override that stops claiming `"advisory"` (for example, declaring
 `writeFence: { mechanism: "engine-serialized", drain: "table-lock" }`
 instead) to actually resolve an `engine-serialized` plan that needs no
@@ -231,9 +229,8 @@ lock spelling at all.
 
 | Code | When |
 | --- | --- |
-| `ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION` | The profile's resolved capabilities omit both `writeFence` and the deprecated `pessimisticLocks` — `createSqlBackend` has no write-fence decision to resolve and refuses outright, naming the one capabilities line to add. |
-| `WRITE_FENCE_DECLARATION_CONFLICT` | The profile's resolved capabilities declare BOTH `writeFence` and `pessimisticLocks` — exactly one write-fence declaration is allowed. |
-| `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved capabilities declare `mechanism: "advisory"` (or the legacy `pessimisticLocks.advisoryLocks: true`) but the profile's `fenceSql` is missing the member that mechanism/drain combination needs. |
+| `ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION` | The profile's resolved capabilities omit `writeFence` — `createSqlBackend` has no write-fence decision to resolve and refuses outright, naming the one capabilities line to add. |
+| `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved capabilities declare `mechanism: "advisory"` but the profile's `fenceSql` is missing the member that mechanism/drain combination needs. |
 | `CATALOG_UNAVAILABLE` | A store path that needs the backend's catalog probes (index materialization, the recorded-time schema check, the recorded-time migration's column read) finds `catalog` absent — a profile whose `provisioning.catalog` is unset builds a backend with no `catalog` member at all. |
 | `ENGINE_PROFILE_OVERRIDE_UNSUPPORTED` | `deriveEngineProfile`'s `overrides` names a key outside the derivable set, or one of the three adapter-backed sub-fields with a changed value (see [the carve-out](#the-adapter-backed-carve-out)). |
 | `ENGINE_ASSEMBLY_UNRECOGNIZED` | The profile's `assembly` is not a value `assembleEngine` produced — a profile built by hand rather than obtained from a bundled builder (optionally adapted with `deriveEngineProfile`). |
@@ -247,8 +244,8 @@ forward, even when every field is copied from a first-party profile
 unchanged. That costs a derived profile's backend two things:
 
 - **No dialect-derivation fallback.** `resolveWriteFencePlan`'s fallback
-  for a profile with neither `writeFence` nor `pessimisticLocks` declared
-  is sound only for the two bundled dialects, so it never applies to a
+  for a profile with no `writeFence` declared is sound only for the two
+  bundled dialects, so it never applies to a
   derived profile regardless — irrelevant in practice as long as
   `declaredCapabilities` is kept, since both bundled declarations already
   carry a write-fence declaration explicitly.

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1543,7 +1543,7 @@ take a relation-wide lock on the table a drain site protects:
 | --- | --- |
 | `"table-lock"` | Yes — a `LOCK TABLE`-style statement is available and the drain site takes it. |
 | `"quiescent"` | The resource is already exclusive for some other reason (`caller-serialized`'s promise, or an engine's own writer slot), so the drain site takes NO statement — one it does not need rather than one it cannot spell. |
-| `"none"` | Neither. A drain site refuses, naming the drain that could not be satisfied. |
+| `"none"` | Neither — under `mechanism: "advisory"` a drain site refuses, naming the drain. `engine-serialized` and `caller-serialized` satisfy every drain site regardless of this value. |
 
 `resolveWriteFencePlan` resolves one of four plans:
 
@@ -2046,7 +2046,7 @@ TypeGraph choosing separate query semantics per backend:
 | Typed constraint error above READ COMMITTED            | n/a (no such isolation mode)                      | ✗ at `REPEATABLE READ` / `SERIALIZABLE`    | PostgreSQL raises `40001` from the claim's upsert instead of resolving the conflict, so the loser retries a serialization failure rather than reading `UniquenessError` |
 | Claim row lock released before end of transaction      | ✗                                                 | ✗                                          | Held to commit/rollback on both dialects, refusal included — a caller that catches a constraint error blocks other writers of that axis for the rest of its transaction |
 | Recursive traversal (`capabilities.recursiveTraversal`) | ✓                                                 | ✓                                          | Identical on both bundled backends. A third-party backend declaring `{ supported: false, reason }` refuses the five recursion-dependent operations with `ConfigurationError` code `RECURSIVE_TRAVERSAL_UNSUPPORTED`; `weightedShortestPath` degrades to a predecessor walk instead — see above. Unweighted `shortestPath` is unaffected — it never emits a recursive CTE |
-| Write fence (`capabilities.writeFence`)           | ✓ `engine-serialized` (single writer slot)        | ✓ `lock` (advisory + table locks)          | Identical guarantee, different mechanism. A custom backend that declares neither resolves `unfenced` and is refused at construction for Operational Identity or TypeGraph-owned recorded-clock allocation |
+| Write fence (`capabilities.writeFence`)           | ✓ `engine-serialized` (single writer slot)        | ✓ `lock` (advisory + table locks)          | Identical guarantee, different mechanism. A custom backend that declares no `writeFence` resolves `unfenced` and is refused at construction for Operational Identity or TypeGraph-owned recorded-clock allocation |
 | Recorded-time ownership (`capabilities.recordedTimeOwnership`) | `"typegraph-relations"` (default)          | `"typegraph-relations"` (default)          | Both bundled backends own the clock today. `"engine-native"` is refused at construction as an interim measure whenever it is combined with `history`/`revisionTracking`, on either dialect |
 | Capability bundles (`CAPABILITY_BUNDLES`)               | Identical                                         | Identical                                  | Both bundled backends implement every pilot bundle's core/extra members on both dialects it scopes to. A third-party backend with a port gap refuses (gated core, or a `refuse`-disposition extra) or degrades (a `fallback`-disposition extra) per that bundle's own registry row |
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1156,7 +1156,7 @@ example, and [what is not derivable yet](/backend-authoring#what-is-not-derivabl
 
 A profile owns everything that genuinely differs between engines: dialect
 tokens, the execution adapter, transaction framing, its `fenceSql` lock
-spelling (see [Write fence declaration](#write-fence-declaration-pessimisticlocks)),
+spelling (see [Write fence declaration](#write-fence-declaration-writefence)),
 provisioning DDL, strategies, and limits. `createSqlBackend` owns everything that is the
 same for every SQL engine: deriving the final capabilities, resolving the
 write-fence decision once, assembling the mirrored member groups, auditing
@@ -1225,7 +1225,7 @@ their own profiles; neither is exported, so a from-scratch profile reaches the s
 copying a bundled profile and adapting its statement, while a derived profile can replace the whole
 `graphTemplateRuntime` bag through `deriveEngineProfile`.
 
-`FenceSql` (see [Write fence declaration](#write-fence-declaration-pessimisticlocks))
+`FenceSql` (see [Write fence declaration](#write-fence-declaration-writefence))
 declares `advisoryLockExpression` and `isolationFactExpression` as the two
 composable, no-`SELECT` forms a backend author supplies; TypeGraph derives
 the standalone-statement counterparts (`advisoryLock`,
@@ -1390,7 +1390,8 @@ can inspect the same object as `backend.capabilities`. The shape is:
 | `vector?.metrics` / `vector?.indexTypes` / `vector?.maxDimensions`         | Vector strategy capabilities (present once a vector strategy is configured)                         |
 | `fulltext?.{supported,languages,phraseQueries,prefixQueries,highlighting}` | Fulltext strategy capabilities                                                                      |
 | `recursiveTraversal?.{supported,reason}`                                   | Whether the engine can compute a bounded transitive closure of a relation in one round trip — a recursive CTE, or a graph-native expansion operator. **Absent means supported** |
-| `pessimisticLocks?.{advisoryLocks,tableLocks,serializedWriters}`           | How this engine serializes concurrent writers, if at all — see [Write fence declaration](#write-fence-declaration-pessimisticlocks) |
+| `writeFence?.{mechanism,drain}`                                            | How this engine excludes concurrent writers, and how far a caller can drain a table lock — see [Write fence declaration](#write-fence-declaration-writefence) |
+| `pessimisticLocks?.{advisoryLocks,tableLocks,serializedWriters}` (deprecated) | The legacy write-fence declaration `writeFence` replaces — see [Write fence declaration](#write-fence-declaration-writefence) |
 | `recordedTimeOwnership?`                                                  | Who allocates recorded-time revisions — see [Recorded-time ownership](#recorded-time-ownership-recordedtimeownership) |
 
 The former top-level `capabilities.transactions` override is not interpreted
@@ -1512,27 +1513,105 @@ round trip. The unweighted `shortestPath` (along with `reachable`, `canReach`, a
 emits no recursive CTE at all — it routes through the iterative working-table or inline path
 instead — so it neither refuses nor falls back regardless of this declaration.
 
-### Write fence declaration (pessimisticLocks)
+<a id="write-fence-declaration-pessimisticlocks"></a>
+
+### Write fence declaration (writeFence)
 
 TypeGraph serializes a family of writes — Operational Identity's mutations, and the
 TypeGraph-owned recorded-clock allocation behind `history` / `revisionTracking` — behind a
-per-graph fence rather than trusting the engine's default isolation. `capabilities.pessimisticLocks`
-declares what this backend can provide, and `resolveWriteFencePlan` is the one place that
-declaration turns into a plan every lock site consumes instead of re-deriving:
+per-graph fence rather than trusting the engine's default isolation. `capabilities.writeFence`
+declares what this backend can provide, as two independent facts, and `resolveWriteFencePlan` is
+the one place that declaration turns into a plan every lock site consumes instead of re-deriving:
 
-- `{ kind: "lock", advisoryLocks: true, tableLocks: boolean }` — take the declared keyed
-  (and, where needed, table) lock.
-- `{ kind: "engine-serialized" }` — no lock needed; the engine serializes writers by
-  construction (SQLite's single writer slot).
-- `{ kind: "unfenced" }` — neither. Every fence that guards a read-then-write across statements
-  refuses rather than running unfenced. Only a predicate carried *inside* the statement it
-  guards degrades, since one statement cannot race itself.
+```typescript
+const capabilities: Partial<BackendCapabilities> = {
+  writeFence: { mechanism: "advisory", drain: "table-lock" },
+};
+```
 
-Resolution order: (1) the declared `pessimisticLocks` value, if present; (2) absent AND the
-backend was built by `createSqliteBackend` / `createPostgresBackend` — derived from `dialect`,
-which is exactly what every lock site used to compute inline; (3) absent on anything else —
-`unfenced`, because an undeclared custom backend is by definition uncertified and inferring
-lock support from `dialect` alone is the unsound inference this capability replaces.
+`mechanism` is how the backend excludes concurrent writers:
+
+| `mechanism` | Meaning |
+| --- | --- |
+| `"advisory"` | A keyed `pg_advisory_xact_lock`-style lock a caller takes explicitly. Needs `fenceSql` (below). |
+| `"engine-serialized"` | The engine serializes writers by construction — SQLite's single writer slot. No lock statement, no `fenceSql`. |
+| `"caller-serialized"` | A deployment-level promise, not an engine fact — see below. No lock statement; a `fenceSql` the backend still carries is used only for its isolation-fact read (recorded capture's isolation guard). |
+
+`drain` is a separate fact: whether a caller that already excluded other writers can additionally
+take a relation-wide lock on the table a drain site protects:
+
+| `drain` | Meaning |
+| --- | --- |
+| `"table-lock"` | Yes — a `LOCK TABLE`-style statement is available and the drain site takes it. |
+| `"quiescent"` | The resource is already exclusive for some other reason (`caller-serialized`'s promise, or an engine's own writer slot), so the drain site takes NO statement — one it does not need rather than one it cannot spell. |
+| `"none"` | Neither. A drain site refuses, naming the drain that could not be satisfied. |
+
+`resolveWriteFencePlan` resolves one of four plans:
+
+- `{ kind: "lock", drain, sql }` — take the declared keyed lock (`sql`, the target's own spelling),
+  and, when `drain === "table-lock"`, the table lock a drain site needs.
+- `{ kind: "engine-serialized" }` — no lock needed; the engine serializes writers by construction.
+- `{ kind: "caller-serialized" }` — no lock needed; the deployment's own promise excludes concurrent
+  writers (see below).
+- `{ kind: "unfenced", reason }` — none of the above. Every fence that guards a read-then-write
+  across statements refuses rather than running unfenced. Only a predicate carried *inside* the
+  statement it guards degrades, since one statement cannot race itself.
+
+Resolution order: (1) the declared `writeFence` value, if present; (2) the deprecated
+`pessimisticLocks` (below), mapped to the same shape, if `writeFence` is absent; (3) both present —
+refused with `WRITE_FENCE_DECLARATION_CONFLICT`, naming both declarations, since exactly one can be
+the effective one; (4) neither present AND the backend was built by `createSqliteBackend` /
+`createPostgresBackend` — derived from `dialect`, which is exactly what every lock site used to
+compute inline; (5) neither present on anything else — `unfenced`, because an undeclared custom
+backend is by definition uncertified and inferring lock support from `dialect` alone is the unsound
+inference this capability replaces.
+
+The two bundled backends resolve exactly these declarations — copy the one matching your engine.
+(In this release they still declare the legacy `pessimisticLocks` shape below, which
+`resolveWriteFencePlan` maps to the line shown; a future release may declare `writeFence` directly,
+with no change to what either backend resolves to.)
+
+- PostgreSQL: `writeFence: { mechanism: "advisory", drain: "table-lock" }`
+- SQLite: `writeFence: { mechanism: "engine-serialized", drain: "table-lock" }` (the writer slot
+  already excludes every drain site's writer, so a drain site under it always takes no statement,
+  read the same way `"quiescent"` is)
+
+A backend that declares `mechanism: "advisory"` also supplies `fenceSql`: `lockTables` (only needed
+when `drain: "table-lock"`) plus the two composable, no-`SELECT` forms `advisoryLockExpression` /
+`isolationFactExpression` a statement embeds inside a larger query it builds itself (see the
+schema-write-fence discussion above) — the complete `FenceSql` bag. `resolveWriteFencePlan`'s `lock`
+arm derives the standalone-statement forms every ordinary lock site actually calls —
+`advisoryLock`; `advisoryLockWithIsolation` (the lock plus the session's isolation-level fact, read
+in the same statement it locks in); and `isolationFact` — from those two expressions, so a backend
+author never spells both forms separately. The bundled PostgreSQL spelling is exported as
+`postgresFenceSql` from `@nicia-ai/typegraph/adapters/drizzle/postgres` — pass it straight through
+as `fenceSql` when wrapping that backend, or supply a custom `FenceSql` matching a different
+engine's lock syntax. A backend that declares `mechanism: "advisory"` with a `fenceSql` missing a
+member the resolved `mechanism`/`drain` combination needs is refused at construction with details
+code `WRITE_FENCE_SQL_UNAVAILABLE`, naming the missing member; `"engine-serialized"` and
+`"caller-serialized"` need no `fenceSql` to take a lock at all.
+
+#### `caller-serialized`: the promise split into two halves
+
+`caller-serialized` is for a deployment that knows its database has no other concurrent writer, but
+whose engine is neither an advisory-lock engine nor a single-writer one — a PostgreSQL-wire engine
+with no working `pg_advisory_xact_lock` / `LOCK TABLE`, for example. The promise has two halves,
+and TypeGraph only enforces the first:
+
+- **In process**, TypeGraph enforces it: every write unit issued through a `caller-serialized`
+  backend — collection writes, `store.transaction`, schema commits, identity and contribution
+  maintenance, index materialization, import — runs through one per-backend serialized queue, so
+  two concurrent calls through one pool cannot race each other.
+- **Outside the process**, the deployment enforces it: no other client writes to this database
+  while this backend is open. TypeGraph cannot see or verify that half; declaring
+  `caller-serialized` is asserting it.
+
+`createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized", drain }` — a claim
+about the deployment — while still refusing the legacy `pessimisticLocks.serializedWriters: true`
+outright, because that boolean is a claim about the *engine*, which this factory's own engine does
+not back.
+
+#### The legacy shape (`pessimisticLocks`)
 
 ```typescript
 const capabilities: Partial<BackendCapabilities> = {
@@ -1540,24 +1619,20 @@ const capabilities: Partial<BackendCapabilities> = {
 };
 ```
 
-The two bundled backends declare exactly these lines — copy the one matching your engine:
+`pessimisticLocks` is deprecated in favor of `writeFence` but stays accepted — `resolveWriteFencePlan`
+maps it through one function, `writeFenceFromLegacyLocks`:
 
-- PostgreSQL: `pessimisticLocks: { advisoryLocks: true, tableLocks: true, serializedWriters: false }`
-- SQLite: `pessimisticLocks: { advisoryLocks: false, tableLocks: false, serializedWriters: true }`
+| Legacy declaration | Maps to |
+| --- | --- |
+| `{ advisoryLocks: true, tableLocks }` | `{ mechanism: "advisory", drain: tableLocks ? "table-lock" : "none" }` |
+| `{ serializedWriters: true }` | `{ mechanism: "engine-serialized", drain: "table-lock" }` |
+| `{ advisoryLocks: false, tableLocks: true, serializedWriters: false }` | `unfenced` (reason `"table-locks-only"`) — TypeGraph has no table-lock-only fence |
+| all three `false` | `unfenced` (reason `"declared-none"`) |
 
-A backend that declares `advisoryLocks: true` also supplies `fenceSql`: `lockTables` plus the two
-composable, no-`SELECT` forms `advisoryLockExpression` / `isolationFactExpression` a statement embeds
-inside a larger query it builds itself (see the schema-write-fence discussion above) — the complete,
-three-member `FenceSql` bag. `resolveWriteFencePlan`'s `lock` arm derives the standalone-statement
-forms every ordinary lock site actually calls — `advisoryLock`; `advisoryLockWithIsolation` (the
-lock plus the session's isolation-level fact, read in the same statement it locks in); and
-`isolationFact` — from those two expressions, so a backend author never spells both forms separately.
-The bundled PostgreSQL spelling is exported as `postgresFenceSql`
-from `@nicia-ai/typegraph/adapters/drizzle/postgres` — pass it straight through as `fenceSql` when
-wrapping that backend, or supply a custom `FenceSql` matching a different engine's lock syntax. A
-backend that declares `advisoryLocks: true` with no `fenceSql` is refused at construction with
-details code `WRITE_FENCE_SQL_UNAVAILABLE`, naming the member to supply; `serializedWriters: true`
-needs no `fenceSql` since it takes no lock at all.
+The resolved `lock` plan's `tableLocks: boolean` field is kept for source compatibility and is
+derived from `drain` (`=== "table-lock"`) — read `drain` in new code, since it distinguishes a
+declaration that cannot drain a site at all (`"none"`) from one that drains it without a statement
+(`"quiescent"`), a distinction `tableLocks: false` collapses to one case.
 
 Constructing Operational Identity, or `history: true` / `revisionTracking: true`, against an
 `unfenced` backend is refused immediately at `createStore` — never mid-flush — with
@@ -1565,10 +1640,10 @@ Constructing Operational Identity, or `history: true` / `revisionTracking: true`
 `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` (recorded-clock allocation), and the refusal message names
 the exact declaration line to add.
 
-A declared-advisory-only backend (`tableLocks: false`) that reaches a site whose operation
-`requires: "table-lock"` is refused with details code `WRITE_FENCE_UNAVAILABLE`, naming
-`details.operation` and `details.requires` — the lock plan resolved, but it cannot satisfy what
-this specific operation needs.
+A `lock` plan whose `drain` cannot back a site's `requires: "table-lock"` — `drain: "none"` — is
+refused with details code `WRITE_FENCE_UNAVAILABLE`, naming `details.operation` and the drain that
+could not be satisfied. `"engine-serialized"` and `"caller-serialized"` satisfy either `requires`
+value without consulting `drain`.
 
 The PostgreSQL schema fence refuses too, and it is worth knowing why it is not on the
 degradable side. The per-graph advisory lock plus `SELECT ... FOR UPDATE` a schema commit takes,
@@ -1589,7 +1664,11 @@ path, on the strength of its writer slot.
 This matters for **DoltgreSQL**, which speaks the PostgreSQL wire protocol but implements neither
 `pg_advisory_xact_lock` nor the `FOR UPDATE` / `FOR SHARE` clauses
 ([doltgresql#2600](https://github.com/dolthub/doltgresql/issues/2600)), and whose engine merges
-concurrent transactions rather than serializing them — so all three facts are false:
+concurrent transactions rather than serializing them — so all three facts are false.
+
+`writeFence` has no arm for "no exclusion mechanism at all" — every `mechanism` value claims
+something real. An engine with neither locks nor a writer slot nor a caller promise to make still
+declares the legacy shape, all three fields `false`:
 
 ```typescript
 const backend = createPostgresBackend(db, {
@@ -1603,10 +1682,13 @@ Declared that way, the backend is honest about what it can do — and TypeGraph 
 schema-managed store is refused at construction, naming the missing capability, rather than
 running a fence the engine cannot enforce.
 
-Do not reach for `serializedWriters: true` because a deployment clamps its pool to one
-connection. That field means the engine serializes writers *by construction*; a deployment
-convention is not a construction, and declaring it would silently re-enable the fences that
-depend on it. (`createPostgresBackend` refuses that particular claim outright for this reason.)
+If the deployment instead knows it is the only writer of this database — a pool clamped to one
+connection, or a single-writer topology otherwise enforced outside TypeGraph — declare
+`writeFence: { mechanism: "caller-serialized", drain: "quiescent" }` instead (see above): that is
+the honest way to spell a deployment convention. Do not reach for `serializedWriters: true` (or
+`mechanism: "engine-serialized"`) for the same purpose — that declaration means the *engine*
+serializes writers by construction, and a deployment convention is not a construction.
+`createPostgresBackend` refuses that particular claim outright for this reason.
 
 ### Recorded-time ownership (recordedTimeOwnership)
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1170,7 +1170,7 @@ engine with a different locking story or an embedded engine with a different
 transaction model.
 
 `createSqlBackend` refuses a profile whose resolved capabilities omit
-`pessimisticLocks` — every mark and registration it applies assumes a
+`writeFence` — every mark and registration it applies assumes a
 resolvable write-fence decision, and a profile that does not declare one
 cannot back that decision soundly. `buildPostgresEngineProfile` and
 `buildSqliteEngineProfile` are the reference profiles to read when modeling a
@@ -1391,7 +1391,6 @@ can inspect the same object as `backend.capabilities`. The shape is:
 | `fulltext?.{supported,languages,phraseQueries,prefixQueries,highlighting}` | Fulltext strategy capabilities                                                                      |
 | `recursiveTraversal?.{supported,reason}`                                   | Whether the engine can compute a bounded transitive closure of a relation in one round trip — a recursive CTE, or a graph-native expansion operator. **Absent means supported** |
 | `writeFence?.{mechanism,drain}`                                            | How this engine excludes concurrent writers, and how far a caller can drain a table lock — see [Write fence declaration](#write-fence-declaration-writefence) |
-| `pessimisticLocks?.{advisoryLocks,tableLocks,serializedWriters}` (deprecated) | The legacy write-fence declaration `writeFence` replaces — see [Write fence declaration](#write-fence-declaration-writefence) |
 | `recordedTimeOwnership?`                                                  | Who allocates recorded-time revisions — see [Recorded-time ownership](#recorded-time-ownership-recordedtimeownership) |
 
 The former top-level `capabilities.transactions` override is not interpreted
@@ -1553,23 +1552,17 @@ take a relation-wide lock on the table a drain site protects:
 - `{ kind: "engine-serialized" }` — no lock needed; the engine serializes writers by construction.
 - `{ kind: "caller-serialized" }` — no lock needed; the deployment's own promise excludes concurrent
   writers (see below).
-- `{ kind: "unfenced", reason }` — none of the above. Every fence that guards a read-then-write
-  across statements refuses rather than running unfenced. Only a predicate carried *inside* the
-  statement it guards degrades, since one statement cannot race itself.
+- `{ kind: "unfenced" }` — no declaration at all. Every fence that guards a read-then-write across
+  statements refuses rather than running unfenced. Only a predicate carried *inside* the statement
+  it guards degrades, since one statement cannot race itself.
 
-Resolution order: (1) the declared `writeFence` value, if present; (2) the deprecated
-`pessimisticLocks` (below), mapped to the same shape, if `writeFence` is absent; (3) both present —
-refused with `WRITE_FENCE_DECLARATION_CONFLICT`, naming both declarations, since exactly one can be
-the effective one; (4) neither present AND the backend was built by `createSqliteBackend` /
-`createPostgresBackend` — derived from `dialect`, which is exactly what every lock site used to
-compute inline; (5) neither present on anything else — `unfenced`, because an undeclared custom
-backend is by definition uncertified and inferring lock support from `dialect` alone is the unsound
-inference this capability replaces.
+Resolution order: (1) the declared `writeFence` value, if present; (2) absent, AND the backend was
+built by `createSqliteBackend` / `createPostgresBackend` — derived from `dialect`, which is exactly
+what every lock site used to compute inline; (3) absent on anything else — `unfenced`, because an
+undeclared custom backend is by definition uncertified and inferring lock support from `dialect`
+alone is the unsound inference this capability replaces.
 
-The two bundled backends resolve exactly these declarations — copy the one matching your engine.
-(In this release they still declare the legacy `pessimisticLocks` shape below, which
-`resolveWriteFencePlan` maps to the line shown; a future release may declare `writeFence` directly,
-with no change to what either backend resolves to.)
+The two bundled backends resolve exactly these declarations — copy the one matching your engine:
 
 - PostgreSQL: `writeFence: { mechanism: "advisory", drain: "table-lock" }`
 - SQLite: `writeFence: { mechanism: "engine-serialized", drain: "table-lock" }` (the writer slot
@@ -1607,32 +1600,8 @@ and TypeGraph only enforces the first:
   `caller-serialized` is asserting it.
 
 `createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized", drain }` — a claim
-about the deployment — while still refusing the legacy `pessimisticLocks.serializedWriters: true`
-outright, because that boolean is a claim about the *engine*, which this factory's own engine does
-not back.
-
-#### The legacy shape (`pessimisticLocks`)
-
-```typescript
-const capabilities: Partial<BackendCapabilities> = {
-  pessimisticLocks: { advisoryLocks: true, tableLocks: true, serializedWriters: false },
-};
-```
-
-`pessimisticLocks` is deprecated in favor of `writeFence` but stays accepted — `resolveWriteFencePlan`
-maps it through one function, `writeFenceFromLegacyLocks`:
-
-| Legacy declaration | Maps to |
-| --- | --- |
-| `{ advisoryLocks: true, tableLocks }` | `{ mechanism: "advisory", drain: tableLocks ? "table-lock" : "none" }` |
-| `{ serializedWriters: true }` | `{ mechanism: "engine-serialized", drain: "table-lock" }` |
-| `{ advisoryLocks: false, tableLocks: true, serializedWriters: false }` | `unfenced` (reason `"table-locks-only"`) — TypeGraph has no table-lock-only fence |
-| all three `false` | `unfenced` (reason `"declared-none"`) |
-
-The resolved `lock` plan's `tableLocks: boolean` field is kept for source compatibility and is
-derived from `drain` (`=== "table-lock"`) — read `drain` in new code, since it distinguishes a
-declaration that cannot drain a site at all (`"none"`) from one that drains it without a statement
-(`"quiescent"`), a distinction `tableLocks: false` collapses to one case.
+about the deployment — while still refusing `mechanism: "engine-serialized"` outright, because that
+value is a claim about the *engine*, which this factory's own engine does not back.
 
 Constructing Operational Identity, or `history: true` / `revisionTracking: true`, against an
 `unfenced` backend is refused immediately at `createStore` — never mid-flush — with
@@ -1640,10 +1609,10 @@ Constructing Operational Identity, or `history: true` / `revisionTracking: true`
 `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` (recorded-clock allocation), and the refusal message names
 the exact declaration line to add.
 
-A `lock` plan whose `drain` cannot back a site's `requires: "table-lock"` — `drain: "none"` — is
+A `lock` plan whose `drain` cannot back a site's `requires: "drain"` — `drain: "none"` — is
 refused with details code `WRITE_FENCE_UNAVAILABLE`, naming `details.operation` and the drain that
 could not be satisfied. `"engine-serialized"` and `"caller-serialized"` satisfy either `requires`
-value without consulting `drain`.
+value (`"keyed"` or `"drain"`) without consulting `drain`.
 
 The PostgreSQL schema fence refuses too, and it is worth knowing why it is not on the
 degradable side. The per-graph advisory lock plus `SELECT ... FOR UPDATE` a schema commit takes,
@@ -1661,34 +1630,40 @@ itself: with no locking clause the fence subquery still yields no row when the e
 is no longer active, so the INSERT still writes nothing. This is how SQLite has always run the
 path, on the strength of its writer slot.
 
-This matters for **DoltgreSQL**, which speaks the PostgreSQL wire protocol but implements neither
-`pg_advisory_xact_lock` nor the `FOR UPDATE` / `FOR SHARE` clauses
-([doltgresql#2600](https://github.com/dolthub/doltgresql/issues/2600)), and whose engine merges
-concurrent transactions rather than serializing them — so all three facts are false.
+This matters for a PostgreSQL-wire engine that implements neither `pg_advisory_xact_lock` nor the
+`FOR UPDATE` / `FOR SHARE` clauses, and whose engine merges concurrent transactions rather than
+serializing them.
 
 `writeFence` has no arm for "no exclusion mechanism at all" — every `mechanism` value claims
-something real. An engine with neither locks nor a writer slot nor a caller promise to make still
-declares the legacy shape, all three fields `false`:
+something real. An engine with neither locks nor a writer slot nor a caller promise to make has
+nothing honest to declare, and `unfenced` is how that shows up downstream — but neither bundled
+factory will hand you that backend. `createPostgresBackend` and `createSqliteBackend` both build on
+`createSqlBackend`, which refuses at construction, with `ConfigurationError` details code
+`ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION`, when the resolved capabilities carry no
+`writeFence` at all — including `capabilities: { writeFence: undefined }` passed to either factory,
+which no longer builds a backend the way it once did:
 
 ```typescript
-const backend = createPostgresBackend(db, {
-  capabilities: {
-    pessimisticLocks: { advisoryLocks: false, tableLocks: false, serializedWriters: false },
-  },
+createPostgresBackend(db, {
+  capabilities: { writeFence: undefined },
 });
+// throws ConfigurationError: ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION
 ```
 
-Declared that way, the backend is honest about what it can do — and TypeGraph is honest back: a
-schema-managed store is refused at construction, naming the missing capability, rather than
+`unfenced` is reachable only outside that gate: a hand-assembled `GraphBackend` that never goes
+through `createSqlBackend`, or a custom `SqlEngineProfile` whose `declaredCapabilities.writeFence`
+some other override clears before it reaches a call site — never through either bundled factory.
+Getting there is a way of admitting the engine truly has nothing to declare; TypeGraph then refuses
+a schema-managed store built on it at `createStore`, naming the missing capability, rather than
 running a fence the engine cannot enforce.
 
 If the deployment instead knows it is the only writer of this database — a pool clamped to one
 connection, or a single-writer topology otherwise enforced outside TypeGraph — declare
 `writeFence: { mechanism: "caller-serialized", drain: "quiescent" }` instead (see above): that is
-the honest way to spell a deployment convention. Do not reach for `serializedWriters: true` (or
-`mechanism: "engine-serialized"`) for the same purpose — that declaration means the *engine*
-serializes writers by construction, and a deployment convention is not a construction.
-`createPostgresBackend` refuses that particular claim outright for this reason.
+the honest way to spell a deployment convention. Do not reach for `mechanism: "engine-serialized"`
+for the same purpose — that declaration means the *engine* serializes writers by construction, and
+a deployment convention is not a construction. `createPostgresBackend` refuses that particular
+claim outright for this reason.
 
 ### Recorded-time ownership (recordedTimeOwnership)
 
@@ -2071,7 +2046,7 @@ TypeGraph choosing separate query semantics per backend:
 | Typed constraint error above READ COMMITTED            | n/a (no such isolation mode)                      | ✗ at `REPEATABLE READ` / `SERIALIZABLE`    | PostgreSQL raises `40001` from the claim's upsert instead of resolving the conflict, so the loser retries a serialization failure rather than reading `UniquenessError` |
 | Claim row lock released before end of transaction      | ✗                                                 | ✗                                          | Held to commit/rollback on both dialects, refusal included — a caller that catches a constraint error blocks other writers of that axis for the rest of its transaction |
 | Recursive traversal (`capabilities.recursiveTraversal`) | ✓                                                 | ✓                                          | Identical on both bundled backends. A third-party backend declaring `{ supported: false, reason }` refuses the five recursion-dependent operations with `ConfigurationError` code `RECURSIVE_TRAVERSAL_UNSUPPORTED`; `weightedShortestPath` degrades to a predecessor walk instead — see above. Unweighted `shortestPath` is unaffected — it never emits a recursive CTE |
-| Write fence (`capabilities.pessimisticLocks`)           | ✓ `engine-serialized` (single writer slot)        | ✓ `lock` (advisory + table locks)          | Identical guarantee, different mechanism. A custom backend that declares neither resolves `unfenced` and is refused at construction for Operational Identity or TypeGraph-owned recorded-clock allocation |
+| Write fence (`capabilities.writeFence`)           | ✓ `engine-serialized` (single writer slot)        | ✓ `lock` (advisory + table locks)          | Identical guarantee, different mechanism. A custom backend that declares neither resolves `unfenced` and is refused at construction for Operational Identity or TypeGraph-owned recorded-clock allocation |
 | Recorded-time ownership (`capabilities.recordedTimeOwnership`) | `"typegraph-relations"` (default)          | `"typegraph-relations"` (default)          | Both bundled backends own the clock today. `"engine-native"` is refused at construction as an interim measure whenever it is combined with `history`/`revisionTracking`, on either dialect |
 | Capability bundles (`CAPABILITY_BUNDLES`)               | Identical                                         | Identical                                  | Both bundled backends implement every pilot bundle's core/extra members on both dialects it scopes to. A third-party backend with a port gap refuses (gated core, or a `refuse`-disposition extra) or degrades (a `fallback`-disposition extra) per that bundle's own registry row |
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -1528,22 +1528,29 @@ const capabilities: Partial<BackendCapabilities> = {
 };
 ```
 
-`mechanism` is how the backend excludes concurrent writers:
+`mechanism` is how the backend excludes concurrent writers. `writeFence` is a discriminated union on
+`mechanism`, and `drain` is a field of the `"advisory"` shape only — `"engine-serialized"` and
+`"caller-serialized"` declarations carry no `drain` key at all:
 
 | `mechanism` | Meaning |
 | --- | --- |
-| `"advisory"` | A keyed `pg_advisory_xact_lock`-style lock a caller takes explicitly. Needs `fenceSql` (below). |
-| `"engine-serialized"` | The engine serializes writers by construction — SQLite's single writer slot. No lock statement, no `fenceSql`. |
-| `"caller-serialized"` | A deployment-level promise, not an engine fact — see below. No lock statement; a `fenceSql` the backend still carries is used only for its isolation-fact read (recorded capture's isolation guard). |
+| `"advisory"` | A keyed `pg_advisory_xact_lock`-style lock a caller takes explicitly. Needs `fenceSql` (below) and a `drain`. |
+| `"engine-serialized"` | The engine serializes writers by construction — SQLite's single writer slot. No lock statement, no `fenceSql`, no `drain`. |
+| `"caller-serialized"` | A deployment-level promise, not an engine fact — see below. No lock statement, no `drain`; a `fenceSql` the backend still carries is used only for its isolation-fact read (recorded capture's isolation guard). |
 
-`drain` is a separate fact: whether a caller that already excluded other writers can additionally
-take a relation-wide lock on the table a drain site protects:
+`drain` (on `mechanism: "advisory"` only) is a separate fact: whether a caller that already excluded
+other writers can additionally take a relation-wide lock on the table a drain site protects:
 
 | `drain` | Meaning |
 | --- | --- |
 | `"table-lock"` | Yes — a `LOCK TABLE`-style statement is available and the drain site takes it. |
-| `"quiescent"` | The resource is already exclusive for some other reason (`caller-serialized`'s promise, or an engine's own writer slot), so the drain site takes NO statement — one it does not need rather than one it cannot spell. |
-| `"none"` | Neither — under `mechanism: "advisory"` a drain site refuses, naming the drain. `engine-serialized` and `caller-serialized` satisfy every drain site regardless of this value. |
+| `"quiescent"` | The resource is already exclusive for some other reason (an advisory lock layered under a deployment's own `caller-serialized` promise, for instance), so the drain site takes NO statement — one it does not need rather than one it cannot spell. |
+| `"none"` | Neither — a drain site refuses, naming the drain. |
+
+`"engine-serialized"` and `"caller-serialized"` satisfy every drain site unconditionally — a writer
+slot and an in-process serialization promise are each already a stronger exclusion than any `drain`
+value could add, so attaching one to either mechanism is refused (see **Runtime validation** below)
+rather than silently ignored.
 
 `resolveWriteFencePlan` resolves one of four plans:
 
@@ -1565,9 +1572,9 @@ alone is the unsound inference this capability replaces.
 The two bundled backends resolve exactly these declarations — copy the one matching your engine:
 
 - PostgreSQL: `writeFence: { mechanism: "advisory", drain: "table-lock" }`
-- SQLite: `writeFence: { mechanism: "engine-serialized", drain: "table-lock" }` (the writer slot
-  already excludes every drain site's writer, so a drain site under it always takes no statement,
-  read the same way `"quiescent"` is)
+- SQLite: `writeFence: { mechanism: "engine-serialized" }` (no `drain`: the writer slot already
+  excludes every drain site's writer, so a drain site under it always takes no statement — the same
+  behavior `drain: "quiescent"` describes for `"advisory"`, without a `drain` field to spell it)
 
 A backend that declares `mechanism: "advisory"` also supplies `fenceSql`: `lockTables` (only needed
 when `drain: "table-lock"`) plus the two composable, no-`SELECT` forms `advisoryLockExpression` /
@@ -1584,6 +1591,18 @@ member the resolved `mechanism`/`drain` combination needs is refused at construc
 code `WRITE_FENCE_SQL_UNAVAILABLE`, naming the missing member; `"engine-serialized"` and
 `"caller-serialized"` need no `fenceSql` to take a lock at all.
 
+#### Runtime validation
+
+TypeScript's discriminated union only holds a caller who goes through the type checker — a plain
+JavaScript backend author, or a value round-tripped through JSON or a config file, can still supply
+an unrecognized `mechanism` string, an unrecognized `drain` string, or a `drain` attached to
+`"engine-serialized"` / `"caller-serialized"`. `resolveWriteFencePlan` validates every declaration —
+whether it came from `capabilities.writeFence` directly or from the first-party dialect fallback —
+before shaping a plan from it, and refuses with `ConfigurationError` details code
+`WRITE_FENCE_DECLARATION_INVALID`, naming the invalid `field` (`"mechanism"` or `"drain"`) and, for
+an unrecognized value, the `accepted` list. An unrecognized `drain` never falls through to behaving
+like `"quiescent"` — it is refused outright, the same as an unrecognized `mechanism`.
+
 #### `caller-serialized`: the promise split into two halves
 
 `caller-serialized` is for a deployment that knows its database has no other concurrent writer, but
@@ -1591,17 +1610,31 @@ whose engine is neither an advisory-lock engine nor a single-writer one — a Po
 with no working `pg_advisory_xact_lock` / `LOCK TABLE`, for example. The promise has two halves,
 and TypeGraph only enforces the first:
 
-- **In process**, TypeGraph enforces it: every write unit issued through a `caller-serialized`
-  backend — collection writes, `store.transaction`, schema commits, identity and contribution
-  maintenance, index materialization, import — runs through one per-backend serialized queue, so
-  two concurrent calls through one pool cannot race each other.
+- **In process**, TypeGraph enforces it: every root member the backend classifies as mutating —
+  collection writes, `store.transaction` / `transactionWithNative`, schema commits, identity and
+  contribution maintenance, index materialization, table/DDL provisioning, `clearGraph`, import,
+  and the raw-SQL members (`execute`, `executeRaw`, `executeStatement`,
+  `executeTemporaryStatement`) that can carry an arbitrary write — runs through one per-backend
+  serialized queue, so two concurrent calls through one pool cannot race each other. A root write
+  awaited from inside a `store.transaction` callback is refused rather than left to deadlock behind
+  the transaction's own queue slot.
 - **Outside the process**, the deployment enforces it: no other client writes to this database
   while this backend is open. TypeGraph cannot see or verify that half; declaring
   `caller-serialized` is asserting it.
 
-`createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized", drain }` — a claim
-about the deployment — while still refusing `mechanism: "engine-serialized"` outright, because that
-value is a claim about the *engine*, which this factory's own engine does not back.
+Adopting an externally owned transaction (`store.withTransaction(externalTx)`, backed by
+`adoptTransaction`) is refused outright on a `caller-serialized` backend, with `ConfigurationError`
+details code `CALLER_SERIALIZED_REFUSES_ADOPTION`: an adopted transaction's lifetime belongs to the
+caller, not to this backend's write-unit queue, so there is no honest way to hold a queue slot open
+for it — queuing it would block every other queued write until the caller's own transaction ends,
+and leaving it unqueued would let its writes interleave with the queue's own, silently breaking the
+promise `caller-serialized` makes. Open the transaction through this backend's own `transaction()` /
+`transactionWithNative()` instead, or do not declare `caller-serialized` on a backend that needs
+cross-store adoption.
+
+`createPostgresBackend` accepts `writeFence: { mechanism: "caller-serialized" }` — a claim about the
+deployment — while still refusing `mechanism: "engine-serialized"` outright, because that value is
+a claim about the *engine*, which this factory's own engine does not back.
 
 Constructing Operational Identity, or `history: true` / `revisionTracking: true`, against an
 `unfenced` backend is refused immediately at `createStore` — never mid-flush — with
@@ -1659,7 +1692,7 @@ running a fence the engine cannot enforce.
 
 If the deployment instead knows it is the only writer of this database — a pool clamped to one
 connection, or a single-writer topology otherwise enforced outside TypeGraph — declare
-`writeFence: { mechanism: "caller-serialized", drain: "quiescent" }` instead (see above): that is
+`writeFence: { mechanism: "caller-serialized" }` instead (see above): that is
 the honest way to spell a deployment convention. Do not reach for `mechanism: "engine-serialized"`
 for the same purpose — that declaration means the *engine* serializes writers by construction, and
 a deployment convention is not a construction. `createPostgresBackend` refuses that particular

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -737,18 +737,17 @@ fenced or refused rather than allowed to rely on a stale decision.
 
 #### Write-fence declaration codes
 
-`capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`)
-resolves one of four write-fence plans a lock site consumes — see
+`capabilities.writeFence` resolves one of four write-fence plans a lock site
+consumes — see
 [Write fence declaration](/backend-setup#write-fence-declaration-writefence).
-Five `ConfigurationError` codes name the ways a backend's fence declaration,
+Four `ConfigurationError` codes name the ways a backend's fence declaration,
 or its resolved plan, turns out not to cover what a write needs:
 
 | `details.code` | Raised when |
 | --- | --- |
-| `WRITE_FENCE_DECLARATION_CONFLICT` | A backend's `capabilities` declare BOTH `writeFence` and the deprecated `pessimisticLocks`. Exactly one write-fence declaration is allowed. For a backend built through `createSqlBackend` (both bundled factories go through it) this is raised at construction, before any store exists, since that factory resolves the write-fence plan eagerly; a custom backend that resolves it lazily instead raises this at the first `resolveWriteFencePlan` call, which can be mid-operation. |
 | `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved declaration's `mechanism` is `"advisory"` but the backend's `fenceSql` is missing the member that `mechanism`/`drain` combination needs to spell (`advisoryLockExpression`, `isolationFactExpression`, or, under `drain: "table-lock"`, `lockTables`) — or, independently of any lock plan, a session isolation-level read (recorded capture's isolation guard) finds no `fenceSql` at all. Raised at backend construction for the lock-plan case; at the point of the read for the session-fact case. |
 | `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` | The store is constructed with `history: true` or `revisionTracking: true` — TypeGraph-owned recorded-clock allocation — against a backend whose write-fence plan resolves `unfenced`. |
-| `WRITE_FENCE_UNAVAILABLE` | A resolved plan cannot satisfy what a specific operation needs: either the plan is `unfenced` outright, or it is a `lock` plan whose `drain` is `"none"` meeting an operation whose `requires` is `"table-lock"`. `details.operation` names the operation and `details.requires` names which lock kind (`"advisory-lock"` or `"table-lock"`) it needed; a `drain: "none"` refusal also names the drain in the message. `"engine-serialized"` and `"caller-serialized"` satisfy either `requires` value without consulting `drain`. |
+| `WRITE_FENCE_UNAVAILABLE` | A resolved plan cannot satisfy what a specific operation needs: either the plan is `unfenced` outright, or it is a `lock` plan whose `drain` is `"none"` meeting an operation whose `requires` is `"drain"`. `details.operation` names the operation and `details.requires` names which kind of exclusion (`"keyed"` or `"drain"`) it needed; a `drain: "none"` refusal also names the drain in the message. `"engine-serialized"` and `"caller-serialized"` satisfy either `requires` value without consulting `drain`. |
 | `ENGINE_NATIVE_RECORDED_TIME_NOT_IMPLEMENTED` | The backend declares `recordedTimeOwnership: "engine-native"` and the store is constructed with `history: true` or `revisionTracking: true` — TypeGraph still allocates its own recorded clock for those options, so the engine-native path is refused as an interim measure, independently of the write-fence plan. See [Recorded-time ownership](/backend-setup#recorded-time-ownership-recordedtimeownership). |
 
 `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` and `ENGINE_NATIVE_RECORDED_TIME_NOT_IMPLEMENTED` refuse at
@@ -757,11 +756,11 @@ or its resolved plan, turns out not to cover what a write needs:
 every individual lock site (the identity graph lock, the identity-enablement drain, identity DDL,
 trusted import, contribution DDL, recorded-clock allocation, schema-fence sites, graph-merge
 provenance), so it fires wherever one of those runs — inside a live transaction, mid-operation,
-not only at `createStore`. `WRITE_FENCE_DECLARATION_CONFLICT` and `WRITE_FENCE_SQL_UNAVAILABLE`
-refuse earlier, at backend construction for a `createSqlBackend`-built backend (or, for the
-session-fact half of `WRITE_FENCE_SQL_UNAVAILABLE`, at the read that needed it), since they are
+not only at `createStore`. `WRITE_FENCE_SQL_UNAVAILABLE`
+refuses earlier, at backend construction for a `createSqlBackend`-built backend (or, for the
+session-fact half, at the read that needed it), since it is
 about the declaration itself rather than what a specific store option or operation requires of it.
-`IDENTITY_REQUIRES_WRITE_FENCE` is a sixth write-fence-related code — see the Operational Identity
+`IDENTITY_REQUIRES_WRITE_FENCE` is a fifth write-fence-related code — see the Operational Identity
 guard codes table above — but is not in this table because it guards identity construction, not
 recorded-clock allocation.
 
@@ -849,7 +848,7 @@ Operational Identity lifecycle failures use stable `details.code` values on
 | --- | --- |
 | `IDENTITY_REQUIRES_ATOMIC_BACKEND` | The selected adapter cannot provide the interactive transaction required by identity writes. |
 | `IDENTITY_REQUIRES_STATEMENT_EXECUTION` | The backend cannot execute the raw statements Operational Identity issues internally. |
-| `IDENTITY_REQUIRES_WRITE_FENCE` | Operational Identity was constructed against a backend whose `capabilities.writeFence` (or the deprecated `pessimisticLocks`) resolves `unfenced` — declare the capability, matching the engine's real locking support. See [Write-fence declaration codes](#write-fence-declaration-codes). |
+| `IDENTITY_REQUIRES_WRITE_FENCE` | Operational Identity was constructed against a backend whose `capabilities.writeFence` resolves `unfenced` — declare the capability, matching the engine's real locking support. See [Write-fence declaration codes](#write-fence-declaration-codes). |
 | `IDENTITY_NOT_ENABLED` | `store.identity`, `tx.identity`, `StoreView.identity`, or an identity-expanded query option was reached on a graph without `identity: { ... }` — normally caught at compile time; this is the runtime guard for a widened or `any`-typed handle. |
 | `IDENTITY_STORAGE_MISSING` | An identity relation disappeared after enablement, or exists without this graph's fill. Restore ledgers, or recreate and rebuild the derived closure, before serving traffic. `details.reason: "unfilled"` marks the second case: the separation relation is present but holds no row for this graph while the ledger holds a live `different` assertion across two distinct identity classes — reopen the Store (the open runs the fill) or run `rebuildIdentityClosure(store)`. A Store handle opened while the relation did not exist keeps failing until it is reopened, which is deliberate: the alternative is a confident "not separated" the moment another graph's upgrade creates the shared relation. |
 | `IDENTITY_UPGRADE_REQUIRES_ATOMIC_DDL` | The backend cannot publish the derived separation relation's upgrade — the `CREATE` and the fill — as one commit, on a graph that owes rows. `details.missingPorts` names what is absent: `schemaWriteTransaction` / `identityTableDdl` on the fenced path, or `executeSchemaDdl` on the schema-commit path. Refused rather than degraded, because a relation created empty and filled afterwards reads as "nothing is separated" in between. Both bundled Drizzle backends implement all three when transactions are enabled, so this is a custom-backend path. |

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -740,15 +740,17 @@ fenced or refused rather than allowed to rely on a stale decision.
 `capabilities.writeFence` resolves one of four write-fence plans a lock site
 consumes — see
 [Write fence declaration](/backend-setup#write-fence-declaration-writefence).
-Four `ConfigurationError` codes name the ways a backend's fence declaration,
-or its resolved plan, turns out not to cover what a write needs:
+`ConfigurationError` codes name the ways a backend's fence declaration, or
+its resolved plan, turns out not to cover what a write needs:
 
 | `details.code` | Raised when |
 | --- | --- |
+| `WRITE_FENCE_DECLARATION_INVALID` | The declared `writeFence` fails runtime validation: an unrecognized `mechanism` string, an unrecognized `drain` string under `mechanism: "advisory"`, or a `drain` key present on `mechanism: "engine-serialized"` / `"caller-serialized"` (`drain` applies only to `"advisory"`). `details.field` names `"mechanism"` or `"drain"`; for an unrecognized value, `details.accepted` lists the allowed strings. Raised by `resolveWriteFencePlan` before any plan is shaped — an invalid `drain` never falls through to behaving like `"quiescent"`. |
 | `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved declaration's `mechanism` is `"advisory"` but the backend's `fenceSql` is missing the member that `mechanism`/`drain` combination needs to spell (`advisoryLockExpression`, `isolationFactExpression`, or, under `drain: "table-lock"`, `lockTables`) — or, independently of any lock plan, a session isolation-level read (recorded capture's isolation guard) finds no `fenceSql` at all. Raised at backend construction for the lock-plan case; at the point of the read for the session-fact case. |
 | `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` | The store is constructed with `history: true` or `revisionTracking: true` — TypeGraph-owned recorded-clock allocation — against a backend whose write-fence plan resolves `unfenced`. |
 | `WRITE_FENCE_UNAVAILABLE` | A resolved plan cannot satisfy what a specific operation needs: either the plan is `unfenced` outright, or it is a `lock` plan whose `drain` is `"none"` meeting an operation whose `requires` is `"drain"`. `details.operation` names the operation and `details.requires` names which kind of exclusion (`"keyed"` or `"drain"`) it needed; a `drain: "none"` refusal also names the drain in the message. `"engine-serialized"` and `"caller-serialized"` satisfy either `requires` value without consulting `drain`. |
 | `ENGINE_NATIVE_RECORDED_TIME_NOT_IMPLEMENTED` | The backend declares `recordedTimeOwnership: "engine-native"` and the store is constructed with `history: true` or `revisionTracking: true` — TypeGraph still allocates its own recorded clock for those options, so the engine-native path is refused as an interim measure, independently of the write-fence plan. See [Recorded-time ownership](/backend-setup#recorded-time-ownership-recordedtimeownership). |
+| `CALLER_SERIALIZED_REFUSES_ADOPTION` | `adoptTransaction` was called on a backend whose resolved write-fence plan is `caller-serialized`. An externally owned transaction's lifetime cannot be held by the backend's in-process write-unit queue, so `store.withTransaction(externalTx)` is refused rather than let its writes silently interleave with the queue's own. `details.member` names `"adoptTransaction"`. |
 
 `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` and `ENGINE_NATIVE_RECORDED_TIME_NOT_IMPLEMENTED` refuse at
 `createStore`, never mid-flush, and the message names the exact declaration line to add.
@@ -756,13 +758,26 @@ or its resolved plan, turns out not to cover what a write needs:
 every individual lock site (the identity graph lock, the identity-enablement drain, identity DDL,
 trusted import, contribution DDL, recorded-clock allocation, schema-fence sites, graph-merge
 provenance), so it fires wherever one of those runs — inside a live transaction, mid-operation,
-not only at `createStore`. `WRITE_FENCE_SQL_UNAVAILABLE`
-refuses earlier, at backend construction for a `createSqlBackend`-built backend (or, for the
-session-fact half, at the read that needed it), since it is
+not only at `createStore`. `WRITE_FENCE_SQL_UNAVAILABLE` and `WRITE_FENCE_DECLARATION_INVALID`
+both refuse earlier, at backend construction for a `createSqlBackend`-built backend (or, for the
+session-fact half of `WRITE_FENCE_SQL_UNAVAILABLE`, at the read that needed it), since they are
 about the declaration itself rather than what a specific store option or operation requires of it.
-`IDENTITY_REQUIRES_WRITE_FENCE` is a fifth write-fence-related code — see the Operational Identity
-guard codes table above — but is not in this table because it guards identity construction, not
-recorded-clock allocation.
+`CALLER_SERIALIZED_REFUSES_ADOPTION` fires wherever `adoptTransaction` is actually called, which is
+never at `createStore` time. `IDENTITY_REQUIRES_WRITE_FENCE` is another write-fence-related code —
+see the Operational Identity guard codes table above — but is not in this table because it guards
+identity construction, not recorded-clock allocation.
+
+### Caller-serialized queue codes
+
+The in-process queue a `writeFence: { mechanism: "caller-serialized" }` declaration builds
+(`src/backend/serialized-execution-queue.ts`) raises two more `ConfigurationError` codes, both
+naming `details.subject` — the SQLite dialect string for SQLite's own per-connection queue, or
+`"caller-serialized"` for the write-unit queue a `caller-serialized` declaration builds:
+
+| `details.code` | Raised when |
+| --- | --- |
+| `SERIALIZED_QUEUE_REENTRANT_SUBMISSION` | A queued operation was awaited from inside a transaction already running on the same queue — the transaction holds the queue's execution slot until it completes, so the nested operation could never run. Use the transaction-scoped context (`tx.nodes` / `tx.edges` / `tx.backend`) instead of the root store or backend inside a `store.transaction` callback, or move the operation outside the transaction. |
+| `CALLER_SERIALIZED_REQUIRES_ASYNC_CONTEXT` | The queue's reentrancy detection depends on `node:async_hooks`' `AsyncLocalStorage`, which is unavailable on this runtime (or had not finished loading). A `caller-serialized` write-fence declaration's in-process promise depends on that detection actually working, so every submission is refused rather than run without it. SQLite's own per-connection queue never raises this code: it runs without detection instead of refusing when the context is unavailable. |
 
 These codes are not part of `RECORDED_CAPTURE_GUARD_CODES` — that set is
 closed to the three codes documented under

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -737,22 +737,32 @@ fenced or refused rather than allowed to rely on a stale decision.
 
 #### Write-fence declaration codes
 
-`capabilities.pessimisticLocks` resolves one of three write-fence plans a
-lock site consumes — see
-[Write fence declaration](/backend-setup#write-fence-declaration-pessimisticlocks).
-Three `ConfigurationError` codes name the ways a backend's fence turns out
-not to cover what a write needs:
+`capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`)
+resolves one of four write-fence plans a lock site consumes — see
+[Write fence declaration](/backend-setup#write-fence-declaration-writefence).
+Five `ConfigurationError` codes name the ways a backend's fence declaration,
+or its resolved plan, turns out not to cover what a write needs:
 
 | `details.code` | Raised when |
 | --- | --- |
+| `WRITE_FENCE_DECLARATION_CONFLICT` | A backend's `capabilities` declare BOTH `writeFence` and the deprecated `pessimisticLocks`. Exactly one write-fence declaration is allowed. For a backend built through `createSqlBackend` (both bundled factories go through it) this is raised at construction, before any store exists, since that factory resolves the write-fence plan eagerly; a custom backend that resolves it lazily instead raises this at the first `resolveWriteFencePlan` call, which can be mid-operation. |
+| `WRITE_FENCE_SQL_UNAVAILABLE` | The resolved declaration's `mechanism` is `"advisory"` but the backend's `fenceSql` is missing the member that `mechanism`/`drain` combination needs to spell (`advisoryLockExpression`, `isolationFactExpression`, or, under `drain: "table-lock"`, `lockTables`) — or, independently of any lock plan, a session isolation-level read (recorded capture's isolation guard) finds no `fenceSql` at all. Raised at backend construction for the lock-plan case; at the point of the read for the session-fact case. |
 | `RECORDED_CLOCK_REQUIRES_WRITE_FENCE` | The store is constructed with `history: true` or `revisionTracking: true` — TypeGraph-owned recorded-clock allocation — against a backend whose write-fence plan resolves `unfenced`. |
-| `WRITE_FENCE_UNAVAILABLE` | A resolved plan cannot satisfy what a specific operation needs: either the plan is `unfenced` outright, or it is a declared-advisory-only `lock` plan (`tableLocks: false`) meeting an operation whose `requires` is `"table-lock"`. `details.operation` names the operation and `details.requires` names which lock kind (`"advisory-lock"` or `"table-lock"`) it needed. |
+| `WRITE_FENCE_UNAVAILABLE` | A resolved plan cannot satisfy what a specific operation needs: either the plan is `unfenced` outright, or it is a `lock` plan whose `drain` is `"none"` meeting an operation whose `requires` is `"table-lock"`. `details.operation` names the operation and `details.requires` names which lock kind (`"advisory-lock"` or `"table-lock"`) it needed; a `drain: "none"` refusal also names the drain in the message. `"engine-serialized"` and `"caller-serialized"` satisfy either `requires` value without consulting `drain`. |
 | `ENGINE_NATIVE_RECORDED_TIME_NOT_IMPLEMENTED` | The backend declares `recordedTimeOwnership: "engine-native"` and the store is constructed with `history: true` or `revisionTracking: true` — TypeGraph still allocates its own recorded clock for those options, so the engine-native path is refused as an interim measure, independently of the write-fence plan. See [Recorded-time ownership](/backend-setup#recorded-time-ownership-recordedtimeownership). |
 
-All three refuse at `createStore`, never mid-flush, and the message names the
-exact declaration line to add. `IDENTITY_REQUIRES_WRITE_FENCE` is the fourth
-write-fence-related code — see the Operational Identity guard codes table
-above — but is not in this table because it guards identity construction, not
+`RECORDED_CLOCK_REQUIRES_WRITE_FENCE` and `ENGINE_NATIVE_RECORDED_TIME_NOT_IMPLEMENTED` refuse at
+`createStore`, never mid-flush, and the message names the exact declaration line to add.
+`WRITE_FENCE_UNAVAILABLE` is not a `createStore`-time check: `requireWriteFence` is called from
+every individual lock site (the identity graph lock, the identity-enablement drain, identity DDL,
+trusted import, contribution DDL, recorded-clock allocation, schema-fence sites, graph-merge
+provenance), so it fires wherever one of those runs — inside a live transaction, mid-operation,
+not only at `createStore`. `WRITE_FENCE_DECLARATION_CONFLICT` and `WRITE_FENCE_SQL_UNAVAILABLE`
+refuse earlier, at backend construction for a `createSqlBackend`-built backend (or, for the
+session-fact half of `WRITE_FENCE_SQL_UNAVAILABLE`, at the read that needed it), since they are
+about the declaration itself rather than what a specific store option or operation requires of it.
+`IDENTITY_REQUIRES_WRITE_FENCE` is a sixth write-fence-related code — see the Operational Identity
+guard codes table above — but is not in this table because it guards identity construction, not
 recorded-clock allocation.
 
 These codes are not part of `RECORDED_CAPTURE_GUARD_CODES` — that set is
@@ -839,7 +849,7 @@ Operational Identity lifecycle failures use stable `details.code` values on
 | --- | --- |
 | `IDENTITY_REQUIRES_ATOMIC_BACKEND` | The selected adapter cannot provide the interactive transaction required by identity writes. |
 | `IDENTITY_REQUIRES_STATEMENT_EXECUTION` | The backend cannot execute the raw statements Operational Identity issues internally. |
-| `IDENTITY_REQUIRES_WRITE_FENCE` | Operational Identity was constructed against a backend whose `capabilities.pessimisticLocks` resolves `unfenced` — declare the capability, matching the engine's real locking support. See [Write-fence declaration codes](#write-fence-declaration-codes). |
+| `IDENTITY_REQUIRES_WRITE_FENCE` | Operational Identity was constructed against a backend whose `capabilities.writeFence` (or the deprecated `pessimisticLocks`) resolves `unfenced` — declare the capability, matching the engine's real locking support. See [Write-fence declaration codes](#write-fence-declaration-codes). |
 | `IDENTITY_NOT_ENABLED` | `store.identity`, `tx.identity`, `StoreView.identity`, or an identity-expanded query option was reached on a graph without `identity: { ... }` — normally caught at compile time; this is the runtime guard for a widened or `any`-typed handle. |
 | `IDENTITY_STORAGE_MISSING` | An identity relation disappeared after enablement, or exists without this graph's fill. Restore ledgers, or recreate and rebuild the derived closure, before serving traffic. `details.reason: "unfilled"` marks the second case: the separation relation is present but holds no row for this graph while the ledger holds a live `different` assertion across two distinct identity classes — reopen the Store (the open runs the fill) or run `rebuildIdentityClosure(store)`. A Store handle opened while the relation did not exist keeps failing until it is reopened, which is deliberate: the alternative is a confident "not separated" the moment another graph's upgrade creates the shared relation. |
 | `IDENTITY_UPGRADE_REQUIRES_ATOMIC_DDL` | The backend cannot publish the derived separation relation's upgrade — the `CREATE` and the fill — as one commit, on a graph that owes rows. `details.missingPorts` names what is absent: `schemaWriteTransaction` / `identityTableDdl` on the fenced path, or `executeSchemaDdl` on the schema-commit path. Refused rather than degraded, because a relation created empty and filled afterwards reads as "nothing is separated" in between. Both bundled Drizzle backends implement all three when transactions are enabled, so this is a custom-backend path. |

--- a/packages/typegraph/eslint.config.mjs
+++ b/packages/typegraph/eslint.config.mjs
@@ -331,9 +331,9 @@ export const DIALECT_LITERAL_EXEMPTIONS = [
   {
     file: "src/backend/capabilities/write-fence.ts",
     reason:
-      "The dialect-keyed default lock capabilities the fence planner starts from (deriveFromDialect), plus the refusal and declaration-guidance messages that must name the engine's own lock primitives and isolation spelling (refuseWriteFenceSqlUnavailable, refuseFenceSqlSessionFactUnavailable, pessimisticLockDeclarationLine, unfencedRefusalMessage).",
+      "The dialect-keyed default fence declaration the planner starts from for a first-party target (deriveFromDialect), plus the two refusal messages that must name the engine's own lock primitives and isolation spelling (refuseWriteFenceSqlUnavailable, refuseFenceSqlSessionFactUnavailable).",
     permanent: true,
-    sites: 9,
+    sites: 4,
   },
   {
     file: "src/store/algorithms/iterative-graph-operation.ts",

--- a/packages/typegraph/eslint.config.mjs
+++ b/packages/typegraph/eslint.config.mjs
@@ -1099,7 +1099,11 @@ const LINT_BLOCKS = [
   },
   // The shared engine factory both dialect factories delegate to
   // (`createSqlBackend`) is the sole module that writes a verdict, so it is
-  // the only block exempted from the audit import ban.
+  // exempted from the audit import ban. It also decorates its own
+  // already-built, already-audited backend through the seam — the
+  // in-process write-fence queue a `caller-serialized` declaration resolves
+  // to — so it drops the seam import ban too, the same way
+  // `postgres.ts` does for its own trusted-transaction decoration.
   {
     files: ["src/backend/drizzle/engine/create-sql-backend.ts"],
     rules: {
@@ -1109,7 +1113,6 @@ const LINT_BLOCKS = [
         ...DRIZZLE_ZONE_RESTRICTIONS,
         GLOBAL_SYMBOL_RESTRICTION,
         ...RUNTIME_PORT_RESTRICTIONS,
-        ...BACKEND_SEAM_IMPORT_RESTRICTIONS,
         ...BACKEND_CARRY_RESTRICTIONS,
         ...BACKEND_CONSTRUCTION_RESTRICTIONS,
         ...DIALECT_SEAM_RESTRICTIONS,

--- a/packages/typegraph/etc/api-surface-exceptions.json
+++ b/packages/typegraph/etc/api-surface-exceptions.json
@@ -49,5 +49,469 @@
     "kind": "required-member-added",
     "reason": "FenceStatements is what a resolved `lock` WriteFencePlan carries as its `sql` field, derived from FenceSql's two expressions by resolveFenceStatements; no code ever hand-authors one. requireWriteFence accepts WriteFencePlan as a parameter, which this checker treats as an author-facing position for every member mandatory on every variant, including FenceStatements's three derived members, so they are required as a set at that boundary just as FenceSql's own members are.",
     "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "BackendCapabilities",
+    "member": "pessimisticLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "PessimisticLockCapabilities",
+    "member": "serializedWriters",
+    "kind": "member-removed",
+    "reason": "removed in favor of writeFence per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "WriteFencePlan",
+    "member": "advisoryLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of the lock arm's drain field per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "WriteFencePlan",
+    "member": "tableLocks",
+    "kind": "member-removed",
+    "reason": "removed in favor of the lock arm's drain field per the 2026-09-06 clean-API ruling",
+    "issue": "#622"
   }
 ]

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-engine.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-engine.api.md
@@ -172,6 +172,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -9104,6 +9105,12 @@ type VectorStrategy = Readonly<{
         concurrent?: boolean;
     }>) => SqlFragment | undefined;
     buildDropIndex?: (this: void, slot: VectorSlot) => SqlFragment | undefined;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-engine.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-engine.api.md
@@ -9101,8 +9101,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-engine.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-engine.api.md
@@ -173,7 +173,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -8292,13 +8291,6 @@ type NormalizedColumnKind = "integer" | "text" | "timestamp-with-time-zone" | "o
 
 // @public
 type NullCheckOp = "isNull" | "isNotNull";
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -47,6 +47,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -5205,6 +5206,12 @@ type VectorStrategy = Readonly<{
         concurrent?: boolean;
     }>) => SqlFragment | undefined;
     buildDropIndex?: (this: void, slot: VectorSlot) => SqlFragment | undefined;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -5202,8 +5202,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres-pglite.api.md
@@ -48,7 +48,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -4596,13 +4595,6 @@ type NormalizedColumnKind = "integer" | "text" | "timestamp-with-time-zone" | "o
 
 // @public
 type NullCheckOp = "isNull" | "isNotNull";
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -44,6 +44,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -9882,6 +9883,12 @@ type VectorStrategy = Readonly<{
         concurrent?: boolean;
     }>) => SqlFragment | undefined;
     buildDropIndex?: (this: void, slot: VectorSlot) => SqlFragment | undefined;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -9879,8 +9879,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-postgres.api.md
@@ -45,7 +45,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -5262,13 +5261,6 @@ type NormalizedColumnKind = "integer" | "text" | "timestamp-with-time-zone" | "o
 
 // @public
 type NullCheckOp = "isNull" | "isNotNull";
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -41,7 +41,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -4703,13 +4702,6 @@ type NormalizedColumnKind = "integer" | "text" | "timestamp-with-time-zone" | "o
 
 // @public
 type NullCheckOp = "isNull" | "isNotNull";
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -5309,8 +5309,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-libsql.api.md
@@ -40,6 +40,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -5312,6 +5313,12 @@ type VectorStrategy = Readonly<{
         concurrent?: boolean;
     }>) => SqlFragment | undefined;
     buildDropIndex?: (this: void, slot: VectorSlot) => SqlFragment | undefined;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -39,6 +39,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -5341,6 +5342,12 @@ type VectorStrategy = Readonly<{
         concurrent?: boolean;
     }>) => SqlFragment | undefined;
     buildDropIndex?: (this: void, slot: VectorSlot) => SqlFragment | undefined;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -5338,8 +5338,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite-local.api.md
@@ -40,7 +40,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -4732,13 +4731,6 @@ type NormalizedColumnKind = "integer" | "text" | "timestamp-with-time-zone" | "o
 
 // @public
 type NullCheckOp = "isNull" | "isNotNull";
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -39,7 +39,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -5298,13 +5297,6 @@ type NormalizedColumnKind = "integer" | "text" | "timestamp-with-time-zone" | "o
 
 // @public
 type NullCheckOp = "isNull" | "isNotNull";
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -38,6 +38,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -10127,6 +10128,12 @@ type VectorStrategy = Readonly<{
         concurrent?: boolean;
     }>) => SqlFragment | undefined;
     buildDropIndex?: (this: void, slot: VectorSlot) => SqlFragment | undefined;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
+++ b/packages/typegraph/etc/typegraph-adapters-drizzle-sqlite.api.md
@@ -10124,8 +10124,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -495,6 +495,7 @@ export type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -3473,7 +3474,7 @@ export function requireExtras<const D extends CapabilityBundleDefinition, Op ext
 
 // @public
 export function requireWriteFence(plan: WriteFencePlan, operation: string, requires: "advisory-lock" | "table-lock"): Extract<WriteFencePlan, {
-    kind: "lock" | "engine-serialized";
+    kind: "lock" | "engine-serialized" | "caller-serialized";
 }>;
 
 // @public
@@ -4801,21 +4802,41 @@ export type VectorStrategy = Readonly<{
 }>;
 
 // @public
+export type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
+
+// @public
 export type WriteFencePlan =
 /**
-* Take the keyed/table lock, spelled by `sql` — the target's OWN declared
+* Take the keyed lock, spelled by `sql` — the target's OWN declared
 * spelling: a lock site never hand-writes the statement, it resolves
 * a plan and consumes `sql.<builder>(…)`.
+*
+* `tableLocks` is kept for source compatibility and is derived from
+* `drain`(`=== "table-lock"`); read `drain` instead — it distinguishes a
+* declaration that cannot drain a table-lock site at all (`"none"`) from
+* one that drains it without a statement (`"quiescent"`).
 */
 Readonly<{
     kind: "lock";
     advisoryLocks: true;
     tableLocks: boolean;
+    drain: "table-lock" | "quiescent" | "none";
     sql: FenceStatements;
 }>
 /** No lock needed: the engine serializes writers. */
 | Readonly<{
     kind: "engine-serialized";
+}>
+/**
+* No lock needed: the deployment itself promises no concurrent writer
+* exists — this backend's own process serializes every write unit it
+* issues, and no other client writes to the database while it is open.
+*/
+| Readonly<{
+    kind: "caller-serialized";
 }>
 /** Neither. Every non-degradable fence refuses. Carries why — see {@link UnfencedReason}. */
 | Readonly<{

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -496,7 +496,6 @@ export type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -3208,13 +3207,6 @@ export type PartialBundleBinding<M extends OptionalGraphBackendMember> = Readonl
 }>;
 
 // @public
-export type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
-
-// @public
 export class Placeholder {
     // (undocumented)
     readonly [SQL_PLACEHOLDER_BRAND]: true;
@@ -3473,7 +3465,7 @@ export function requireExtras<const D extends CapabilityBundleDefinition, Op ext
 };
 
 // @public
-export function requireWriteFence(plan: WriteFencePlan, operation: string, requires: "advisory-lock" | "table-lock"): Extract<WriteFencePlan, {
+export function requireWriteFence(plan: WriteFencePlan, operation: string, requires: "keyed" | "drain"): Extract<WriteFencePlan, {
     kind: "lock" | "engine-serialized" | "caller-serialized";
 }>;
 
@@ -4015,7 +4007,7 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
     };
     readonly fenceSql: {
         readonly kind: "reasoned";
-        readonly reason: "The write-fence lock spelling a backend's `writeFence: { mechanism: \"advisory\" }` declaration requires (or, in the deprecated legacy shape, `pessimisticLocks.advisoryLocks: true`). Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.";
+        readonly reason: "The write-fence lock spelling a backend's `writeFence: { mechanism: \"advisory\" }` declaration requires. Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.";
         readonly accesses: 2;
     };
     readonly commitSchemaVersionIfKindsEmpty: {
@@ -4434,9 +4426,6 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
 export type UnbundledOptionalMember = ReasonedUnbundledMember | DeferredUnbundledMember;
 
 // @public
-type UnfencedReason = "undeclared" | "declared-none" | "table-locks-only";
-
-// @public
 export const UNIQUE_SIDECAR_BATCH: {
     readonly id: "uniqueSidecarBatch";
     readonly kind: "graduated";
@@ -4813,16 +4802,9 @@ export type WriteFencePlan =
 * Take the keyed lock, spelled by `sql` — the target's OWN declared
 * spelling: a lock site never hand-writes the statement, it resolves
 * a plan and consumes `sql.<builder>(…)`.
-*
-* `tableLocks` is kept for source compatibility and is derived from
-* `drain`(`=== "table-lock"`); read `drain` instead — it distinguishes a
-* declaration that cannot drain a table-lock site at all (`"none"`) from
-* one that drains it without a statement (`"quiescent"`).
 */
 Readonly<{
     kind: "lock";
-    advisoryLocks: true;
-    tableLocks: boolean;
     drain: "table-lock" | "quiescent" | "none";
     sql: FenceStatements;
 }>
@@ -4838,10 +4820,9 @@ Readonly<{
 | Readonly<{
     kind: "caller-serialized";
 }>
-/** Neither. Every non-degradable fence refuses. Carries why — see {@link UnfencedReason}. */
+/** Neither. Every non-degradable fence refuses: `capabilities.writeFence` is absent. */
 | Readonly<{
     kind: "unfenced";
-    reason: UnfencedReason;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -4015,7 +4015,7 @@ export const UNBUNDLED_OPTIONAL_MEMBERS: {
     };
     readonly fenceSql: {
         readonly kind: "reasoned";
-        readonly reason: "The write-fence lock spelling a backend's `pessimisticLocks.advisoryLocks: true` declaration requires. Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.";
+        readonly reason: "The write-fence lock spelling a backend's `writeFence: { mechanism: \"advisory\" }` declaration requires (or, in the deprecated legacy shape, `pessimisticLocks.advisoryLocks: true`). Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.";
         readonly accesses: 2;
     };
     readonly commitSchemaVersionIfKindsEmpty: {

--- a/packages/typegraph/etc/typegraph-backend.api.md
+++ b/packages/typegraph/etc/typegraph-backend.api.md
@@ -4792,8 +4792,12 @@ export type VectorStrategy = Readonly<{
 
 // @public
 export type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -7255,8 +7255,12 @@ export type WorkingCopyStrategy<G extends GraphDef> = Readonly<{
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -126,6 +126,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -7258,6 +7259,12 @@ type WidenBrandedIds<T> = {
 // @public
 export type WorkingCopyStrategy<G extends GraphDef> = Readonly<{
     create: (baseStore: Store<G>) => Promise<Store<G>>;
+}>;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -127,7 +127,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -4706,13 +4705,6 @@ type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -6375,8 +6375,12 @@ type WidenBrandedIds<T> = {
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -118,7 +118,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -4056,13 +4055,6 @@ type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -117,6 +117,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -6379,6 +6380,12 @@ type WidenBrandedIds<T> = {
         [P in keyof A]: UnbrandParam<A[P]>;
     }) => R : T[K];
 };
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -118,7 +118,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -3680,13 +3679,6 @@ type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -117,6 +117,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -6035,6 +6036,12 @@ type WidenBrandedIds<T> = {
         [P in keyof A]: UnbrandParam<A[P]>;
     }) => R : T[K];
 };
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -6031,8 +6031,12 @@ type WidenBrandedIds<T> = {
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -118,7 +118,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -3610,13 +3609,6 @@ type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -5982,8 +5982,12 @@ type WidenBrandedIds<T> = {
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -117,6 +117,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -5986,6 +5987,12 @@ type WidenBrandedIds<T> = {
         [P in keyof A]: UnbrandParam<A[P]>;
     }) => R : T[K];
 };
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -118,7 +118,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -3619,13 +3618,6 @@ type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -5979,8 +5979,12 @@ type WidenBrandedIds<T> = {
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -117,6 +117,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -5983,6 +5984,12 @@ type WidenBrandedIds<T> = {
         [P in keyof A]: UnbrandParam<A[P]>;
     }) => R : T[K];
 };
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -39,6 +39,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -2757,6 +2758,12 @@ type VectorStrategy = Readonly<{
 
 // @public
 export function wrapZodError(error: ZodError, context: ValidationContext): ValidationError;
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -2753,8 +2753,12 @@ export function wrapZodError(error: ZodError, context: ValidationContext): Valid
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-schema.api.md
+++ b/packages/typegraph/etc/typegraph-schema.api.md
@@ -40,7 +40,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -1915,13 +1914,6 @@ type OntologyRelation = Readonly<{
 
 // @public
 export function parseSerializedSchema(json: string): SerializedSchema;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
-}>;
 
 // @public
 class Placeholder {

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -117,6 +117,7 @@ type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -6062,6 +6063,12 @@ type WidenBrandedIds<T> = {
         [P in keyof A]: UnbrandParam<A[P]>;
     }) => R : T[K];
 };
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -6058,8 +6058,12 @@ type WidenBrandedIds<T> = {
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -118,7 +118,6 @@ type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -3707,13 +3706,6 @@ type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -216,6 +216,7 @@ export type BackendCapabilities = Readonly<{
     graphAnalytics?: GraphAnalyticsCapabilities | undefined;
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
+    writeFence?: WriteFenceDeclaration | undefined;
     pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
@@ -8305,6 +8306,12 @@ type WidenBrandedIds<T> = {
         [P in keyof A]: UnbrandParam<A[P]>;
     }) => R : T[K];
 };
+
+// @public
+type WriteFenceDeclaration = Readonly<{
+    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    drain: "table-lock" | "quiescent" | "none";
+}>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -8301,8 +8301,12 @@ type WidenBrandedIds<T> = {
 
 // @public
 type WriteFenceDeclaration = Readonly<{
-    mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+    mechanism: "advisory";
     drain: "table-lock" | "quiescent" | "none";
+}> | Readonly<{
+    mechanism: "engine-serialized";
+}> | Readonly<{
+    mechanism: "caller-serialized";
 }>;
 
 // (No @packageDocumentation comment for this package)

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -217,7 +217,6 @@ export type BackendCapabilities = Readonly<{
     contributions?: ContributionCapabilities | undefined;
     recursiveTraversal?: RecursiveTraversalCapability | undefined;
     writeFence?: WriteFenceDeclaration | undefined;
-    pessimisticLocks?: PessimisticLockCapabilities | undefined;
     recordedTimeOwnership?: "typegraph-relations" | "engine-native";
 }>;
 
@@ -5392,13 +5391,6 @@ export type PersonalizedPageRankSeed<G extends GraphDef> = Readonly<{
     id: string;
     kind: NodeKinds<G>;
     weight?: number;
-}>;
-
-// @public
-type PessimisticLockCapabilities = Readonly<{
-    advisoryLocks: boolean;
-    tableLocks: boolean;
-    serializedWriters: boolean;
 }>;
 
 // @public (undocumented)

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -104,7 +104,10 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * is unaffected: `bindExtraIfReachable` and `missingRequiredExtras` are named
  * exports every caller reaches directly, so neither needed a forgotten name.
  *
- * Write-fence batch (WS5 B10): the same 14 entrypoints B1's
+ * Write-fence batch (WS5 B10, historical — `pessimisticLocks` and
+ * `PessimisticLockCapabilities` were later deleted outright; see the removal
+ * batch note after "Declared write-fence surface (#622)" below for the
+ * current state): the same 14 entrypoints B1's
  * `recursiveTraversal` batch moved (every entrypoint rendering
  * `BackendCapabilities` unexported, plus `.` and `./backend`, which export it
  * directly) each move by exactly +1, but the ADDED SYMBOL is not the same
@@ -133,9 +136,10 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * (mirroring `RecursiveTraversalVerdict`'s treatment at that same barrel), or
  * does not reach a rendered public signature at all. The first-party mark
  * (`markFirstPartyFactory`/`carryFirstPartyFactoryMark`), the two refusal
- * constructors, and `pessimisticLockDeclarationLine` are deliberately not
- * exported anywhere, so none of them can register as a forgotten export
- * either. Delta table (old → new, all +1): `.` 352→353, `./backend` 10→11,
+ * constructors, and `pessimisticLockDeclarationLine` (since deleted along
+ * with the capability it printed, not merely left unexported) were
+ * deliberately not exported anywhere, so none of them ever registered as a
+ * forgotten export either. Delta table (old → new, all +1): `.` 352→353, `./backend` 10→11,
  * `./interchange` 604→605, `./profiler` 606→607, `./schema` 223→224,
  * `./graph-merge` 618→619, `./provenance` 612→613, `./sqlite/local` 608→609,
  * `./postgres/pglite` 608→609, `./adapters/drizzle/sqlite` 203→204,
@@ -223,6 +227,9 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * Fence-plan spelling: `GraphBackend` gaining an optional `fenceSql: FenceSql`
  * member makes `FenceSql` newly reachable through the same 14 entrypoints the
  * write-fence batch above already moved for `PessimisticLockCapabilities`
+ * (a symbol later deleted outright — see the removal batch note after
+ * "Declared write-fence surface (#622)" below; named here only to identify
+ * which 14 entrypoints share this type graph)
  * (every entrypoint whose public type graph renders `GraphBackend` /
  * `BackendIdentity` without directly exporting it), each +1: `.`,
  * `./interchange`, `./profiler`, `./schema`, `./graph-merge`, `./provenance`,
@@ -329,6 +336,36 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * `BackendCapabilities` unexported too. 14 entrypoints move, all +1, all for
  * the identical symbol; no entrypoint's debt decreases and no 15th
  * entrypoint moves.
+ *
+ * `pessimisticLocks` removal (B10 clean-up): `BackendCapabilities.pessimisticLocks`,
+ * `PessimisticLockCapabilities`, `writeFenceFromLegacyLocks`, and
+ * `pessimisticLockDeclarationLine` are deleted outright — `writeFence` is
+ * now the only write-fence declaration. This is a debt DECREASE, the first
+ * one this family has had: the 14 entrypoints that rendered
+ * `PessimisticLockCapabilities` as a forgotten export (the 13 from the
+ * write-fence batch above plus `./adapters/drizzle/engine`, which joined the
+ * family in the `#622` batch just above) each lose exactly that one name
+ * (−1): `.`, `./interchange`, `./profiler`, `./schema`, `./graph-merge`,
+ * `./provenance`, `./sqlite/local`, `./postgres/pglite`, the five
+ * `./adapters/drizzle/*` sub-entrypoints, and `./adapters/drizzle/engine`.
+ * `./backend` loses a different name (−1): `UnfencedReason` — a forgotten
+ * export there since the `WriteFencePlan`/`resolveWriteFencePlan` batch
+ * above added the `unfenced` arm's `reason` field — is deleted along with
+ * that field now that `undeclared` is the only way to reach `unfenced`.
+ * `WriteFenceTarget`, exported directly at `./backend`, and
+ * `PessimisticLockCapabilities` itself, also exported directly there, both
+ * disappear from that entrypoint's public surface too, but neither was
+ * forgotten-export debt, so neither moves this count. Delta table (old →
+ * new, all −1): `.` 389→388, `./backend` 17→16, `./interchange` 702→701,
+ * `./profiler` 704→703, `./schema` 272→271, `./graph-merge` 719→718,
+ * `./provenance` 710→709, `./sqlite/local` 706→705, `./postgres/pglite`
+ * 706→705, `./adapters/drizzle/sqlite` 248→247, `./adapters/drizzle/postgres`
+ * 247→246, `./adapters/drizzle/postgres/pglite` 251→250,
+ * `./adapters/drizzle/sqlite/local` 251→250,
+ * `./adapters/drizzle/sqlite/libsql` 251→250, `./adapters/drizzle/engine`
+ * 321→320. Gate: every entrypoint's debt DECREASED by exactly 1, the removed
+ * symbol is `PessimisticLockCapabilities` everywhere except `./backend`
+ * (`UnfencedReason`), and exactly 15 entrypoints moved.
  */
 // Dynamic pinned edge lookup adds DynamicStoreViewEdgeCollection to the six
 // non-root Store-bearing entrypoints. Removing that single name reproduces each
@@ -344,40 +381,40 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
 // directly, so its own debt is unchanged.
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   ".": {
-    count: 389,
-    sha256: "296798d2cb2a4bdf1b1547394e75c69fb27c504c58c9cceab44d7c6008610ec8",
+    count: 388,
+    sha256: "ba5d322f78a05b64e3c21926da4836acb52a26ee41906b9904915884dae7c6ac",
   },
   "./adapters/drizzle/engine": {
-    count: 321,
-    sha256: "b7c939af039e2b911ef6eec2ac0f9a1793a1061f1de6a3d8f7bcdc136d97f6cc",
+    count: 320,
+    sha256: "e4dd8a48116696b9fa69b13c67a1213c3ba034b0093ed3f646f0dcaa7bbaaefa",
   },
   "./adapters/drizzle/indexes": {
     count: 24,
     sha256: "6c11a8d2c13c886a2d6473f8af99d9c4988c7bbfe97545a6a6f748cdd18bf6d8",
   },
   "./adapters/drizzle/postgres": {
-    count: 247,
-    sha256: "bc129772f9e9be4c5d270dc9822645a0c9aa79e5f61cb2c31c5b8a5238fe7f4a",
+    count: 246,
+    sha256: "5fc01b18bbba5ed13dbd7505f6c8272b6c584205e560cc93f07d6ff65c699996",
   },
   "./adapters/drizzle/postgres/pglite": {
-    count: 251,
-    sha256: "abde0f0eea0abe922eea98c21aa64caad060eb7570b35be72cebca90cfa45e22",
+    count: 250,
+    sha256: "924e5570b2adaaf898c2b60bf40cbdf1253049cf5f84820cb0426e3235df524f",
   },
   "./adapters/drizzle/sqlite": {
-    count: 248,
-    sha256: "a69b25e4df337cac2f22886dae336c4b706537a64b865c87d3706201a97ae194",
+    count: 247,
+    sha256: "6ecc56851e7c322b365927d926ecd116db03998df0eaf6b14edc2106aa88b6ac",
   },
   "./adapters/drizzle/sqlite/libsql": {
-    count: 251,
-    sha256: "2d9ab4e3ed7b55ee1a9a19aaf459db1693cfba5bd048fe87fe49cb2fcca058a3",
+    count: 250,
+    sha256: "25e36fa53b2453fbbc139ce0f52fa55ec9364c305830aaf6c7f726d07bbcd068",
   },
   "./adapters/drizzle/sqlite/local": {
-    count: 251,
-    sha256: "2d9ab4e3ed7b55ee1a9a19aaf459db1693cfba5bd048fe87fe49cb2fcca058a3",
+    count: 250,
+    sha256: "25e36fa53b2453fbbc139ce0f52fa55ec9364c305830aaf6c7f726d07bbcd068",
   },
   "./backend": {
-    count: 17,
-    sha256: "d7be94fc8aff9a4c4f7e304ce209aaf05f426ad2a8e808fa8b5066bfae75f19e",
+    count: 16,
+    sha256: "fbcbd40667f4a4374dd0e267e595a852e5dfeec68d3d4e5e775848bc6468738f",
   },
   "./core": {
     count: 72,
@@ -391,36 +428,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   // lists: EDGE_TEMPORAL_READ_NAMES, IDENTITY_READ_NAMES, and NODE_READ_NAMES.
   // These three implementation constants are referenced, not public exports.
   "./graph-merge": {
-    count: 719,
-    sha256: "b4273d0e98554c6f23185c1e8a03537e46c5841bbf156a02a788ed20f0fd4388",
+    count: 718,
+    sha256: "b07fd3180190cdbadbcfedf6fd11ddc0562da1ba2ea5d3c4b48fe903c5655363",
   },
   "./indexes": {
     count: 46,
     sha256: "5a43d419097711d242c6208632e7e498374a5977eb10a7faba904b10e13f35cd",
   },
   "./interchange": {
-    count: 702,
-    sha256: "2cd7f13f276ed0b8921349904b596b985bf164f06750e511815c6d5b81febb09",
+    count: 701,
+    sha256: "81043bec464594503096ab691a03990c6217ef4285ddd478f0588558e441ac0c",
   },
   "./postgres/pglite": {
-    count: 706,
-    sha256: "a7187bc7f6a7f63a5f02401aedd5e806b1b1fbcb199a7f390a4ffd8357835f19",
+    count: 705,
+    sha256: "1298bd09525e1465a1d8483dd2127d5765a77d882a47940542fdcda623d0bcd3",
   },
   "./profiler": {
-    count: 704,
-    sha256: "f289b42f2e24ee80c53fd99e3424b8e0d6db48452ecd18f8ddfc7cbc64458fd8",
+    count: 703,
+    sha256: "3f48dc86aa37a1ca6de85ac0d82f37a53e83637a867a0412039599a59caf5fd1",
   },
   "./provenance": {
-    count: 710,
-    sha256: "b446a4165ead1c5e61253c1c6881a54b4809cc92afe59b0adda4e70db6889b15",
+    count: 709,
+    sha256: "7337e5c316d4ca805fe6822a6c51bddca1ad02ecd91d5353f7c99f228ce5145f",
   },
   "./schema": {
-    count: 272,
-    sha256: "f5bf2568fcb4d6b76db3c247e0cab49ed4a62a802e4873b3574621141030625e",
+    count: 271,
+    sha256: "a7078b0bb662cbe6f4a1a511cfc1f06971db0cb1e0272a4fa5ea13a8691c56d2",
   },
   "./sqlite/local": {
-    count: 706,
-    sha256: "a7187bc7f6a7f63a5f02401aedd5e806b1b1fbcb199a7f390a4ffd8357835f19",
+    count: 705,
+    sha256: "1298bd09525e1465a1d8483dd2127d5765a77d882a47940542fdcda623d0bcd3",
   },
 };
 

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -337,7 +337,7 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * the identical symbol; no entrypoint's debt decreases and no 15th
  * entrypoint moves.
  *
- * `pessimisticLocks` removal (B10 clean-up): `BackendCapabilities.pessimisticLocks`,
+ * `pessimisticLocks` removal: `BackendCapabilities.pessimisticLocks`,
  * `PessimisticLockCapabilities`, `writeFenceFromLegacyLocks`, and
  * `pessimisticLockDeclarationLine` are deleted outright — `writeFence` is
  * now the only write-fence declaration. This is a debt DECREASE, the first
@@ -352,10 +352,9 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * export there since the `WriteFencePlan`/`resolveWriteFencePlan` batch
  * above added the `unfenced` arm's `reason` field — is deleted along with
  * that field now that `undeclared` is the only way to reach `unfenced`.
- * `WriteFenceTarget`, exported directly at `./backend`, and
- * `PessimisticLockCapabilities` itself, also exported directly there, both
- * disappear from that entrypoint's public surface too, but neither was
- * forgotten-export debt, so neither moves this count. Delta table (old →
+ * `PessimisticLockCapabilities`, exported directly at `./backend`, also
+ * disappears from that entrypoint's surface, but a direct export is not
+ * forgotten-export debt, so it does not move this count. Delta table (old →
  * new, all −1): `.` 389→388, `./backend` 17→16, `./interchange` 702→701,
  * `./profiler` 704→703, `./schema` 272→271, `./graph-merge` 719→718,
  * `./provenance` 710→709, `./sqlite/local` 706→705, `./postgres/pglite`

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -310,6 +310,25 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
  * spelling batch above moved reach `FenceSql` through `GraphBackend
  * .fenceSql` instead, a field whose type is unchanged by this shrink, so
  * none of them render `WriteFencePlan`/`FenceStatements` and none move here.
+ *
+ * Declared write-fence surface (#622): `BackendCapabilities.writeFence?:
+ * WriteFenceDeclaration` joins the capability bag as the mechanism/drain
+ * declaration the deprecated `pessimisticLocks` maps onto.
+ * `WriteFenceDeclaration` is exported directly from `./backend` (this
+ * batch's barrel work), so that entrypoint's own debt is unchanged. Every
+ * other entrypoint whose public type graph renders `BackendCapabilities`
+ * without directly exporting `WriteFenceDeclaration` gains it as a forgotten
+ * export (+1): the same 13 entrypoints the write-fence batch above moved for
+ * `PessimisticLockCapabilities` (`.`, `./interchange`, `./profiler`,
+ * `./schema`, `./graph-merge`, `./provenance`, `./sqlite/local`,
+ * `./postgres/pglite`, and the five `./adapters/drizzle/*` sub-entrypoints
+ * other than `./adapters/drizzle/engine`), plus `./adapters/drizzle/engine`
+ * itself for the first time in this family — the builder-export batch above
+ * made `SqlEngineProfile.declaredCapabilities: BackendCapabilities` reachable
+ * there through the two builders it exported, so it now renders
+ * `BackendCapabilities` unexported too. 14 entrypoints move, all +1, all for
+ * the identical symbol; no entrypoint's debt decreases and no 15th
+ * entrypoint moves.
  */
 // Dynamic pinned edge lookup adds DynamicStoreViewEdgeCollection to the six
 // non-root Store-bearing entrypoints. Removing that single name reproduces each
@@ -325,36 +344,36 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
 // directly, so its own debt is unchanged.
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   ".": {
-    count: 388,
-    sha256: "11f038ecdf42bbad583047a01c5b5106f226a42291f67f19d588448764a6cbeb",
+    count: 389,
+    sha256: "296798d2cb2a4bdf1b1547394e75c69fb27c504c58c9cceab44d7c6008610ec8",
   },
   "./adapters/drizzle/engine": {
-    count: 320,
-    sha256: "de637873ab980dde2778687f620ffbc5cef77e54e4d422050c0bb2dc181eee7d",
+    count: 321,
+    sha256: "b7c939af039e2b911ef6eec2ac0f9a1793a1061f1de6a3d8f7bcdc136d97f6cc",
   },
   "./adapters/drizzle/indexes": {
     count: 24,
     sha256: "6c11a8d2c13c886a2d6473f8af99d9c4988c7bbfe97545a6a6f748cdd18bf6d8",
   },
   "./adapters/drizzle/postgres": {
-    count: 246,
-    sha256: "8c006f6a1e41393662c563d728e9a1ea8e37088c8b99d36141a4576a749baf5e",
+    count: 247,
+    sha256: "bc129772f9e9be4c5d270dc9822645a0c9aa79e5f61cb2c31c5b8a5238fe7f4a",
   },
   "./adapters/drizzle/postgres/pglite": {
-    count: 250,
-    sha256: "202efb4305f220d6ff4cb3e0a9d8f1d7d99dbbc5b3233015745dd9d928a31924",
+    count: 251,
+    sha256: "abde0f0eea0abe922eea98c21aa64caad060eb7570b35be72cebca90cfa45e22",
   },
   "./adapters/drizzle/sqlite": {
-    count: 247,
-    sha256: "22ef6d9483a40553b274996237ac3121560d8d88966c6e32003c1f97311f5872",
+    count: 248,
+    sha256: "a69b25e4df337cac2f22886dae336c4b706537a64b865c87d3706201a97ae194",
   },
   "./adapters/drizzle/sqlite/libsql": {
-    count: 250,
-    sha256: "17154fcd67efb82e904e7ed3fa57cc984114bdd75b7acaebb6ed5782d7f8c3cf",
+    count: 251,
+    sha256: "2d9ab4e3ed7b55ee1a9a19aaf459db1693cfba5bd048fe87fe49cb2fcca058a3",
   },
   "./adapters/drizzle/sqlite/local": {
-    count: 250,
-    sha256: "17154fcd67efb82e904e7ed3fa57cc984114bdd75b7acaebb6ed5782d7f8c3cf",
+    count: 251,
+    sha256: "2d9ab4e3ed7b55ee1a9a19aaf459db1693cfba5bd048fe87fe49cb2fcca058a3",
   },
   "./backend": {
     count: 17,
@@ -372,36 +391,36 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   // lists: EDGE_TEMPORAL_READ_NAMES, IDENTITY_READ_NAMES, and NODE_READ_NAMES.
   // These three implementation constants are referenced, not public exports.
   "./graph-merge": {
-    count: 718,
-    sha256: "edb32f3b47436fd7c4e2f62c571c106553aa28f2c19bb7cd783f766832336961",
+    count: 719,
+    sha256: "b4273d0e98554c6f23185c1e8a03537e46c5841bbf156a02a788ed20f0fd4388",
   },
   "./indexes": {
     count: 46,
     sha256: "5a43d419097711d242c6208632e7e498374a5977eb10a7faba904b10e13f35cd",
   },
   "./interchange": {
-    count: 701,
-    sha256: "9bf069f3f6a6f49d1bc2d6ef61d99c53cacc3fd4dc62d0ae966a1d66feaf9579",
+    count: 702,
+    sha256: "2cd7f13f276ed0b8921349904b596b985bf164f06750e511815c6d5b81febb09",
   },
   "./postgres/pglite": {
-    count: 705,
-    sha256: "d6154cb7bf47cd8c18b885c603287a4bbc54c75da64e72b97bb81c4d50e3f18b",
+    count: 706,
+    sha256: "a7187bc7f6a7f63a5f02401aedd5e806b1b1fbcb199a7f390a4ffd8357835f19",
   },
   "./profiler": {
-    count: 703,
-    sha256: "01d9f20480fae6d947b675be3cd6b71b6280563605ae3c8a61f569fd29466dde",
+    count: 704,
+    sha256: "f289b42f2e24ee80c53fd99e3424b8e0d6db48452ecd18f8ddfc7cbc64458fd8",
   },
   "./provenance": {
-    count: 709,
-    sha256: "824fef0bce05b867a867f66be6555931b5f3d074c43dd0ccd44a417d15268ae2",
+    count: 710,
+    sha256: "b446a4165ead1c5e61253c1c6881a54b4809cc92afe59b0adda4e70db6889b15",
   },
   "./schema": {
-    count: 271,
-    sha256: "98937d4bdad02494cdd60bf29a4287e543d9471a673d5846cb6796207d0f7448",
+    count: 272,
+    sha256: "f5bf2568fcb4d6b76db3c247e0cab49ed4a62a802e4873b3574621141030625e",
   },
   "./sqlite/local": {
-    count: 705,
-    sha256: "d6154cb7bf47cd8c18b885c603287a4bbc54c75da64e72b97bb81c4d50e3f18b",
+    count: 706,
+    sha256: "a7187bc7f6a7f63a5f02401aedd5e806b1b1fbcb199a7f390a4ffd8357835f19",
   },
 };
 

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -882,7 +882,7 @@ export const UNBUNDLED_OPTIONAL_MEMBERS = {
   fenceSql: {
     kind: "reasoned",
     reason:
-      "The write-fence lock spelling a backend's `pessimisticLocks.advisoryLocks: true` declaration requires. Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.",
+      "The write-fence lock spelling a backend's `writeFence: { mechanism: \"advisory\" }` declaration requires (or, in the deprecated legacy shape, `pessimisticLocks.advisoryLocks: true`). Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.",
     accesses: 2,
   },
   commitSchemaVersionIfKindsEmpty: {

--- a/packages/typegraph/src/backend/capabilities/bundle-registry.ts
+++ b/packages/typegraph/src/backend/capabilities/bundle-registry.ts
@@ -882,7 +882,7 @@ export const UNBUNDLED_OPTIONAL_MEMBERS = {
   fenceSql: {
     kind: "reasoned",
     reason:
-      "The write-fence lock spelling a backend's `writeFence: { mechanism: \"advisory\" }` declaration requires (or, in the deprecated legacy shape, `pessimisticLocks.advisoryLocks: true`). Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.",
+      "The write-fence lock spelling a backend's `writeFence: { mechanism: \"advisory\" }` declaration requires. Every lock site reads it exclusively through the resolved `WriteFencePlan`'s `sql` field (`resolveWriteFencePlan`/`requireWriteFence` in `backend/capabilities/write-fence.ts`). The one exception is `assertRecordedCaptureTransactionIsolation` (`store/recorded-capture/guards.ts`), which reads `target.fenceSql` directly: it is gated purely on `dialect`, not on a resolved fence plan, so there is no plan to read the spelling through.",
     accesses: 2,
   },
   commitSchemaVersionIfKindsEmpty: {

--- a/packages/typegraph/src/backend/capabilities/declarations.ts
+++ b/packages/typegraph/src/backend/capabilities/declarations.ts
@@ -67,10 +67,9 @@ export function assertNoLegacyTransactionCapability(
  *    declaration claims support while also carrying an explanation for a
  *    lack of it.
  *
- * Deliberately narrow: no `pessimisticLocks` / `graphAnalytics` / surface
- * cross-checks here. An all-`false` lock declaration is legitimate on its
- * own, and declaration-vs-surface consistency is a different concern (a
- * resolved bundle's job, not a bundled declaration's).
+ * Deliberately narrow: no `writeFence` / `graphAnalytics` / surface
+ * cross-checks here — declaration-vs-surface consistency is a different
+ * concern (a resolved bundle's job, not a bundled declaration's).
  *
  * @throws {ConfigurationError} when a declaration contradicts its own shape.
  */

--- a/packages/typegraph/src/backend/capabilities/index.ts
+++ b/packages/typegraph/src/backend/capabilities/index.ts
@@ -135,7 +135,6 @@ export {
 } from "./resolve";
 export {
   type FenceSql,
-  type PessimisticLockCapabilities,
   requireWriteFence,
   resolveWriteFencePlan,
   type WriteFencePlan,

--- a/packages/typegraph/src/backend/capabilities/write-fence.ts
+++ b/packages/typegraph/src/backend/capabilities/write-fence.ts
@@ -1,7 +1,6 @@
 /**
  * The write-fence capability: how this engine excludes concurrent writers,
- * declared as `capabilities.writeFence` (preferred) or the deprecated
- * `capabilities.pessimisticLocks`.
+ * declared as `capabilities.writeFence`.
  *
  * `resolveWriteFencePlan` is THE one owner of the write-fence decision every
  * lock site used to re-derive from `dialect` inline. A lock site never
@@ -15,11 +14,10 @@ import { type BackendCapabilities } from "../types";
 
 /**
  * The lock-statement spelling a backend supplies alongside its
- * `pessimisticLocks` declaration: the two composable, no-`SELECT`
- * expressions a fused statement (a CTE, a data-modifying statement) embeds
- * directly, plus the one relation-lock builder. A backend that declares
- * `advisoryLocks: true` must supply this; one that only serializes writers
- * needs none.
+ * `writeFence` declaration: the two composable, no-`SELECT` expressions a
+ * fused statement (a CTE, a data-modifying statement) embeds directly, plus
+ * the one relation-lock builder. A backend that declares `writeFence.mechanism:
+ * "advisory"` must supply this; one that only serializes writers needs none.
  *
  * This is deliberately the ONLY spelling a backend author writes.
  * {@link resolveFenceStatements} derives the standalone-statement forms
@@ -133,46 +131,6 @@ export function resolveFenceStatements(fenceSql: FenceSql): FenceStatements {
 }
 
 /**
- * The two independent facts a backend can report about concurrent-writer
- * serialization.
- */
-export type PessimisticLockCapabilities = Readonly<{
-  /** `pg_advisory_xact_lock`-style keyed locks scoped to the transaction. */
-  advisoryLocks: boolean;
-  /** `LOCK TABLE … IN … MODE`-style relation locks. */
-  tableLocks: boolean;
-  /**
-   * The engine serializes concurrent writers by construction (SQLite's single
-   * writer slot). This is what makes "take no lock" CORRECT on SQLite and
-   * WRONG on an engine with neither locks nor a slot.
-   */
-  serializedWriters: boolean;
-}>;
-
-/**
- * Why {@link resolveWriteFencePlan} could not resolve a usable fence — the
- * three states `writeFenceFromLegacyLocks`/`resolveWriteFencePlan` can reach
- * an `unfenced` plan from:
- *
- * - `"undeclared"` — `capabilities.pessimisticLocks` is absent on a target
- *   that is not one of TypeGraph's bundled factories (M-5's defect
- *   population: an undeclared custom backend is by definition uncertified).
- * - `"declared-none"` — `pessimisticLocks` is present but declares all three
- *   of `advisoryLocks`, `tableLocks`, and `serializedWriters` false.
- * - `"table-locks-only"` — `pessimisticLocks` declares `{advisoryLocks:
- *   false, tableLocks: true, serializedWriters: false}`. The plan model has
- *   no table-lock-alone arm (see the note next to `planFromLockCapabilities`
- *   below, which handles the legacy shapes `writeFenceFromLegacyLocks`
- *   declines to map), so this declaration resolves `unfenced` exactly like
- *   an absent or all-false one, even though it is neither.
- *
- * Every refusal that reaches an `unfenced` plan states the actual reason
- * instead of a message broad enough to cover all three.
- */
-export type UnfencedReason =
-  "undeclared" | "declared-none" | "table-locks-only";
-
-/**
  * How a backend excludes concurrent writers, and how far a caller that took
  * the lock can drain the resource it protects.
  *
@@ -194,48 +152,11 @@ export type UnfencedReason =
  * in-process queue) so a table-lock site takes NO statement rather than one
  * it does not need; `"none"` means neither — a table-lock site refuses,
  * naming this drain.
- *
- * `writeFenceFromLegacyLocks` is the one place a legacy `PessimisticLockCapabilities`
- * declaration is translated into this shape.
  */
 export type WriteFenceDeclaration = Readonly<{
   mechanism: "advisory" | "engine-serialized" | "caller-serialized";
   drain: "table-lock" | "quiescent" | "none";
 }>;
-
-/**
- * THE one mapping from the legacy `pessimisticLocks` declaration to a
- * {@link WriteFenceDeclaration}. Every reader of a legacy declaration goes
- * through this function rather than re-deriving the mapping inline, so the
- * two declaration styles can never drift apart on what they mean.
- *
- * - `advisoryLocks: true` → `{ mechanism: "advisory", drain: tableLocks ?
- *   "table-lock" : "none" }` — `tableLocks` decides the drain, exactly as it
- *   always has.
- * - `serializedWriters: true` → `{ mechanism: "engine-serialized", drain:
- *   "table-lock" }` — the writer slot excludes writers outright, and a
- *   table-lock site under it has always taken no statement (reading that as
- *   "drains").
- * - Neither (an all-false declaration, or `{ tableLocks: true }` alone —
- *   the plan model has no table-lock-only arm) → `undefined`. The caller
- *   falls back to the existing `unfenced` reasons (`"declared-none"` /
- *   `"table-locks-only"`); construction still succeeds and only a
- *   fence-requiring site refuses, exactly as today.
- */
-export function writeFenceFromLegacyLocks(
-  locks: PessimisticLockCapabilities,
-): WriteFenceDeclaration | undefined {
-  if (locks.advisoryLocks) {
-    return {
-      mechanism: "advisory",
-      drain: locks.tableLocks ? "table-lock" : "none",
-    };
-  }
-  if (locks.serializedWriters) {
-    return { mechanism: "engine-serialized", drain: "table-lock" };
-  }
-  return undefined;
-}
 
 /**
  * The decision every lock site consumes, rather than a flag a caller would
@@ -246,17 +167,9 @@ export type WriteFencePlan =
    * Take the keyed lock, spelled by `sql` — the target's OWN declared
    * spelling: a lock site never hand-writes the statement, it resolves
    * a plan and consumes `sql.<builder>(…)`.
-   *
-   * `tableLocks` is kept for source compatibility and is derived from
-   * `drain`(`=== "table-lock"`); read `drain` instead — it distinguishes a
-   * declaration that cannot drain a table-lock site at all (`"none"`) from
-   * one that drains it without a statement (`"quiescent"`).
    */
   | Readonly<{
       kind: "lock";
-      advisoryLocks: true;
-      /** @deprecated Read `drain` — this is `drain === "table-lock"`. */
-      tableLocks: boolean;
       drain: "table-lock" | "quiescent" | "none";
       sql: FenceStatements;
     }>
@@ -268,8 +181,8 @@ export type WriteFencePlan =
    * issues, and no other client writes to the database while it is open.
    */
   | Readonly<{ kind: "caller-serialized" }>
-  /** Neither. Every non-degradable fence refuses. Carries why — see {@link UnfencedReason}. */
-  | Readonly<{ kind: "unfenced"; reason: UnfencedReason }>;
+  /** Neither. Every non-degradable fence refuses: `capabilities.writeFence` is absent. */
+  | Readonly<{ kind: "unfenced" }>;
 
 /**
  * What `resolveWriteFencePlan` needs: the dialect (for the first-party
@@ -458,11 +371,11 @@ export function isFirstPartyProfile(profile: object): boolean {
 
 /**
  * The write-fence declaration a first-party (bundled-factory) target derives
- * when its `capabilities` name neither `writeFence` nor the legacy
- * `pessimisticLocks` — exactly what every lock site used to compute inline
- * from `dialect` before this capability existed. `writeFenceDeclarationLine`
- * formats this same derivation as the migration-guide literal a refusal
- * prints, so the derivation and the printed suggestion can never disagree.
+ * when its `capabilities` name no `writeFence` — exactly what every lock
+ * site used to compute inline from `dialect` before this capability
+ * existed. `writeFenceDeclarationLine` formats this same derivation as the
+ * migration-guide literal a refusal prints, so the derivation and the
+ * printed suggestion can never disagree.
  */
 function deriveFromDialect(dialect: SqlDialect): WriteFenceDeclaration {
   switch (dialect) {
@@ -482,25 +395,20 @@ function deriveFromDialect(dialect: SqlDialect): WriteFenceDeclaration {
  * Which declaration style {@link planFromWriteFenceDeclaration} resolved its
  * `WriteFenceDeclaration` from — carried only so
  * {@link refuseWriteFenceSqlUnavailable} can name the declaration the target
- * ACTUALLY made, rather than assuming the legacy shape unconditionally.
+ * ACTUALLY made, rather than assuming a shape unconditionally.
  *
  * - `"writeFence"` — the target declared `capabilities.writeFence` directly.
- * - `"pessimisticLocks"` — the target declared the legacy
- *   `capabilities.pessimisticLocks`, mapped through
- *   {@link writeFenceFromLegacyLocks}.
- * - `"dialect"` — neither is declared; a first-party factory target's
+ * - `"dialect"` — `writeFence` is absent; a first-party factory target's
  *   `mechanism` came from {@link deriveFromDialect}.
  */
-type WriteFenceDeclarationSource =
-  "writeFence" | "pessimisticLocks" | "dialect";
+type WriteFenceDeclarationSource = "writeFence" | "dialect";
 
 /**
  * Names the declaration {@link refuseWriteFenceSqlUnavailable} blames for
- * promising a lock this target cannot spell — the phrase every one of its
- * three provenances (a direct `writeFence`, a mapped legacy
- * `pessimisticLocks`, or the first-party dialect derivation) fills in
- * differently, so the refusal never states a declaration the target did not
- * actually make.
+ * promising a lock this target cannot spell — the phrase each of its two
+ * provenances (a direct `writeFence`, or the first-party dialect derivation)
+ * fills in differently, so the refusal never states a declaration the
+ * target did not actually make.
  */
 function describeResolvedAdvisoryDeclaration(
   declaration: WriteFenceDeclaration,
@@ -510,9 +418,6 @@ function describeResolvedAdvisoryDeclaration(
   switch (source) {
     case "writeFence": {
       return `declares \`capabilities.${formatWriteFenceDeclaration(declaration)}\``;
-    }
-    case "pessimisticLocks": {
-      return "declares `capabilities.pessimisticLocks.advisoryLocks: true`";
     }
     case "dialect": {
       return `resolves an advisory-lock write fence from its \`${dialect}\` dialect`;
@@ -572,10 +477,9 @@ function fenceSqlMemberPurpose(member: keyof FenceSql): string {
  *
  * The one call site is `planFromWriteFenceDeclaration`, shared by every
  * `resolveWriteFencePlan` arm that can resolve `mechanism: "advisory"` — a
- * declared `writeFence`, a mapped legacy `pessimisticLocks`, and the
- * first-party dialect derivation all resolve through it, and each passes its
- * own {@link WriteFenceDeclarationSource} so the message names the
- * declaration the target actually made.
+ * declared `writeFence` and the first-party dialect derivation both resolve
+ * through it, and each passes its own {@link WriteFenceDeclarationSource} so
+ * the message names the declaration the target actually made.
  *
  * @throws {ConfigurationError} always.
  */
@@ -599,7 +503,7 @@ function refuseWriteFenceSqlUnavailable(
       suggestion:
         dialect === "postgres" ?
           "Supply `fenceSql: postgresFenceSql` (exported from `@nicia-ai/typegraph/adapters/drizzle/postgres`) — the bundled PostgreSQL backend does this automatically — or provide a custom FenceSql matching this engine's lock syntax."
-        : "Provide a custom `fenceSql: FenceSql` matching this engine's lock syntax, or declare `pessimisticLocks.advisoryLocks: false`.",
+        : 'Provide a custom `fenceSql: FenceSql` matching this engine\'s lock syntax, or declare `writeFence.mechanism: "engine-serialized"` instead.',
     },
   );
 }
@@ -610,10 +514,10 @@ function refuseWriteFenceSqlUnavailable(
  * {@link refuseWriteFenceSqlUnavailable}: that refusal fires only under a
  * resolved `lock` plan, so it can name the declaration that actually
  * resolved to `mechanism: "advisory"` — a claim that makes no sense for a
- * target with no lock plan in play at all (e.g. one declaring
- * `serializedWriters: true` and no advisory locks). A session-fact read is
- * gated on `dialect` alone, not on a resolved plan, so it needs its own
- * refusal naming what it actually needs.
+ * target with no lock plan in play at all (e.g. one declaring `mechanism:
+ * "engine-serialized"`). A session-fact read is gated on `dialect` alone,
+ * not on a resolved plan, so it needs its own refusal naming what it
+ * actually needs.
  *
  * @throws {ConfigurationError} always.
  */
@@ -636,12 +540,11 @@ export function refuseFenceSqlSessionFactUnavailable(
 /**
  * THE one constructor of a {@link WriteFencePlan} from an already-resolved
  * {@link WriteFenceDeclaration}, regardless of which declaration style
- * produced it (`capabilities.writeFence` directly, the legacy
- * `pessimisticLocks` mapped through {@link writeFenceFromLegacyLocks}, or
- * the first-party dialect derivation). One owner means a `writeFence`
- * declaration and its legacy equivalent resolve to the identical plan shape.
+ * produced it (`capabilities.writeFence` directly, or the first-party
+ * dialect derivation). One owner means both provenances resolve to the
+ * identical plan shape.
  *
- * `source` names which of those three provenances `declaration` came from —
+ * `source` names which of those two provenances `declaration` came from —
  * threaded only to {@link refuseWriteFenceSqlUnavailable}, so a missing
  * `fenceSql` is blamed on the declaration the target actually made.
  */
@@ -681,8 +584,6 @@ function planFromWriteFenceDeclaration(
       }
       return {
         kind: "lock",
-        advisoryLocks: true,
-        tableLocks: declaration.drain === "table-lock",
         drain: declaration.drain,
         sql: resolveFenceStatements(
           requireDefined(
@@ -704,81 +605,21 @@ function planFromWriteFenceDeclaration(
   }
 }
 
-function planFromLockCapabilities(
-  target: WriteFenceTarget,
-  declared: PessimisticLockCapabilities,
-): WriteFencePlan {
-  const mapped = writeFenceFromLegacyLocks(declared);
-  if (mapped !== undefined)
-    return planFromWriteFenceDeclaration(target, mapped, "pessimisticLocks");
-  // A declared table-locks-only engine (no advisoryLocks, no
-  // serializedWriters) resolves `unfenced` with reason `"table-locks-only"`:
-  // every TypeGraph fence needs either the advisory key or the writer slot,
-  // and the plan model has no table-lock-only arm, so `{advisoryLocks:
-  // false, tableLocks: true, serializedWriters: false}` refuses with
-  // WRITE_FENCE_UNAVAILABLE exactly as it does at every other table-lock
-  // site — including trusted import's, even though that site takes a table
-  // lock with no advisory lock above it. Trusted import owns the whole node
-  // and edge relations for the duration of its own transaction, so there is
-  // no shared resource left for a second writer to race it on, and no wider
-  // fence for an advisory key to nest inside — but that exemption from
-  // needing an advisory lock is not an exemption from this declaration
-  // requirement. An all-false declaration reaches the same arm with reason
-  // `"declared-none"`.
-  return {
-    kind: "unfenced",
-    reason: declared.tableLocks ? "table-locks-only" : "declared-none",
-  };
-}
-
 /**
- * THE refusal for a target whose `capabilities` name BOTH a `writeFence`
- * declaration and the legacy `pessimisticLocks` one: exactly one is the
- * effective declaration, and picking one silently over the other would let
- * a caller believe both are honored when only one ever is.
- *
- * @throws {ConfigurationError} always.
- */
-function refuseWriteFenceDeclarationConflict(target: WriteFenceTarget): never {
-  throw new ConfigurationError(
-    "This backend's `capabilities` declare both `writeFence` and the " +
-      "legacy `pessimisticLocks`. Exactly one write-fence declaration is " +
-      "allowed — remove whichever one does not describe this backend.",
-    {
-      code: "WRITE_FENCE_DECLARATION_CONFLICT",
-      dialect: target.dialect,
-      writeFence: target.capabilities.writeFence,
-      pessimisticLocks: target.capabilities.pessimisticLocks,
-    },
-    {
-      suggestion:
-        "Declare `capabilities.writeFence` alone (preferred) or `capabilities.pessimisticLocks` alone (deprecated), not both.",
-    },
-  );
-}
-
-/**
- * THE one reader of `capabilities.writeFence` and the legacy
- * `capabilities.pessimisticLocks`, and THE one constructor of a
+ * THE one reader of `capabilities.writeFence`, and THE one constructor of a
  * {@link WriteFencePlan}.
  *
  * Resolution order:
  *
- * 1. **Both declared** — refuse (`WRITE_FENCE_DECLARATION_CONFLICT`): a
- *    target cannot mean two things at once.
- * 2. **`writeFence` declared** — resolve it directly through
+ * 1. **`writeFence` declared** — resolve it directly through
  *    {@link planFromWriteFenceDeclaration}.
- * 3. **Legacy `pessimisticLocks` declared** — map it through
- *    {@link writeFenceFromLegacyLocks} and resolve exactly as case 2, or
- *    fall to `unfenced` with the existing reason when the mapping declines
- *    (`"table-locks-only"` / `"declared-none"`).
- * 4. **Neither declared, first-party factory** — derive from `dialect`
+ * 2. **Undeclared, first-party factory** — derive from `dialect`
  *    ({@link deriveFromDialect}), which is exactly what every lock site used
- *    to compute inline. Both bundled factories declare `pessimisticLocks`
+ *    to compute inline. Both bundled factories declare `writeFence`
  *    unconditionally, so nothing in-tree reaches this arm; it is reachable
  *    only from tests that build a backend object bypassing the factories'
  *    declared capabilities while still carrying the first-party mark.
- * 5. **Neither declared, anything else** — `unfenced`. Conservative: an
+ * 3. **Undeclared, anything else** — `unfenced`. Conservative: an
  *    undeclared custom backend is by definition uncertified, and inferring
  *    lock support from `dialect` alone is the unsound inference this
  *    capability replaces (a PostgreSQL-wire backend reporting `dialect:
@@ -787,15 +628,9 @@ function refuseWriteFenceDeclarationConflict(target: WriteFenceTarget): never {
 export function resolveWriteFencePlan(
   target: WriteFenceTarget,
 ): WriteFencePlan {
-  const { writeFence, pessimisticLocks } = target.capabilities;
-  if (writeFence !== undefined && pessimisticLocks !== undefined) {
-    refuseWriteFenceDeclarationConflict(target);
-  }
+  const { writeFence } = target.capabilities;
   if (writeFence !== undefined) {
     return planFromWriteFenceDeclaration(target, writeFence, "writeFence");
-  }
-  if (pessimisticLocks !== undefined) {
-    return planFromLockCapabilities(target, pessimisticLocks);
   }
   if (FIRST_PARTY_FACTORY_BACKENDS.has(target)) {
     return planFromWriteFenceDeclaration(
@@ -804,7 +639,7 @@ export function resolveWriteFencePlan(
       "dialect",
     );
   }
-  return { kind: "unfenced", reason: "undeclared" };
+  return { kind: "unfenced" };
 }
 
 /**
@@ -818,135 +653,31 @@ function formatWriteFenceDeclaration(
 }
 
 /**
- * THE one owner of the literal legacy `pessimisticLocks` declaration line a
- * refusal recommends.
- *
- * Deprecated in favor of {@link writeFenceDeclarationLine}, which prints this
- * same line alongside the preferred `writeFence` spelling — prefer that in
- * new code. Not machine-`@deprecated`: it shipped `@public` at 0.56.0 and
- * stays a genuine, permanently supported alias for a caller that already
- * reads it directly, not a migration-window shim.
- */
-export function pessimisticLockDeclarationLine(dialect: SqlDialect): string {
-  switch (dialect) {
-    case "postgres": {
-      return "pessimisticLocks: { advisoryLocks: true, tableLocks: true, serializedWriters: false }";
-    }
-    case "sqlite": {
-      return "pessimisticLocks: { advisoryLocks: false, tableLocks: false, serializedWriters: true }";
-    }
-    default: {
-      return dialect satisfies never;
-    }
-  }
-}
-
-/**
  * THE one owner of the literal declaration line a refusal recommends —
  * printed verbatim by both unfenced refusals below and by
  * `createSqlBackend`'s own construction-time gate, so the migration guide
- * cannot rot into a pointer (ruling OQ-B). Prints the preferred `writeFence`
- * spelling first, then the legacy `pessimisticLocks` line
- * ({@link pessimisticLockDeclarationLine}) a reader may still be carrying.
- *
- * `indent` is prefixed to every non-empty line of the (multi-line) result,
- * so a caller embedding this inside an indented suggestion never has to
- * indent the continuation lines itself — a caller who only interpolates the
- * first line's prefix leaves the "or, legacy:" line and the legacy
- * declaration flush against the margin.
+ * cannot rot into a pointer (ruling OQ-B).
  */
 export function writeFenceDeclarationLine(
   dialect: SqlDialect,
   indent = "",
 ): string {
-  const lines = [
-    formatWriteFenceDeclaration(deriveFromDialect(dialect)),
-    "",
-    "or, legacy:",
-    "",
-    pessimisticLockDeclarationLine(dialect),
-  ];
-  return lines
-    .map((line) => (line === "" ? line : `${indent}${line}`))
-    .join("\n");
+  const line = formatWriteFenceDeclaration(deriveFromDialect(dialect));
+  return indent === "" ? line : `${indent}${line}`;
 }
 
 /**
- * THE one owner of the "why `unfenced`" phrase — consumed by both
- * `unfencedRefusalMessage` (the two construction gates, which also print a
- * dialect-keyed fix) and `requireWriteFence`'s `unfenced` arm below, which
- * has no dialect to key a fix to (a bare `WriteFencePlan` carries `reason`
- * but not the target's dialect).
+ * The shared body of both unfenced-construction refusals below: `undeclared`
+ * is the only way `resolveWriteFencePlan` ever reaches `unfenced` now that
+ * `writeFence` is the sole declaration, so this states that fact plainly and
+ * prints the fix, keyed to the dialect the backend reports.
  */
-function unfencedDeclarationStateDescription(reason: UnfencedReason): string {
-  switch (reason) {
-    case "undeclared": {
-      return (
-        "`capabilities.writeFence` (or the deprecated " +
-        "`capabilities.pessimisticLocks`) is absent"
-      );
-    }
-    case "declared-none": {
-      return "`capabilities.pessimisticLocks` declares neither advisory/table locks nor serialized writers";
-    }
-    case "table-locks-only": {
-      return (
-        "`capabilities.pessimisticLocks` reports table locks without " +
-        "advisory locks or serialized writers — TypeGraph has no " +
-        "table-lock-only fence, so this posture is unsupported"
-      );
-    }
-    default: {
-      return reason satisfies never;
-    }
-  }
-}
-
-/**
- * The shared body of both unfenced-construction refusals below: states the
- * ACTUAL reason `unfenced` was reached — see {@link UnfencedReason} — rather
- * than a message broad enough to cover all three, then prints the fix,
- * keyed to the dialect the backend reports.
- */
-function unfencedRefusalMessage(
-  dialect: SqlDialect,
-  reason: UnfencedReason,
-  resource: string,
-): string {
-  const declaredLine = writeFenceDeclarationLine(dialect, "  ");
-  const otherDialect: SqlDialect =
-    dialect === "postgres" ? "sqlite" : "postgres";
-  const otherLine = writeFenceDeclarationLine(otherDialect, "  ");
-  const dialectDescription =
-    dialect === "postgres" ?
-      "an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"
-    : "an engine with a single writer slot";
-  const otherDescription =
-    otherDialect === "postgres" ?
-      "an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"
-    : "an engine with a single writer slot";
-  const declarationState = unfencedDeclarationStateDescription(reason);
-
-  if (reason === "table-locks-only") {
-    return (
-      `This backend's ${declarationState}, and ${resource} cannot run ` +
-      "unfenced. Declare an advisory-lock mechanism:\n\n" +
-      `${declaredLine}\n\n` +
-      "or a single-writer mechanism:\n\n" +
-      `${otherLine}\n`
-    );
-  }
-
+function unfencedRefusalMessage(dialect: SqlDialect, resource: string): string {
   return (
-    `This backend declares no usable write fence: ${declarationState}, ` +
-    `so TypeGraph cannot know whether it fences concurrent writers, and ${resource} ` +
-    "cannot run unfenced. Add ONE write-fence declaration to the " +
-    "capabilities you pass:\n\n" +
-    `${declaredLine}\n\n` +
-    `(that is the correct declaration for ${dialectDescription}; use\n\n` +
-    `${otherLine}\n\n` +
-    `for ${otherDescription}). If the engine honors neither, this refusal ` +
-    `is correct and ${resource} is unavailable on it.`
+    "This backend declares no usable write fence: `capabilities.writeFence` " +
+    `is absent, so TypeGraph cannot know whether it fences concurrent ` +
+    `writers, and ${resource} cannot run unfenced. Declare it:\n\n` +
+    `${writeFenceDeclarationLine(dialect, "  ")}\n`
   );
 }
 
@@ -956,16 +687,13 @@ function unfencedRefusalMessage(
  *
  * @throws {ConfigurationError} always.
  */
-export function refuseUnfencedOperationalIdentity(
-  dialect: SqlDialect,
-  reason: UnfencedReason,
-): never {
+export function refuseUnfencedOperationalIdentity(dialect: SqlDialect): never {
   throw new ConfigurationError(
-    unfencedRefusalMessage(dialect, reason, "Operational Identity"),
-    { code: "IDENTITY_REQUIRES_WRITE_FENCE", dialect, reason },
+    unfencedRefusalMessage(dialect, "Operational Identity"),
+    { code: "IDENTITY_REQUIRES_WRITE_FENCE", dialect },
     {
       suggestion:
-        "Declare `capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) on this backend, or construct the store without `identity`.",
+        "Declare `capabilities.writeFence` on this backend, or construct the store without `identity`.",
     },
   );
 }
@@ -977,20 +705,16 @@ export function refuseUnfencedOperationalIdentity(
  *
  * @throws {ConfigurationError} always.
  */
-export function refuseUnfencedClockAllocation(
-  dialect: SqlDialect,
-  reason: UnfencedReason,
-): never {
+export function refuseUnfencedClockAllocation(dialect: SqlDialect): never {
   throw new ConfigurationError(
     unfencedRefusalMessage(
       dialect,
-      reason,
       "TypeGraph's recorded-time clock allocation",
     ),
-    { code: "RECORDED_CLOCK_REQUIRES_WRITE_FENCE", dialect, reason },
+    { code: "RECORDED_CLOCK_REQUIRES_WRITE_FENCE", dialect },
     {
       suggestion:
-        "Declare `capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) on this backend, or construct the store without `history`/`revisionTracking`.",
+        "Declare `capabilities.writeFence` on this backend, or construct the store without `history`/`revisionTracking`.",
     },
   );
 }
@@ -1007,19 +731,19 @@ export function refuseUnfencedClockAllocation(
  * either lock shape, so there is nothing for either `requires` to add.
  *
  * @throws {ConfigurationError} under `unfenced`, and under
- * `kind: "lock" && drain === "none"` when `requires === "table-lock"`.
+ * `kind: "lock" && drain === "none"` when `requires === "drain"`.
  */
 export function requireWriteFence(
   plan: WriteFencePlan,
   operation: string,
-  requires: "advisory-lock" | "table-lock",
+  requires: "keyed" | "drain",
 ): Extract<
   WriteFencePlan,
   { kind: "lock" | "engine-serialized" | "caller-serialized" }
 > {
   switch (plan.kind) {
     case "lock": {
-      if (requires === "table-lock" && plan.drain === "none") {
+      if (requires === "drain" && plan.drain === "none") {
         throw new ConfigurationError(
           `${operation} requires a table lock, but this backend's write-fence ` +
             'declaration reports drain: "none".',
@@ -1031,7 +755,7 @@ export function requireWriteFence(
           },
           {
             suggestion:
-              'Declare `writeFence.drain: "table-lock"` (or, in the deprecated legacy shape, `pessimisticLocks.tableLocks: true`) on this backend, or avoid this operation.',
+              'Declare `writeFence.drain: "table-lock"` on this backend, or avoid this operation.',
           },
         );
       }
@@ -1046,18 +770,15 @@ export function requireWriteFence(
     case "unfenced": {
       throw new ConfigurationError(
         `${operation} requires a write fence, but this backend declares no ` +
-          `usable write fence (${unfencedDeclarationStateDescription(plan.reason)}).`,
+          "usable write fence (`capabilities.writeFence` is absent).",
         {
           code: "WRITE_FENCE_UNAVAILABLE",
           operation,
           requires,
-          reason: plan.reason,
         },
         {
           suggestion:
-            plan.reason === "table-locks-only" ?
-              'Declare `writeFence: { mechanism: "advisory", drain: "table-lock" }` (or, in the deprecated legacy shape, `pessimisticLocks.advisoryLocks: true`) on this backend for an engine that honors advisory locks, or `writeFence: { mechanism: "engine-serialized", drain: "table-lock" }` (or `pessimisticLocks.serializedWriters: true`) for a single-writer engine.'
-            : "Declare `capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) on this backend, matching the engine's real locking support.",
+            "Declare `capabilities.writeFence` on this backend, matching the engine's real locking support.",
         },
       );
     }

--- a/packages/typegraph/src/backend/capabilities/write-fence.ts
+++ b/packages/typegraph/src/backend/capabilities/write-fence.ts
@@ -663,7 +663,7 @@ export function writeFenceDeclarationLine(
   indent = "",
 ): string {
   const line = formatWriteFenceDeclaration(deriveFromDialect(dialect));
-  return indent === "" ? line : `${indent}${line}`;
+  return `${indent}${line}`;
 }
 
 /**

--- a/packages/typegraph/src/backend/capabilities/write-fence.ts
+++ b/packages/typegraph/src/backend/capabilities/write-fence.ts
@@ -144,19 +144,40 @@ export function resolveFenceStatements(fenceSql: FenceSql): FenceStatements {
  * this backend is open. `"row"` (a per-row lock) joins this union in a later
  * release.
  *
- * `drain` is a separate fact: whether a caller that already excluded other
- * writers can additionally take a relation-wide lock on the resource a
- * table-lock site protects. `"table-lock"` means yes (a `LOCK TABLE`-style
- * statement is available and appropriate); `"quiescent"` means the resource
- * is already exclusive for another reason (e.g. `caller-serialized`'s
- * in-process queue) so a table-lock site takes NO statement rather than one
- * it does not need; `"none"` means neither — a table-lock site refuses,
- * naming this drain.
+ * `drain` is a separate fact, and applies ONLY to `mechanism: "advisory"`:
+ * whether a caller that already took the keyed lock can additionally take a
+ * relation-wide lock on the resource a table-lock site protects.
+ * `"table-lock"` means yes (a `LOCK TABLE`-style statement is available and
+ * appropriate); `"quiescent"` means the resource is already exclusive for
+ * another reason (e.g. a `caller-serialized` in-process queue layered
+ * alongside an advisory lock) so a table-lock site takes NO statement rather
+ * than one it does not need; `"none"` means neither — a table-lock site
+ * refuses, naming this drain. `"engine-serialized"` and `"caller-serialized"`
+ * carry no `drain`: an engine's single writer slot and an in-process
+ * serialization promise are each already a stronger exclusion than any
+ * `drain` value could add, so there is nothing for the field to say —
+ * declaring one alongside either mechanism is refused
+ * (`WRITE_FENCE_DECLARATION_INVALID`, `validateWriteFenceDeclaration` below).
  */
-export type WriteFenceDeclaration = Readonly<{
-  mechanism: "advisory" | "engine-serialized" | "caller-serialized";
-  drain: "table-lock" | "quiescent" | "none";
-}>;
+export type WriteFenceDeclaration =
+  | Readonly<{
+      mechanism: "advisory";
+      drain: "table-lock" | "quiescent" | "none";
+    }>
+  | Readonly<{ mechanism: "engine-serialized" }>
+  | Readonly<{ mechanism: "caller-serialized" }>;
+
+/**
+ * The one member of {@link WriteFenceDeclaration} that carries `drain` —
+ * named so a function that only ever runs inside the `mechanism: "advisory"`
+ * arm of a resolved declaration (the fence-SQL refusal below) can say so in
+ * its own parameter type instead of accepting the full union and re-widening
+ * `drain` into "possibly absent".
+ */
+type AdvisoryWriteFenceDeclaration = Extract<
+  WriteFenceDeclaration,
+  { mechanism: "advisory" }
+>;
 
 /**
  * The decision every lock site consumes, rather than a flag a caller would
@@ -383,7 +404,7 @@ function deriveFromDialect(dialect: SqlDialect): WriteFenceDeclaration {
       return { mechanism: "advisory", drain: "table-lock" };
     }
     case "sqlite": {
-      return { mechanism: "engine-serialized", drain: "table-lock" };
+      return { mechanism: "engine-serialized" };
     }
     default: {
       return dialect satisfies never;
@@ -411,7 +432,7 @@ type WriteFenceDeclarationSource = "writeFence" | "dialect";
  * target did not actually make.
  */
 function describeResolvedAdvisoryDeclaration(
-  declaration: WriteFenceDeclaration,
+  declaration: AdvisoryWriteFenceDeclaration,
   source: WriteFenceDeclarationSource,
   dialect: SqlDialect,
 ): string {
@@ -485,7 +506,7 @@ function fenceSqlMemberPurpose(member: keyof FenceSql): string {
  */
 function refuseWriteFenceSqlUnavailable(
   dialect: SqlDialect,
-  declaration: WriteFenceDeclaration,
+  declaration: AdvisoryWriteFenceDeclaration,
   source: WriteFenceDeclarationSource,
   member: keyof FenceSql,
 ): never {
@@ -537,6 +558,95 @@ export function refuseFenceSqlSessionFactUnavailable(
   );
 }
 
+/** {@link validateWriteFenceDeclaration}'s accepted `mechanism` values. */
+const VALID_WRITE_FENCE_MECHANISMS = [
+  "advisory",
+  "engine-serialized",
+  "caller-serialized",
+] as const;
+
+/** {@link validateWriteFenceDeclaration}'s accepted `drain` values. */
+const VALID_WRITE_FENCE_DRAINS = ["table-lock", "quiescent", "none"] as const;
+
+/**
+ * THE refusal for a `WriteFenceDeclaration` field TypeScript's discriminated
+ * union cannot police at runtime — see {@link validateWriteFenceDeclaration}.
+ *
+ * @throws {ConfigurationError} always.
+ */
+function refuseInvalidWriteFenceDeclaration(
+  field: "mechanism" | "drain",
+  value: unknown,
+  accepted: readonly string[],
+): never {
+  throw new ConfigurationError(
+    `capabilities.writeFence.${field} is invalid: ${JSON.stringify(value)}. ` +
+      `Accepted values are ${accepted.map((accepted) => `"${accepted}"`).join(", ")}.`,
+    { code: "WRITE_FENCE_DECLARATION_INVALID", field, value, accepted },
+    {
+      suggestion: `Declare capabilities.writeFence.${field} as one of the accepted values.`,
+    },
+  );
+}
+
+/**
+ * THE one validator of a raw `WriteFenceDeclaration` value, run before
+ * {@link planFromWriteFenceDeclaration} shapes a plan from it.
+ *
+ * TypeScript's discriminated union only holds a caller who goes through the
+ * type checker — a plain-JavaScript backend author, or a value round-tripped
+ * through JSON/config, can supply any string for `mechanism` or `drain`, or
+ * attach a `drain` to a serialized mechanism that accepts none. Every one of
+ * those is refused HERE, before a plan is shaped, for two reasons a
+ * downstream `default` arm cannot provide on its own: an invalid `drain`
+ * must never fall through to behaving like `"quiescent"` (a table-lock site
+ * would then silently take no lock instead of refusing), and an invalid
+ * `mechanism` must never reach a switch's `default` arm, which — unlike this
+ * validator — has no reason to believe the value it was handed is one of the
+ * cases it already exhausted, and `x satisfies never` is a compile-time
+ * assertion only: at runtime it would return the invalid string as though it
+ * were a resolved plan.
+ */
+function validateWriteFenceDeclaration(
+  declaration: WriteFenceDeclaration,
+): void {
+  const mechanism: string = declaration.mechanism;
+  if (
+    !(VALID_WRITE_FENCE_MECHANISMS as readonly string[]).includes(mechanism)
+  ) {
+    refuseInvalidWriteFenceDeclaration(
+      "mechanism",
+      mechanism,
+      VALID_WRITE_FENCE_MECHANISMS,
+    );
+  }
+  if (mechanism === "advisory") {
+    const drain: string = (declaration as AdvisoryWriteFenceDeclaration).drain;
+    if (!(VALID_WRITE_FENCE_DRAINS as readonly string[]).includes(drain)) {
+      refuseInvalidWriteFenceDeclaration(
+        "drain",
+        drain,
+        VALID_WRITE_FENCE_DRAINS,
+      );
+    }
+    return;
+  }
+  if ("drain" in declaration) {
+    throw new ConfigurationError(
+      "capabilities.writeFence.drain applies only to " +
+        `mechanism: "advisory"; "${mechanism}" must not declare a drain.`,
+      {
+        code: "WRITE_FENCE_DECLARATION_INVALID",
+        field: "drain",
+        mechanism,
+      },
+      {
+        suggestion: `Remove drain from this writeFence declaration — mechanism: "${mechanism}" needs none.`,
+      },
+    );
+  }
+}
+
 /**
  * THE one constructor of a {@link WriteFencePlan} from an already-resolved
  * {@link WriteFenceDeclaration}, regardless of which declaration style
@@ -553,6 +663,7 @@ function planFromWriteFenceDeclaration(
   declaration: WriteFenceDeclaration,
   source: WriteFenceDeclarationSource,
 ): WriteFencePlan {
+  validateWriteFenceDeclaration(declaration);
   switch (declaration.mechanism) {
     case "advisory": {
       if (!fenceSqlMemberPresent(target.fenceSql, "advisoryLockExpression")) {
@@ -600,7 +711,17 @@ function planFromWriteFenceDeclaration(
       return { kind: "caller-serialized" };
     }
     default: {
-      return declaration.mechanism satisfies never;
+      // Unreachable for a TypeScript-typed caller (exhaustive above) and for
+      // any runtime value too: `validateWriteFenceDeclaration` already
+      // refused an unrecognized `mechanism` before this switch ran. Refuses
+      // rather than returning `declaration.mechanism satisfies never` —
+      // which, for an actual invalid string reaching here, would hand that
+      // string back as though it were a resolved `WriteFencePlan`.
+      return refuseInvalidWriteFenceDeclaration(
+        "mechanism",
+        (declaration as WriteFenceDeclaration).mechanism,
+        VALID_WRITE_FENCE_MECHANISMS,
+      );
     }
   }
 }
@@ -649,7 +770,24 @@ export function resolveWriteFencePlan(
 function formatWriteFenceDeclaration(
   declaration: WriteFenceDeclaration,
 ): string {
-  return `writeFence: { mechanism: "${declaration.mechanism}", drain: "${declaration.drain}" }`;
+  switch (declaration.mechanism) {
+    case "advisory": {
+      return `writeFence: { mechanism: "advisory", drain: "${declaration.drain}" }`;
+    }
+    case "engine-serialized": {
+      return 'writeFence: { mechanism: "engine-serialized" }';
+    }
+    case "caller-serialized": {
+      return 'writeFence: { mechanism: "caller-serialized" }';
+    }
+    default: {
+      return refuseInvalidWriteFenceDeclaration(
+        "mechanism",
+        (declaration as WriteFenceDeclaration).mechanism,
+        VALID_WRITE_FENCE_MECHANISMS,
+      );
+    }
+  }
 }
 
 /**

--- a/packages/typegraph/src/backend/capabilities/write-fence.ts
+++ b/packages/typegraph/src/backend/capabilities/write-fence.ts
@@ -10,6 +10,7 @@
 import { ConfigurationError } from "../../errors";
 import { type SqlDialect } from "../../query/dialect/types";
 import { sql, type SqlFragment } from "../../query/sql-fragment";
+import { requireDefined } from "../../utils/presence";
 import { type BackendCapabilities } from "../types";
 
 /**
@@ -523,10 +524,51 @@ function describeResolvedAdvisoryDeclaration(
 }
 
 /**
- * THE refusal for a `lock` decision whose target supplies no spelling to
- * take it with — never defaulted, never silently degraded to
- * `unfenced`: the declaration already promised a real lock exists, so the
- * only honest response to a missing spelling is to say so.
+ * Whether `fenceSql` actually supplies `member` as a callable — the runtime
+ * check behind {@link refuseWriteFenceSqlUnavailable}'s per-member refusal.
+ * `FenceSql`'s type keeps all three members required as a set (a caller
+ * constructing one under TypeScript can never omit one), so this only ever
+ * catches a `fenceSql` built outside that check — a plain JS backend author,
+ * or a test target assembled with a cast — supplying an object that is
+ * missing (or has stubbed `undefined` over) the one member a resolved
+ * mechanism/drain combination actually needs.
+ */
+function fenceSqlMemberPresent(
+  fenceSql: FenceSql | undefined,
+  member: keyof FenceSql,
+): boolean {
+  return typeof fenceSql?.[member] === "function";
+}
+
+/**
+ * What TypeGraph cannot spell without `member` — the phrase
+ * {@link refuseWriteFenceSqlUnavailable} interpolates into its message so a
+ * caller reads which statement is missing, not just that "something" is.
+ */
+function fenceSqlMemberPurpose(member: keyof FenceSql): string {
+  switch (member) {
+    case "advisoryLockExpression": {
+      return "advisory-lock statement this fence needs to take";
+    }
+    case "isolationFactExpression": {
+      return "session isolation-level read this fence needs to take";
+    }
+    case "lockTables": {
+      return 'table-lock statement its drain: "table-lock" declaration needs to take';
+    }
+    default: {
+      return member satisfies never;
+    }
+  }
+}
+
+/**
+ * THE refusal for a `lock` decision whose target supplies no spelling — or
+ * an incomplete one — to take it with: never defaulted, never silently
+ * degraded to `unfenced`. The declaration already promised a real lock
+ * exists, so the only honest response to a missing spelling is to say so,
+ * naming the exact `fenceSql` member the resolved mechanism/drain
+ * combination needed and could not find.
  *
  * The one call site is `planFromWriteFenceDeclaration`, shared by every
  * `resolveWriteFencePlan` arm that can resolve `mechanism: "advisory"` — a
@@ -541,12 +583,18 @@ function refuseWriteFenceSqlUnavailable(
   dialect: SqlDialect,
   declaration: WriteFenceDeclaration,
   source: WriteFenceDeclarationSource,
+  member: keyof FenceSql,
 ): never {
   throw new ConfigurationError(
     `This backend ${describeResolvedAdvisoryDeclaration(declaration, source, dialect)} ` +
-      "but supplies no `fenceSql`, so TypeGraph cannot spell the lock " +
-      "statement this fence needs to take.",
-    { code: "WRITE_FENCE_SQL_UNAVAILABLE", dialect },
+      `but its \`fenceSql\` is missing \`${member}\`, so TypeGraph cannot ` +
+      `spell the ${fenceSqlMemberPurpose(member)}.`,
+    {
+      code: "WRITE_FENCE_SQL_UNAVAILABLE",
+      dialect,
+      member,
+      drain: declaration.drain,
+    },
     {
       suggestion:
         dialect === "postgres" ?
@@ -604,15 +652,44 @@ function planFromWriteFenceDeclaration(
 ): WriteFencePlan {
   switch (declaration.mechanism) {
     case "advisory": {
-      if (target.fenceSql === undefined) {
-        refuseWriteFenceSqlUnavailable(target.dialect, declaration, source);
+      if (!fenceSqlMemberPresent(target.fenceSql, "advisoryLockExpression")) {
+        refuseWriteFenceSqlUnavailable(
+          target.dialect,
+          declaration,
+          source,
+          "advisoryLockExpression",
+        );
+      }
+      if (!fenceSqlMemberPresent(target.fenceSql, "isolationFactExpression")) {
+        refuseWriteFenceSqlUnavailable(
+          target.dialect,
+          declaration,
+          source,
+          "isolationFactExpression",
+        );
+      }
+      if (
+        declaration.drain === "table-lock" &&
+        !fenceSqlMemberPresent(target.fenceSql, "lockTables")
+      ) {
+        refuseWriteFenceSqlUnavailable(
+          target.dialect,
+          declaration,
+          source,
+          "lockTables",
+        );
       }
       return {
         kind: "lock",
         advisoryLocks: true,
         tableLocks: declaration.drain === "table-lock",
         drain: declaration.drain,
-        sql: resolveFenceStatements(target.fenceSql),
+        sql: resolveFenceStatements(
+          requireDefined(
+            target.fenceSql,
+            "resolveWriteFencePlan: fenceSql was validated present above",
+          ),
+        ),
       };
     }
     case "engine-serialized": {

--- a/packages/typegraph/src/backend/capabilities/write-fence.ts
+++ b/packages/typegraph/src/backend/capabilities/write-fence.ts
@@ -1,9 +1,10 @@
 /**
- * The `pessimisticLocks` capability: whether this engine can serialize
- * concurrent writers, and how.
+ * The write-fence capability: how this engine excludes concurrent writers,
+ * declared as `capabilities.writeFence` (preferred) or the deprecated
+ * `capabilities.pessimisticLocks`.
  *
- * `resolveWriteFencePlan` is THE one owner of the pessimistic-lock decision
- * every lock site used to re-derive from `dialect` inline. A lock site never
+ * `resolveWriteFencePlan` is THE one owner of the write-fence decision every
+ * lock site used to re-derive from `dialect` inline. A lock site never
  * spells the dialect itself; it resolves a plan and consumes it.
  */
 import { ConfigurationError } from "../../errors";
@@ -116,8 +117,8 @@ function isolationFactStatement(fenceSql: FenceSql): SqlFragment {
  * `isolationFact` from `fenceSql`'s `advisoryLockExpression` /
  * `isolationFactExpression` — the only way to reach those three forms, so a
  * fused embedding and a portable lock site can never spell the lock or the
- * isolation read differently. Called once, by `planFromLockCapabilities`,
- * when a `lock` plan resolves.
+ * isolation read differently. Called once, by
+ * `planFromWriteFenceDeclaration`, when a `lock` plan resolves.
  */
 export function resolveFenceStatements(fenceSql: FenceSql): FenceStatements {
   return {
@@ -149,7 +150,7 @@ export type PessimisticLockCapabilities = Readonly<{
 
 /**
  * Why {@link resolveWriteFencePlan} could not resolve a usable fence — the
- * three states `planFromLockCapabilities`/`resolveWriteFencePlan` can reach
+ * three states `writeFenceFromLegacyLocks`/`resolveWriteFencePlan` can reach
  * an `unfenced` plan from:
  *
  * - `"undeclared"` — `capabilities.pessimisticLocks` is absent on a target
@@ -160,8 +161,9 @@ export type PessimisticLockCapabilities = Readonly<{
  * - `"table-locks-only"` — `pessimisticLocks` declares `{advisoryLocks:
  *   false, tableLocks: true, serializedWriters: false}`. The plan model has
  *   no table-lock-alone arm (see the note next to `planFromLockCapabilities`
- *   below), so this declaration resolves `unfenced` exactly like an absent
- *   or all-false one, even though it is neither.
+ *   below, which handles the legacy shapes `writeFenceFromLegacyLocks`
+ *   declines to map), so this declaration resolves `unfenced` exactly like
+ *   an absent or all-false one, even though it is neither.
  *
  * Every refusal that reaches an `unfenced` plan states the actual reason
  * instead of a message broad enough to cover all three.
@@ -170,33 +172,111 @@ export type UnfencedReason =
   "undeclared" | "declared-none" | "table-locks-only";
 
 /**
+ * How a backend excludes concurrent writers, and how far a caller that took
+ * the lock can drain the resource it protects.
+ *
+ * `mechanism` is the exclusion primitive: `"advisory"` is a keyed
+ * `pg_advisory_xact_lock`-style lock a caller takes explicitly (and needs
+ * `fenceSql` to spell); `"engine-serialized"` is the engine's own single
+ * writer slot (SQLite); `"caller-serialized"` is a promise the DEPLOYMENT
+ * makes rather than the engine or a lock — the backend's own process
+ * serializes every write unit it issues (see the in-process queue this
+ * mechanism requires) AND no other client writes to the same database while
+ * this backend is open. `"row"` (a per-row lock) joins this union in a later
+ * release.
+ *
+ * `drain` is a separate fact: whether a caller that already excluded other
+ * writers can additionally take a relation-wide lock on the resource a
+ * table-lock site protects. `"table-lock"` means yes (a `LOCK TABLE`-style
+ * statement is available and appropriate); `"quiescent"` means the resource
+ * is already exclusive for another reason (e.g. `caller-serialized`'s
+ * in-process queue) so a table-lock site takes NO statement rather than one
+ * it does not need; `"none"` means neither — a table-lock site refuses,
+ * naming this drain.
+ *
+ * `writeFenceFromLegacyLocks` is the one place a legacy `PessimisticLockCapabilities`
+ * declaration is translated into this shape.
+ */
+export type WriteFenceDeclaration = Readonly<{
+  mechanism: "advisory" | "engine-serialized" | "caller-serialized";
+  drain: "table-lock" | "quiescent" | "none";
+}>;
+
+/**
+ * THE one mapping from the legacy `pessimisticLocks` declaration to a
+ * {@link WriteFenceDeclaration}. Every reader of a legacy declaration goes
+ * through this function rather than re-deriving the mapping inline, so the
+ * two declaration styles can never drift apart on what they mean.
+ *
+ * - `advisoryLocks: true` → `{ mechanism: "advisory", drain: tableLocks ?
+ *   "table-lock" : "none" }` — `tableLocks` decides the drain, exactly as it
+ *   always has.
+ * - `serializedWriters: true` → `{ mechanism: "engine-serialized", drain:
+ *   "table-lock" }` — the writer slot excludes writers outright, and a
+ *   table-lock site under it has always taken no statement (reading that as
+ *   "drains").
+ * - Neither (an all-false declaration, or `{ tableLocks: true }` alone —
+ *   the plan model has no table-lock-only arm) → `undefined`. The caller
+ *   falls back to the existing `unfenced` reasons (`"declared-none"` /
+ *   `"table-locks-only"`); construction still succeeds and only a
+ *   fence-requiring site refuses, exactly as today.
+ */
+export function writeFenceFromLegacyLocks(
+  locks: PessimisticLockCapabilities,
+): WriteFenceDeclaration | undefined {
+  if (locks.advisoryLocks) {
+    return {
+      mechanism: "advisory",
+      drain: locks.tableLocks ? "table-lock" : "none",
+    };
+  }
+  if (locks.serializedWriters) {
+    return { mechanism: "engine-serialized", drain: "table-lock" };
+  }
+  return undefined;
+}
+
+/**
  * The decision every lock site consumes, rather than a flag a caller would
  * have to re-derive.
  */
 export type WriteFencePlan =
   /**
-   * Take the keyed/table lock, spelled by `sql` — the target's OWN declared
+   * Take the keyed lock, spelled by `sql` — the target's OWN declared
    * spelling: a lock site never hand-writes the statement, it resolves
    * a plan and consumes `sql.<builder>(…)`.
+   *
+   * `tableLocks` is kept for source compatibility and is derived from
+   * `drain`(`=== "table-lock"`); read `drain` instead — it distinguishes a
+   * declaration that cannot drain a table-lock site at all (`"none"`) from
+   * one that drains it without a statement (`"quiescent"`).
    */
   | Readonly<{
       kind: "lock";
       advisoryLocks: true;
+      /** @deprecated Read `drain` — this is `drain === "table-lock"`. */
       tableLocks: boolean;
+      drain: "table-lock" | "quiescent" | "none";
       sql: FenceStatements;
     }>
   /** No lock needed: the engine serializes writers. */
   | Readonly<{ kind: "engine-serialized" }>
+  /**
+   * No lock needed: the deployment itself promises no concurrent writer
+   * exists — this backend's own process serializes every write unit it
+   * issues, and no other client writes to the database while it is open.
+   */
+  | Readonly<{ kind: "caller-serialized" }>
   /** Neither. Every non-degradable fence refuses. Carries why — see {@link UnfencedReason}. */
   | Readonly<{ kind: "unfenced"; reason: UnfencedReason }>;
 
 /**
  * What `resolveWriteFencePlan` needs: the dialect (for the first-party
  * dialect-derivation arm and for the refusal message), the declared
- * capabilities, and — when `pessimisticLocks.advisoryLocks` is (or derives)
- * `true` — the lock-statement spelling that decision requires.
- * Structural on purpose — see the module-private first-party mark below,
- * which is carried out-of-band rather than as a type member.
+ * capabilities, and — when the resolved declaration's `mechanism` is (or
+ * derives) `"advisory"` — the lock-statement spelling that decision
+ * requires. Structural on purpose — see the module-private first-party mark
+ * below, which is carried out-of-band rather than as a type member.
  */
 export type WriteFenceTarget = Readonly<{
   dialect: SqlDialect;
@@ -375,24 +455,69 @@ export function isFirstPartyProfile(profile: object): boolean {
   return FIRST_PARTY_PROFILES.has(profile);
 }
 
-function deriveFromDialect(dialect: SqlDialect): PessimisticLockCapabilities {
+/**
+ * The write-fence declaration a first-party (bundled-factory) target derives
+ * when its `capabilities` name neither `writeFence` nor the legacy
+ * `pessimisticLocks` — exactly what every lock site used to compute inline
+ * from `dialect` before this capability existed. `writeFenceDeclarationLine`
+ * formats this same derivation as the migration-guide literal a refusal
+ * prints, so the derivation and the printed suggestion can never disagree.
+ */
+function deriveFromDialect(dialect: SqlDialect): WriteFenceDeclaration {
   switch (dialect) {
     case "postgres": {
-      return {
-        advisoryLocks: true,
-        tableLocks: true,
-        serializedWriters: false,
-      };
+      return { mechanism: "advisory", drain: "table-lock" };
     }
     case "sqlite": {
-      return {
-        advisoryLocks: false,
-        tableLocks: false,
-        serializedWriters: true,
-      };
+      return { mechanism: "engine-serialized", drain: "table-lock" };
     }
     default: {
       return dialect satisfies never;
+    }
+  }
+}
+
+/**
+ * Which declaration style {@link planFromWriteFenceDeclaration} resolved its
+ * `WriteFenceDeclaration` from — carried only so
+ * {@link refuseWriteFenceSqlUnavailable} can name the declaration the target
+ * ACTUALLY made, rather than assuming the legacy shape unconditionally.
+ *
+ * - `"writeFence"` — the target declared `capabilities.writeFence` directly.
+ * - `"pessimisticLocks"` — the target declared the legacy
+ *   `capabilities.pessimisticLocks`, mapped through
+ *   {@link writeFenceFromLegacyLocks}.
+ * - `"dialect"` — neither is declared; a first-party factory target's
+ *   `mechanism` came from {@link deriveFromDialect}.
+ */
+type WriteFenceDeclarationSource =
+  "writeFence" | "pessimisticLocks" | "dialect";
+
+/**
+ * Names the declaration {@link refuseWriteFenceSqlUnavailable} blames for
+ * promising a lock this target cannot spell — the phrase every one of its
+ * three provenances (a direct `writeFence`, a mapped legacy
+ * `pessimisticLocks`, or the first-party dialect derivation) fills in
+ * differently, so the refusal never states a declaration the target did not
+ * actually make.
+ */
+function describeResolvedAdvisoryDeclaration(
+  declaration: WriteFenceDeclaration,
+  source: WriteFenceDeclarationSource,
+  dialect: SqlDialect,
+): string {
+  switch (source) {
+    case "writeFence": {
+      return `declares \`capabilities.${formatWriteFenceDeclaration(declaration)}\``;
+    }
+    case "pessimisticLocks": {
+      return "declares `capabilities.pessimisticLocks.advisoryLocks: true`";
+    }
+    case "dialect": {
+      return `resolves an advisory-lock write fence from its \`${dialect}\` dialect`;
+    }
+    default: {
+      return source satisfies never;
     }
   }
 }
@@ -403,15 +528,23 @@ function deriveFromDialect(dialect: SqlDialect): PessimisticLockCapabilities {
  * `unfenced`: the declaration already promised a real lock exists, so the
  * only honest response to a missing spelling is to say so.
  *
- * Both call sites are in this module: `planFromLockCapabilities`, shared by
- * `resolveWriteFencePlan`'s declared and first-party-dialect-derived arms.
+ * The one call site is `planFromWriteFenceDeclaration`, shared by every
+ * `resolveWriteFencePlan` arm that can resolve `mechanism: "advisory"` — a
+ * declared `writeFence`, a mapped legacy `pessimisticLocks`, and the
+ * first-party dialect derivation all resolve through it, and each passes its
+ * own {@link WriteFenceDeclarationSource} so the message names the
+ * declaration the target actually made.
  *
  * @throws {ConfigurationError} always.
  */
-function refuseWriteFenceSqlUnavailable(dialect: SqlDialect): never {
+function refuseWriteFenceSqlUnavailable(
+  dialect: SqlDialect,
+  declaration: WriteFenceDeclaration,
+  source: WriteFenceDeclarationSource,
+): never {
   throw new ConfigurationError(
-    "This backend declares `capabilities.pessimisticLocks.advisoryLocks: " +
-      "true` but supplies no `fenceSql`, so TypeGraph cannot spell the lock " +
+    `This backend ${describeResolvedAdvisoryDeclaration(declaration, source, dialect)} ` +
+      "but supplies no `fenceSql`, so TypeGraph cannot spell the lock " +
       "statement this fence needs to take.",
     { code: "WRITE_FENCE_SQL_UNAVAILABLE", dialect },
     {
@@ -427,12 +560,12 @@ function refuseWriteFenceSqlUnavailable(dialect: SqlDialect): never {
  * THE refusal for a session-fact read (no lock plan involved) whose target
  * supplies no `fenceSql` to spell it with. Distinct from
  * {@link refuseWriteFenceSqlUnavailable}: that refusal fires only under a
- * resolved `lock` plan, so its message correctly says the backend "declares
- * `capabilities.pessimisticLocks.advisoryLocks: true`" — a claim that is
- * simply false for a target with no lock plan in play at all (e.g. one
- * declaring `serializedWriters: true` and no advisory locks). A session-fact
- * read is gated on `dialect` alone, not on a resolved plan, so it needs its
- * own refusal naming what it actually needs.
+ * resolved `lock` plan, so it can name the declaration that actually
+ * resolved to `mechanism: "advisory"` — a claim that makes no sense for a
+ * target with no lock plan in play at all (e.g. one declaring
+ * `serializedWriters: true` and no advisory locks). A session-fact read is
+ * gated on `dialect` alone, not on a resolved plan, so it needs its own
+ * refusal naming what it actually needs.
  *
  * @throws {ConfigurationError} always.
  */
@@ -452,22 +585,55 @@ export function refuseFenceSqlSessionFactUnavailable(
   );
 }
 
+/**
+ * THE one constructor of a {@link WriteFencePlan} from an already-resolved
+ * {@link WriteFenceDeclaration}, regardless of which declaration style
+ * produced it (`capabilities.writeFence` directly, the legacy
+ * `pessimisticLocks` mapped through {@link writeFenceFromLegacyLocks}, or
+ * the first-party dialect derivation). One owner means a `writeFence`
+ * declaration and its legacy equivalent resolve to the identical plan shape.
+ *
+ * `source` names which of those three provenances `declaration` came from —
+ * threaded only to {@link refuseWriteFenceSqlUnavailable}, so a missing
+ * `fenceSql` is blamed on the declaration the target actually made.
+ */
+function planFromWriteFenceDeclaration(
+  target: WriteFenceTarget,
+  declaration: WriteFenceDeclaration,
+  source: WriteFenceDeclarationSource,
+): WriteFencePlan {
+  switch (declaration.mechanism) {
+    case "advisory": {
+      if (target.fenceSql === undefined) {
+        refuseWriteFenceSqlUnavailable(target.dialect, declaration, source);
+      }
+      return {
+        kind: "lock",
+        advisoryLocks: true,
+        tableLocks: declaration.drain === "table-lock",
+        drain: declaration.drain,
+        sql: resolveFenceStatements(target.fenceSql),
+      };
+    }
+    case "engine-serialized": {
+      return { kind: "engine-serialized" };
+    }
+    case "caller-serialized": {
+      return { kind: "caller-serialized" };
+    }
+    default: {
+      return declaration.mechanism satisfies never;
+    }
+  }
+}
+
 function planFromLockCapabilities(
   target: WriteFenceTarget,
   declared: PessimisticLockCapabilities,
 ): WriteFencePlan {
-  if (declared.advisoryLocks) {
-    if (target.fenceSql === undefined) {
-      refuseWriteFenceSqlUnavailable(target.dialect);
-    }
-    return {
-      kind: "lock",
-      advisoryLocks: true,
-      tableLocks: declared.tableLocks,
-      sql: resolveFenceStatements(target.fenceSql),
-    };
-  }
-  if (declared.serializedWriters) return { kind: "engine-serialized" };
+  const mapped = writeFenceFromLegacyLocks(declared);
+  if (mapped !== undefined)
+    return planFromWriteFenceDeclaration(target, mapped, "pessimisticLocks");
   // A declared table-locks-only engine (no advisoryLocks, no
   // serializedWriters) resolves `unfenced` with reason `"table-locks-only"`:
   // every TypeGraph fence needs either the advisory key or the writer slot,
@@ -489,43 +655,100 @@ function planFromLockCapabilities(
 }
 
 /**
- * THE one reader of `capabilities.pessimisticLocks`, and THE one constructor
- * of a {@link WriteFencePlan}.
+ * THE refusal for a target whose `capabilities` name BOTH a `writeFence`
+ * declaration and the legacy `pessimisticLocks` one: exactly one is the
+ * effective declaration, and picking one silently over the other would let
+ * a caller believe both are honored when only one ever is.
+ *
+ * @throws {ConfigurationError} always.
+ */
+function refuseWriteFenceDeclarationConflict(target: WriteFenceTarget): never {
+  throw new ConfigurationError(
+    "This backend's `capabilities` declare both `writeFence` and the " +
+      "legacy `pessimisticLocks`. Exactly one write-fence declaration is " +
+      "allowed — remove whichever one does not describe this backend.",
+    {
+      code: "WRITE_FENCE_DECLARATION_CONFLICT",
+      dialect: target.dialect,
+      writeFence: target.capabilities.writeFence,
+      pessimisticLocks: target.capabilities.pessimisticLocks,
+    },
+    {
+      suggestion:
+        "Declare `capabilities.writeFence` alone (preferred) or `capabilities.pessimisticLocks` alone (deprecated), not both.",
+    },
+  );
+}
+
+/**
+ * THE one reader of `capabilities.writeFence` and the legacy
+ * `capabilities.pessimisticLocks`, and THE one constructor of a
+ * {@link WriteFencePlan}.
  *
  * Resolution order:
  *
- * 1. **Declared** — use the declaration. Every first-party backend declares
- *    `pessimisticLocks` (`SQLITE_CAPABILITIES` / `POSTGRES_CAPABILITIES`),
- *    and a custom backend takes this path by writing one line.
- * 2. **Absent, first-party factory** — derive from `dialect`
- *    (`postgres` → `{advisoryLocks:true,tableLocks:true,serializedWriters:false}`,
- *    `sqlite` → `{advisoryLocks:false,tableLocks:false,serializedWriters:true}`),
- *    which is exactly what every lock site used to compute inline. Both
- *    bundled factories declare `pessimisticLocks` unconditionally, so nothing
- *    in-tree reaches this arm; it is reachable only from tests that build a
- *    backend object bypassing the factories' declared capabilities while
- *    still carrying the first-party mark.
- * 3. **Absent, anything else** — `unfenced`. Conservative: an undeclared
- *    custom backend is by definition uncertified, and inferring lock support
- *    from `dialect` alone is the unsound inference this capability replaces
- *    (a PostgreSQL-wire backend reporting `dialect: "postgres"` need not
- *    honor `pg_advisory_xact_lock`).
+ * 1. **Both declared** — refuse (`WRITE_FENCE_DECLARATION_CONFLICT`): a
+ *    target cannot mean two things at once.
+ * 2. **`writeFence` declared** — resolve it directly through
+ *    {@link planFromWriteFenceDeclaration}.
+ * 3. **Legacy `pessimisticLocks` declared** — map it through
+ *    {@link writeFenceFromLegacyLocks} and resolve exactly as case 2, or
+ *    fall to `unfenced` with the existing reason when the mapping declines
+ *    (`"table-locks-only"` / `"declared-none"`).
+ * 4. **Neither declared, first-party factory** — derive from `dialect`
+ *    ({@link deriveFromDialect}), which is exactly what every lock site used
+ *    to compute inline. Both bundled factories declare `pessimisticLocks`
+ *    unconditionally, so nothing in-tree reaches this arm; it is reachable
+ *    only from tests that build a backend object bypassing the factories'
+ *    declared capabilities while still carrying the first-party mark.
+ * 5. **Neither declared, anything else** — `unfenced`. Conservative: an
+ *    undeclared custom backend is by definition uncertified, and inferring
+ *    lock support from `dialect` alone is the unsound inference this
+ *    capability replaces (a PostgreSQL-wire backend reporting `dialect:
+ *    "postgres"` need not honor `pg_advisory_xact_lock`).
  */
 export function resolveWriteFencePlan(
   target: WriteFenceTarget,
 ): WriteFencePlan {
-  const declared = target.capabilities.pessimisticLocks;
-  if (declared !== undefined) return planFromLockCapabilities(target, declared);
+  const { writeFence, pessimisticLocks } = target.capabilities;
+  if (writeFence !== undefined && pessimisticLocks !== undefined) {
+    refuseWriteFenceDeclarationConflict(target);
+  }
+  if (writeFence !== undefined) {
+    return planFromWriteFenceDeclaration(target, writeFence, "writeFence");
+  }
+  if (pessimisticLocks !== undefined) {
+    return planFromLockCapabilities(target, pessimisticLocks);
+  }
   if (FIRST_PARTY_FACTORY_BACKENDS.has(target)) {
-    return planFromLockCapabilities(target, deriveFromDialect(target.dialect));
+    return planFromWriteFenceDeclaration(
+      target,
+      deriveFromDialect(target.dialect),
+      "dialect",
+    );
   }
   return { kind: "unfenced", reason: "undeclared" };
 }
 
 /**
- * THE one owner of the literal `pessimisticLocks` declaration line a refusal
- * recommends — printed verbatim by both unfenced refusals below, so the
- * migration guide cannot rot into a pointer (ruling OQ-B).
+ * Formats a {@link WriteFenceDeclaration} exactly as a caller would write it
+ * under `capabilities.writeFence`.
+ */
+function formatWriteFenceDeclaration(
+  declaration: WriteFenceDeclaration,
+): string {
+  return `writeFence: { mechanism: "${declaration.mechanism}", drain: "${declaration.drain}" }`;
+}
+
+/**
+ * THE one owner of the literal legacy `pessimisticLocks` declaration line a
+ * refusal recommends.
+ *
+ * Deprecated in favor of {@link writeFenceDeclarationLine}, which prints this
+ * same line alongside the preferred `writeFence` spelling — prefer that in
+ * new code. Not machine-`@deprecated`: it shipped `@public` at 0.56.0 and
+ * stays a genuine, permanently supported alias for a caller that already
+ * reads it directly, not a migration-window shim.
  */
 export function pessimisticLockDeclarationLine(dialect: SqlDialect): string {
   switch (dialect) {
@@ -542,6 +765,36 @@ export function pessimisticLockDeclarationLine(dialect: SqlDialect): string {
 }
 
 /**
+ * THE one owner of the literal declaration line a refusal recommends —
+ * printed verbatim by both unfenced refusals below and by
+ * `createSqlBackend`'s own construction-time gate, so the migration guide
+ * cannot rot into a pointer (ruling OQ-B). Prints the preferred `writeFence`
+ * spelling first, then the legacy `pessimisticLocks` line
+ * ({@link pessimisticLockDeclarationLine}) a reader may still be carrying.
+ *
+ * `indent` is prefixed to every non-empty line of the (multi-line) result,
+ * so a caller embedding this inside an indented suggestion never has to
+ * indent the continuation lines itself — a caller who only interpolates the
+ * first line's prefix leaves the "or, legacy:" line and the legacy
+ * declaration flush against the margin.
+ */
+export function writeFenceDeclarationLine(
+  dialect: SqlDialect,
+  indent = "",
+): string {
+  const lines = [
+    formatWriteFenceDeclaration(deriveFromDialect(dialect)),
+    "",
+    "or, legacy:",
+    "",
+    pessimisticLockDeclarationLine(dialect),
+  ];
+  return lines
+    .map((line) => (line === "" ? line : `${indent}${line}`))
+    .join("\n");
+}
+
+/**
  * THE one owner of the "why `unfenced`" phrase — consumed by both
  * `unfencedRefusalMessage` (the two construction gates, which also print a
  * dialect-keyed fix) and `requireWriteFence`'s `unfenced` arm below, which
@@ -551,7 +804,10 @@ export function pessimisticLockDeclarationLine(dialect: SqlDialect): string {
 function unfencedDeclarationStateDescription(reason: UnfencedReason): string {
   switch (reason) {
     case "undeclared": {
-      return "`capabilities.pessimisticLocks` is absent";
+      return (
+        "`capabilities.writeFence` (or the deprecated " +
+        "`capabilities.pessimisticLocks`) is absent"
+      );
     }
     case "declared-none": {
       return "`capabilities.pessimisticLocks` declares neither advisory/table locks nor serialized writers";
@@ -580,10 +836,10 @@ function unfencedRefusalMessage(
   reason: UnfencedReason,
   resource: string,
 ): string {
-  const declaredLine = pessimisticLockDeclarationLine(dialect);
+  const declaredLine = writeFenceDeclarationLine(dialect, "  ");
   const otherDialect: SqlDialect =
     dialect === "postgres" ? "sqlite" : "postgres";
-  const otherLine = pessimisticLockDeclarationLine(otherDialect);
+  const otherLine = writeFenceDeclarationLine(otherDialect, "  ");
   const dialectDescription =
     dialect === "postgres" ?
       "an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"
@@ -597,23 +853,23 @@ function unfencedRefusalMessage(
   if (reason === "table-locks-only") {
     return (
       `This backend's ${declarationState}, and ${resource} cannot run ` +
-      "unfenced. Declare `pessimisticLocks.advisoryLocks: true` for an " +
-      "engine that honors advisory locks:\n\n" +
-      `  ${declaredLine}\n\n` +
-      "or `pessimisticLocks.serializedWriters: true` for a single-writer " +
-      "engine:\n\n" +
-      `  ${otherLine}\n`
+      "unfenced. Declare an advisory-lock mechanism:\n\n" +
+      `${declaredLine}\n\n` +
+      "or a single-writer mechanism:\n\n" +
+      `${otherLine}\n`
     );
   }
 
   return (
     `This backend declares no usable write fence: ${declarationState}, ` +
     `so TypeGraph cannot know whether it fences concurrent writers, and ${resource} ` +
-    "cannot run unfenced. Add ONE line to the capabilities you pass:\n\n" +
-    `  ${declaredLine}\n\n` +
-    `(that is the correct declaration for ${dialectDescription}; use\n` +
-    `\`${otherLine}\` for ${otherDescription}). If the engine honors ` +
-    `neither, this refusal is correct and ${resource} is unavailable on it.`
+    "cannot run unfenced. Add ONE write-fence declaration to the " +
+    "capabilities you pass:\n\n" +
+    `${declaredLine}\n\n` +
+    `(that is the correct declaration for ${dialectDescription}; use\n\n` +
+    `${otherLine}\n\n` +
+    `for ${otherDescription}). If the engine honors neither, this refusal ` +
+    `is correct and ${resource} is unavailable on it.`
   );
 }
 
@@ -632,7 +888,7 @@ export function refuseUnfencedOperationalIdentity(
     { code: "IDENTITY_REQUIRES_WRITE_FENCE", dialect, reason },
     {
       suggestion:
-        "Declare `capabilities.pessimisticLocks` on this backend, or construct the store without `identity`.",
+        "Declare `capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) on this backend, or construct the store without `identity`.",
     },
   );
 }
@@ -657,34 +913,39 @@ export function refuseUnfencedClockAllocation(
     { code: "RECORDED_CLOCK_REQUIRES_WRITE_FENCE", dialect, reason },
     {
       suggestion:
-        "Declare `capabilities.pessimisticLocks` on this backend, or construct the store without `history`/`revisionTracking`.",
+        "Declare `capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) on this backend, or construct the store without `history`/`revisionTracking`.",
     },
   );
 }
 
 /**
  * THE refusal for a fence that cannot degrade: `unfenced` always refuses,
- * and a `lock` plan that lacks the table lock an operation requires refuses
- * too — the declared-advisory-only posture, which T15 exercises as its own
- * matrix row.
+ * and a `lock` plan whose `drain` cannot back the table lock an operation
+ * requires refuses too — the declared-advisory-only posture (`drain:
+ * "none"`), which T15 exercises as its own matrix row.
  *
- * `engine-serialized` satisfies both requirements: the writer slot is the
- * fence, whichever shape of lock the caller would otherwise have taken.
+ * `engine-serialized` and `caller-serialized` satisfy both `requires`
+ * values without consulting `drain`: a writer slot and an in-process,
+ * out-of-band serialization promise are each a stronger exclusion than
+ * either lock shape, so there is nothing for either `requires` to add.
  *
  * @throws {ConfigurationError} under `unfenced`, and under
- * `kind: "lock" && tableLocks === false` when `requires === "table-lock"`.
+ * `kind: "lock" && drain === "none"` when `requires === "table-lock"`.
  */
 export function requireWriteFence(
   plan: WriteFencePlan,
   operation: string,
   requires: "advisory-lock" | "table-lock",
-): Extract<WriteFencePlan, { kind: "lock" | "engine-serialized" }> {
+): Extract<
+  WriteFencePlan,
+  { kind: "lock" | "engine-serialized" | "caller-serialized" }
+> {
   switch (plan.kind) {
     case "lock": {
-      if (requires === "table-lock" && !plan.tableLocks) {
+      if (requires === "table-lock" && plan.drain === "none") {
         throw new ConfigurationError(
-          `${operation} requires a table lock, but this backend's ` +
-            "pessimisticLocks declaration reports tableLocks: false.",
+          `${operation} requires a table lock, but this backend's write-fence ` +
+            'declaration reports drain: "none".',
           {
             code: "WRITE_FENCE_UNAVAILABLE",
             operation,
@@ -693,13 +954,16 @@ export function requireWriteFence(
           },
           {
             suggestion:
-              "Declare `pessimisticLocks.tableLocks: true` on this backend, or avoid this operation.",
+              'Declare `writeFence.drain: "table-lock"` (or, in the deprecated legacy shape, `pessimisticLocks.tableLocks: true`) on this backend, or avoid this operation.',
           },
         );
       }
       return plan;
     }
     case "engine-serialized": {
+      return plan;
+    }
+    case "caller-serialized": {
       return plan;
     }
     case "unfenced": {
@@ -715,8 +979,8 @@ export function requireWriteFence(
         {
           suggestion:
             plan.reason === "table-locks-only" ?
-              "Declare `pessimisticLocks.advisoryLocks: true` on this backend for an engine that honors advisory locks, or `pessimisticLocks.serializedWriters: true` for a single-writer engine."
-            : "Declare `capabilities.pessimisticLocks` on this backend, matching the engine's real locking support.",
+              'Declare `writeFence: { mechanism: "advisory", drain: "table-lock" }` (or, in the deprecated legacy shape, `pessimisticLocks.advisoryLocks: true`) on this backend for an engine that honors advisory locks, or `writeFence: { mechanism: "engine-serialized", drain: "table-lock" }` (or `pessimisticLocks.serializedWriters: true`) for a single-writer engine.'
+            : "Declare `capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) on this backend, matching the engine's real locking support.",
         },
       );
     }

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -1714,9 +1714,12 @@ export function createContributionMaterializer(
         );
         return;
       }
-      case "engine-serialized": {
+      case "engine-serialized":
+      case "caller-serialized": {
         // SQLite needs nothing: `BEGIN IMMEDIATE` already holds the
-        // database's single writer slot for the whole fence.
+        // database's single writer slot for the whole fence. Under
+        // `caller-serialized`, the deployment's own promise plays the same
+        // role.
         return;
       }
       default: {
@@ -1770,10 +1773,13 @@ export function createContributionMaterializer(
         );
         return;
       }
-      case "engine-serialized": {
+      case "engine-serialized":
+      case "caller-serialized": {
         // SQLite has no relation lock and needs none: `BEGIN IMMEDIATE` took
         // the database's single writer slot when the fence opened, so probe,
         // drop and refill already run with every other writer excluded.
+        // `caller-serialized` reads the same way through the deployment's
+        // own promise.
         return;
       }
       default: {

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -1766,6 +1766,12 @@ export function createContributionMaterializer(
     );
     switch (fence.kind) {
       case "lock": {
+        if (fence.drain !== "table-lock") {
+          // `drain: "quiescent"`: the declaration already excludes
+          // concurrent writers by some other means, so this site takes no
+          // statement.
+          return;
+        }
         await tx.executeStatement(
           asCompiledStatementSql(
             fence.sql.lockTables([tableName], "access-exclusive"),

--- a/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
+++ b/packages/typegraph/src/backend/drizzle/contribution-materializations.ts
@@ -1704,7 +1704,7 @@ export function createContributionMaterializer(
     tx: SchemaWriteTransactionBackend,
   ): Promise<void> {
     const plan = resolveWriteFencePlan(deps.fenceTarget);
-    const fence = requireWriteFence(plan, "contribution DDL", "advisory-lock");
+    const fence = requireWriteFence(plan, "contribution DDL", "keyed");
     switch (fence.kind) {
       case "lock": {
         await tx.execute(
@@ -1762,7 +1762,7 @@ export function createContributionMaterializer(
     const fence = requireWriteFence(
       plan,
       "shared fulltext table lock",
-      "table-lock",
+      "drain",
     );
     switch (fence.kind) {
       case "lock": {

--- a/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
@@ -12,6 +12,7 @@
  * only what genuinely differs between engines.
  */
 import { ConfigurationError } from "../../../errors";
+import { WRITE_MEMBER_KEYS } from "../../../store/operations/write-members";
 import { requireDefined } from "../../../utils/presence";
 import {
   isFirstPartyProfile,
@@ -20,9 +21,16 @@ import {
   writeFenceDeclarationLine,
   type WriteFenceTarget,
 } from "../../capabilities/write-fence";
+import { deriveBackend, type ExactBackendOverlay } from "../../derive-backend";
+import {
+  createSerializedExecutionQueue,
+  runWithSerializedQueue,
+  type SerializedExecutionQueue,
+} from "../../serialized-execution-queue";
 import { auditBackendResource } from "../../transaction-resource";
 import type {
   AdapterBackend,
+  GraphCommandPort,
   SchemaWriteTransactionBackend,
 } from "../../types";
 import { gateFulltextMethods } from "../contribution-materializations";
@@ -37,6 +45,118 @@ import { createIndexMaterializationMembers } from "./members/index-materializati
 import { createKindRemovalMembers } from "./members/kind-removal-members";
 import { createSchemaVersionMembers } from "./members/schema-version-members";
 import type { EngineAssemblyContext, SqlEngineProfile } from "./profile";
+
+/**
+ * Every root member a `caller-serialized` write-fence declaration must
+ * serialize through the in-process queue this factory builds for it: the
+ * three WRITE classes of `src/backend/member-classes.ts` — graph-entity
+ * writes, their sidecars, and backend-owned bulk ingestion
+ * (`WRITE_MEMBER_KEYS`, the same set the write pipeline bans outside its
+ * seam) — plus the two transaction openers, `transaction` and
+ * `transactionWithNative`. Read from the taxonomy's own exported constant, so
+ * a write member the taxonomy adds later is queued here automatically,
+ * never from a second, hand-kept list this factory would have to remember to
+ * update.
+ */
+const QUEUED_ROOT_MEMBER_KEYS = [
+  ...WRITE_MEMBER_KEYS,
+  "transaction",
+  "transactionWithNative",
+] as const;
+
+/**
+ * Runs `port.execute` through `queue`, keeping `session` untouched. `commands`
+ * is the one {@link QUEUED_ROOT_MEMBER_KEYS} member that is a port object
+ * rather than a bare function, so {@link buildQueuedWriteUnits} special-cases
+ * it here instead of trying to wrap it the same way as every other member.
+ */
+function queueCommandPort(
+  port: GraphCommandPort,
+  queue: SerializedExecutionQueue,
+): GraphCommandPort {
+  return {
+    session: port.session,
+    execute: (command, context) =>
+      runWithSerializedQueue(queue, () => port.execute(command, context)),
+  };
+}
+
+/**
+ * Builds the overlay {@link buildCallerSerializedBackend} decorates `backend`
+ * with: every member {@link QUEUED_ROOT_MEMBER_KEYS} names, routed through
+ * `queue`, plus `close`, which disposes `queue` after delegating to
+ * `backend`'s own.
+ *
+ * Read with `Reflect.get` rather than static property access, so an OPTIONAL
+ * write member this particular backend does not implement is simply absent
+ * from the overlay instead of wrapping `undefined`. `deriveBackend` then
+ * leaves every member this overlay does not name — every read, the
+ * transaction-handle builders, `adoptTransaction` — resolving to `backend`'s
+ * own, unqueued implementation; a transaction's own body reaches `backend`
+ * directly too (`EngineAssemblyContext.self()`, resolved once in
+ * `createSqlBackend` before this function ever runs), which is what lets
+ * `transaction`'s internal delegation to `transactionWithNative` run without
+ * re-entering this same queue.
+ */
+function buildQueuedWriteUnits<TTx>(
+  backend: AdapterBackend<TTx>,
+  queue: SerializedExecutionQueue,
+): ExactBackendOverlay<AdapterBackend<TTx>, Partial<AdapterBackend<TTx>>> {
+  const overlay: Partial<Record<keyof AdapterBackend<TTx>, unknown>> = {};
+  for (const key of QUEUED_ROOT_MEMBER_KEYS) {
+    const member: unknown = Reflect.get(backend, key);
+    if (key === "commands") {
+      overlay[key] = queueCommandPort(member as GraphCommandPort, queue);
+      continue;
+    }
+    if (typeof member !== "function") continue;
+    const original = member as (
+      ...args: readonly unknown[]
+    ) => Promise<unknown>;
+    overlay[key] = (...args: readonly unknown[]) =>
+      runWithSerializedQueue(queue, () => original(...args));
+  }
+  overlay.close = async () => {
+    try {
+      await backend.close();
+    } finally {
+      queue.dispose();
+    }
+  };
+  // `overlay` was built entirely from `QUEUED_ROOT_MEMBER_KEYS` — a subset of
+  // `keyof AdapterBackend<TTx>` derived from the write-member taxonomy plus
+  // the two transaction openers — and every value either re-wraps that exact
+  // member's own function (same signature, same return type) or narrows
+  // `commands` to the identical `GraphCommandPort` shape. The cast states a
+  // fact the loop above already establishes; it is not a widening.
+  return overlay as unknown as ExactBackendOverlay<
+    AdapterBackend<TTx>,
+    Partial<AdapterBackend<TTx>>
+  >;
+}
+
+/**
+ * The in-process half of a `caller-serialized` write-fence promise: one
+ * queue for the whole backend, and a decorated object whose root write units
+ * — {@link QUEUED_ROOT_MEMBER_KEYS} — run through it one at a time. Called
+ * only when `resolveWriteFencePlan` resolved `kind: "caller-serialized"` for
+ * this backend.
+ *
+ * Exported (like `finalizeEngineCapabilities`, `resolveFenceStatements`, and
+ * this module's other internals tests reach directly) so
+ * `tests/caller-serialized-queue.test.ts` can apply the wrapping to a plain
+ * backend by itself and compare the result against the exact pre-wrap
+ * object, isolated from the closures `createSqlBackend` builds fresh on
+ * every call — the proof `insertNode`, `commands`, etc. is the wrapped
+ * function rather than "a function from a different construction" has no
+ * other way to be meaningful.
+ */
+export function buildCallerSerializedBackend<TTx>(
+  backend: AdapterBackend<TTx>,
+): AdapterBackend<TTx> {
+  const queue = createSerializedExecutionQueue();
+  return deriveBackend(backend, buildQueuedWriteUnits(backend, queue));
+}
 
 /**
  * Assembles one `AdapterBackend` from a {@link SqlEngineProfile}.
@@ -294,9 +414,44 @@ export function createSqlBackend<TTx>(
   // "independent" is a verdict the guards can tell apart from a backend
   // nobody looked at.
   auditBackendResource(backend, profile.resourceAudit);
-  applyEngineMarks(backend, {
+
+  // A `caller-serialized` write-fence declaration promises that this
+  // backend's own process serializes every write unit it issues;
+  // `buildCallerSerializedBackend` is the in-process half of that promise.
+  // Built AFTER the audit above (so `deriveBackend`'s own carry, not a
+  // second write, is what gives the decorated object `backend`'s
+  // resource-audit verdict) and BEFORE `applyEngineMarks` below: two of that
+  // call's marks — `markBundledRootAutocommitEligible` and the atomic-program
+  // registrations — key a `WeakSet`/`WeakMap` by the exact object passed to
+  // it and are NOT among the marks `deriveBackend` carries forward on its
+  // own (only the first-party-factory mark, the schema-fenced-insert mark,
+  // and the resource audit are). Applying the marks to whichever object this
+  // function actually returns, instead of always to the pre-queue `backend`
+  // nothing outside this function can still reach, is what keeps every mark
+  // and registration attached to the backend a caller actually holds.
+  const queuedBackend: AdapterBackend<TTx> =
+    fencePlan.kind === "caller-serialized" ?
+      buildCallerSerializedBackend(backend)
+    : backend;
+
+  // Read off `queuedBackend`, not the `capabilities` local above: a root
+  // atomic SQL/mutation program dispatches its whole multi-statement batch
+  // directly against the connection, bypassing every member
+  // `QUEUED_ROOT_MEMBER_KEYS` wraps — registering root atomic authority on
+  // the queued object would let that raw dispatch run outside the very
+  // queue a `caller-serialized` declaration promises every write goes
+  // through. `deriveBackend` already refuses to carry root (or un-preserved
+  // session) atomic-batch authority across ANY decoration — by construction,
+  // never selectively — so `queuedBackend.capabilities.execution.atomicBatch`
+  // already reads the correct, downgraded value for the object this factory
+  // is about to return; the plain pass-through case (`queuedBackend ===
+  // backend`) reads the identical object `capabilities` names, so this
+  // changes nothing for either bundled backend.
+  const queuedCapabilities = queuedBackend.capabilities;
+
+  applyEngineMarks(queuedBackend, {
     isFirstParty,
-    capabilities,
+    capabilities: queuedCapabilities,
     fencePlan,
     autocommit: profile.autocommit,
     execution: profile.execution,
@@ -313,5 +468,5 @@ export function createSqlBackend<TTx>(
     },
   });
 
-  return backend;
+  return queuedBackend;
 }

--- a/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
@@ -164,11 +164,10 @@ export function buildCallerSerializedBackend<TTx>(
  * The write-fence-declaration refusal below is what makes the marking
  * `applyEngineMarks` (`./marks`) performs sound for a profile this factory
  * did not write itself, not only for the two bundled ones: a profile whose
- * resolved capabilities name neither `writeFence` nor the legacy
- * `pessimisticLocks` is refused outright, because every mark and
- * registration `applyEngineMarks` applies assumes a resolvable write-fence
- * decision, and `resolveWriteFencePlan`'s dialect-derivation fallback is
- * sound only for the two bundled dialects.
+ * resolved capabilities name no `writeFence` is refused outright, because
+ * every mark and registration `applyEngineMarks` applies assumes a
+ * resolvable write-fence decision, and `resolveWriteFencePlan`'s
+ * dialect-derivation fallback is sound only for the two bundled dialects.
  * `applyEngineMarks`'s own doc comment covers its two further gates —
  * `markBundledRootAutocommitEligible` on the profile's `autocommit`
  * declaration, `markSchemaFencedInsertEligible` on the resolved fence plan.
@@ -194,16 +193,12 @@ export function createSqlBackend<TTx>(
     },
   );
 
-  if (
-    capabilities.writeFence === undefined &&
-    capabilities.pessimisticLocks === undefined
-  ) {
+  if (capabilities.writeFence === undefined) {
     throw new ConfigurationError(
-      "This engine profile declares no usable write fence: neither " +
-        "capabilities.writeFence nor the legacy capabilities.pessimisticLocks " +
-        "is present, so createSqlBackend cannot resolve a write-fence " +
-        "decision for it and refuses to mark it as fenced. Add ONE " +
-        "declaration to the capabilities the profile declares:\n\n" +
+      "This engine profile declares no usable write fence: " +
+        "capabilities.writeFence is absent, so createSqlBackend cannot " +
+        "resolve a write-fence decision for it and refuses to mark it as " +
+        "fenced. Declare it on the capabilities the profile declares:\n\n" +
         `${writeFenceDeclarationLine(profile.dialect, "  ")}\n\n` +
         "(that is the correct declaration for this profile's dialect).",
       {
@@ -212,7 +207,7 @@ export function createSqlBackend<TTx>(
       },
       {
         suggestion:
-          "Declare capabilities.writeFence (or the deprecated capabilities.pessimisticLocks) on this profile's declaredCapabilities.",
+          "Declare capabilities.writeFence on this profile's declaredCapabilities.",
       },
     );
   }
@@ -227,8 +222,8 @@ export function createSqlBackend<TTx>(
   // ONE fence target for the whole backend and every transaction-scoped one
   // it builds, marked first-party only under the same gate as the backend
   // itself: `capabilities` here is the object this factory just finalized,
-  // so a recognized-first-party caller who blanked `pessimisticLocks` out of
-  // a profile's declaration still resolves the dialect-derived plan, not
+  // so a recognized-first-party caller who blanked `writeFence` out of a
+  // profile's declaration still resolves the dialect-derived plan, not
   // `unfenced`, for the two bundled dialects — while a profile without a
   // recognized token never reaches that fallback.
   const fenceTargetBase: WriteFenceTarget = {

--- a/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
@@ -22,6 +22,7 @@ import {
   type WriteFenceTarget,
 } from "../../capabilities/write-fence";
 import { deriveBackend, type ExactBackendOverlay } from "../../derive-backend";
+import { GRAPH_BACKEND_MEMBER_CLASSES } from "../../member-classes";
 import {
   createSerializedExecutionQueue,
   runWithSerializedQueue,
@@ -32,6 +33,7 @@ import type {
   AdapterBackend,
   GraphCommandPort,
   SchemaWriteTransactionBackend,
+  TransactionBackend,
 } from "../../types";
 import { gateFulltextMethods } from "../contribution-materializations";
 import { resolveEngineAssembly } from "./assembly";
@@ -47,22 +49,183 @@ import { createSchemaVersionMembers } from "./members/schema-version-members";
 import type { EngineAssemblyContext, SqlEngineProfile } from "./profile";
 
 /**
- * Every root member a `caller-serialized` write-fence declaration must
- * serialize through the in-process queue this factory builds for it: the
- * three WRITE classes of `src/backend/member-classes.ts` — graph-entity
- * writes, their sidecars, and backend-owned bulk ingestion
- * (`WRITE_MEMBER_KEYS`, the same set the write pipeline bans outside its
- * seam) — plus the two transaction openers, `transaction` and
- * `transactionWithNative`. Read from the taxonomy's own exported constant, so
- * a write member the taxonomy adds later is queued here automatically,
- * never from a second, hand-kept list this factory would have to remember to
- * update.
+ * `provisioning`-class members excluded from the caller-serialized queue
+ * because they derive text synchronously without ever executing SQL:
+ * `identityTableDdl` / `recordedTableDdl` return a DDL string array/record
+ * built from table names alone, with no `Promise` in their real signature.
+ * Queuing either through {@link buildQueuedWriteUnits}'s generic
+ * "re-wrap as `(...) => runWithSerializedQueue(...)`" path would silently
+ * turn its synchronous return value into a `Promise`, breaking every
+ * caller that reads the result without awaiting — a change in kind, not
+ * degree, for a member that touches no connection at all.
  */
-const QUEUED_ROOT_MEMBER_KEYS = [
-  ...WRITE_MEMBER_KEYS,
-  "transaction",
-  "transactionWithNative",
+const PROVISIONING_DERIVATION_MEMBER_KEYS = [
+  "identityTableDdl",
+  "recordedTableDdl",
 ] as const;
+
+/**
+ * `provisioning`-class member excluded because it is not itself a callable
+ * write: `catalog` is a bag of read-only introspection probes
+ * (`BackendCatalogProbes`), not a function. `buildQueuedWriteUnits` already
+ * skips any non-function member it reads, so an included `catalog` would be
+ * silently dropped regardless — it is named here so the totality ratchet in
+ * `tests/caller-serialized-queue.test.ts` sees a documented exclusion
+ * instead of an accidental one.
+ */
+const PROVISIONING_PROBE_MEMBER_KEYS = ["catalog"] as const;
+
+/**
+ * `rawSql`-class member excluded for the same reason as the two provisioning
+ * derivations above: `compileSql` turns a `SqlFragment` into
+ * `{ sql, params }` synchronously and never touches a connection. The other
+ * four raw-SQL members — `execute`, `executeRaw`, `executeStatement`,
+ * `executeTemporaryStatement` — all dispatch through the execution
+ * adapter's `execRun`/`execGet` against the live connection and CAN carry a
+ * write, so they stay queued even though the member classification does not
+ * call any of the five a "write".
+ */
+const RAW_SQL_DERIVATION_MEMBER_KEYS = ["compileSql"] as const;
+
+/**
+ * The `lifecycle`-class member excluded from the generic per-member wrap:
+ * `"close"` is handled by {@link buildQueuedWriteUnits}'s own disposal
+ * wrapper below (it must run, and dispose the queue, even with queued work
+ * outstanding), never by routing through the queue itself. The class's other
+ * two members flow through unexcluded: `"transaction"` is queued like any
+ * other lifecycle member (it is also, descriptively, one of the two
+ * transaction openers this factory relies on — see
+ * {@link QUEUED_ROOT_MEMBER_KEYS}'s own doc comment), and `"clearGraph"` —
+ * the class's one genuine destructive write — is queued the same way.
+ */
+const LIFECYCLE_EXCLUDED_MEMBER_KEYS = ["close"] as const;
+
+/**
+ * The one `AdapterBackend`-only member that opens a TypeGraph-managed
+ * transaction — not part of `keyof GraphBackend`, so `member-classes.ts`'s
+ * taxonomy does not (and structurally cannot) name it; `transaction`, the
+ * other opener, reaches {@link QUEUED_ROOT_MEMBER_KEYS} through the
+ * `lifecycle` class instead, and a schema-write transaction opener
+ * (`schemaWriteTransaction`) reaches it through the `schema` class.
+ * `adoptTransaction`, the third `AdapterBackend`-only member, is
+ * deliberately ABSENT from every list here: it is refused outright under
+ * `caller-serialized` rather than queued — see
+ * {@link buildQueuedWriteUnits}'s own `adoptTransaction` override.
+ */
+const TRANSACTION_OPENER_MEMBER_KEYS = ["transactionWithNative"] as const;
+
+/**
+ * Every root member a `caller-serialized` write-fence declaration must
+ * serialize through the in-process queue this factory builds for it: every
+ * member `src/backend/member-classes.ts` classifies in a mutation-capable
+ * class — graph-entity writes, their sidecars, backend-owned bulk
+ * ingestion, derived-data maintenance, schema commits (including the
+ * `schema`-class transaction opener, `schemaWriteTransaction`), DDL and
+ * table provisioning, the raw-SQL members that actually execute something,
+ * and the lifecycle class's one destructive write (`clearGraph`) — plus
+ * `transactionWithNative`, the one `AdapterBackend`-only transaction opener.
+ *
+ * Read from the taxonomy's own exported classes (`GRAPH_BACKEND_MEMBER_CLASSES`),
+ * so a write member a class adds later is queued here automatically, never
+ * from a second, hand-kept list this factory would have to remember to
+ * update; only the four documented exceptions above (two pure derivations,
+ * one probe bag, one raw-SQL compiler) are named individually, each with its
+ * own reason, and `tests/caller-serialized-queue.test.ts` pins that this list
+ * plus those four exceptions is exactly `keyof AdapterBackend` (minus
+ * `adoptTransaction`, refused rather than queued or excluded).
+ *
+ * Why per-member queueing (rather than, say, one lock spanning every call) is
+ * enough: every multi-call write workflow either runs entirely inside one
+ * already-queued opener call (`transaction`, `transactionWithNative`,
+ * `schemaWriteTransaction`) or relies on its own CAS/claim protocol whose
+ * claim writes are themselves individually-queued members of this same set —
+ * there is no third shape of multi-statement write this queue would need to
+ * span.
+ */
+export const QUEUED_ROOT_MEMBER_KEYS = [
+  ...WRITE_MEMBER_KEYS,
+  ...GRAPH_BACKEND_MEMBER_CLASSES.maintenance,
+  ...GRAPH_BACKEND_MEMBER_CLASSES.schema,
+  ...GRAPH_BACKEND_MEMBER_CLASSES.provisioning,
+  ...GRAPH_BACKEND_MEMBER_CLASSES.rawSql,
+  ...GRAPH_BACKEND_MEMBER_CLASSES.lifecycle,
+  ...TRANSACTION_OPENER_MEMBER_KEYS,
+].filter(
+  (key) =>
+    !(
+      [
+        ...PROVISIONING_DERIVATION_MEMBER_KEYS,
+        ...PROVISIONING_PROBE_MEMBER_KEYS,
+        ...RAW_SQL_DERIVATION_MEMBER_KEYS,
+        ...LIFECYCLE_EXCLUDED_MEMBER_KEYS,
+      ] as readonly string[]
+    ).includes(key),
+);
+
+/**
+ * Every `keyof AdapterBackend` member intentionally left OUT of
+ * {@link QUEUED_ROOT_MEMBER_KEYS}, each with the one-line reason it stays
+ * unqueued: every `read` and `identity` member (never writes / a static
+ * description property, not an operation), the two provisioning derivations,
+ * the one provisioning probe bag, the one raw-SQL compiler, `close`
+ * (this file's own disposal wrapper), and `adoptTransaction` (refused
+ * outright rather than queued or silently left alone).
+ *
+ * `tests/caller-serialized-queue.test.ts`'s totality ratchet partitions the
+ * FULL taxonomy plus the two `AdapterBackend`-only members into this
+ * record's keys and {@link QUEUED_ROOT_MEMBER_KEYS}, asserting the two sets
+ * are disjoint and their union is everything `keyof AdapterBackend` names —
+ * so a member a future class reclassifies, or a brand-new member nobody
+ * classifies at all, cannot land unqueued silently: it either appears here
+ * with a reason, in `QUEUED_ROOT_MEMBER_KEYS`, or fails the ratchet.
+ */
+export const UNQUEUED_ROOT_MEMBER_REASONS: Readonly<Record<string, string>> = {
+  ...Object.fromEntries(
+    GRAPH_BACKEND_MEMBER_CLASSES.read.map(
+      (key) => [key, "read: never writes"] as const,
+    ),
+  ),
+  ...Object.fromEntries(
+    GRAPH_BACKEND_MEMBER_CLASSES.identity.map(
+      (key) =>
+        [
+          key,
+          "identity: a static description property, not a callable operation",
+        ] as const,
+    ),
+  ),
+  ...Object.fromEntries(
+    PROVISIONING_DERIVATION_MEMBER_KEYS.map(
+      (key) =>
+        [
+          key,
+          "provisioning derivation: returns DDL text synchronously without executing it",
+        ] as const,
+    ),
+  ),
+  ...Object.fromEntries(
+    PROVISIONING_PROBE_MEMBER_KEYS.map(
+      (key) =>
+        [
+          key,
+          "provisioning probe: a bag of read-only introspection functions, not itself callable",
+        ] as const,
+    ),
+  ),
+  ...Object.fromEntries(
+    RAW_SQL_DERIVATION_MEMBER_KEYS.map(
+      (key) =>
+        [
+          key,
+          "rawSql derivation: compiles SQL text synchronously without executing it",
+        ] as const,
+    ),
+  ),
+  close:
+    "lifecycle: handled by this file's own disposal wrapper, which must run (and dispose the queue) even with queued work outstanding",
+  adoptTransaction:
+    "refused outright under caller-serialized (CALLER_SERIALIZED_REFUSES_ADOPTION) rather than queued or left silently unqueued",
+};
 
 /**
  * Runs `port.execute` through `queue`, keeping `session` untouched. `commands`
@@ -82,21 +245,60 @@ function queueCommandPort(
 }
 
 /**
+ * THE refusal `adoptTransaction` becomes on a `caller-serialized` backend:
+ * an externally-owned transaction's lifetime is the CALLER's, not something
+ * this factory's write-unit queue can hold a slot open for — the caller, not
+ * TypeGraph, decides when it commits, so queuing it would either block every
+ * other queued write until that external transaction ends (defeating the
+ * point of adopting one mid-flight) or — if left unqueued, as it always was
+ * before this fence declaration existed — let its writes interleave with the
+ * queue's own, silently breaking the very promise `caller-serialized`
+ * makes. Refusing outright is the only honest option.
+ */
+function refuseCallerSerializedAdoption<TTx>(
+  // The real signature's one parameter, accepted (and ignored) so this
+  // matches `AdapterBackend<TTx>["adoptTransaction"]` exactly rather than a
+  // zero-arity stand-in the cast below would otherwise have to paper over.
+  _externalTransaction: TTx,
+): TransactionBackend {
+  throw new ConfigurationError(
+    "adoptTransaction is unavailable on a caller-serialized backend: an " +
+      "externally owned transaction's lifetime cannot be held by the " +
+      "backend's write-unit queue, so store.withTransaction(externalTx) is " +
+      "refused rather than silently allowed to interleave with queued " +
+      "root writes.",
+    {
+      code: "CALLER_SERIALIZED_REFUSES_ADOPTION",
+      member: "adoptTransaction" satisfies keyof AdapterBackend<TTx>,
+    },
+    {
+      suggestion:
+        "Open the transaction through this backend's own transaction()/" +
+        "transactionWithNative() instead of adopting an externally opened " +
+        "one, or drop the caller-serialized write-fence declaration if " +
+        "cross-store adoption is required.",
+    },
+  );
+}
+
+/**
  * Builds the overlay {@link buildCallerSerializedBackend} decorates `backend`
  * with: every member {@link QUEUED_ROOT_MEMBER_KEYS} names, routed through
- * `queue`, plus `close`, which disposes `queue` after delegating to
- * `backend`'s own.
+ * `queue`; `close`, which disposes `queue` after delegating to `backend`'s
+ * own; and `adoptTransaction`, replaced outright with
+ * {@link refuseCallerSerializedAdoption} rather than queued or left
+ * unqueued.
  *
  * Read with `Reflect.get` rather than static property access, so an OPTIONAL
  * write member this particular backend does not implement is simply absent
  * from the overlay instead of wrapping `undefined`. `deriveBackend` then
- * leaves every member this overlay does not name — every read, the
- * transaction-handle builders, `adoptTransaction` — resolving to `backend`'s
- * own, unqueued implementation; a transaction's own body reaches `backend`
- * directly too (`EngineAssemblyContext.self()`, resolved once in
- * `createSqlBackend` before this function ever runs), which is what lets
- * `transaction`'s internal delegation to `transactionWithNative` run without
- * re-entering this same queue.
+ * leaves every member this overlay does not name — every read, and the
+ * transaction-handle builders — resolving to `backend`'s own, unqueued
+ * implementation; a transaction's own body reaches `backend` directly too
+ * (`EngineAssemblyContext.self()`, resolved once in `createSqlBackend`
+ * before this function ever runs), which is what lets `transaction`'s
+ * internal delegation to `transactionWithNative` run without re-entering
+ * this same queue.
  */
 function buildQueuedWriteUnits<TTx>(
   backend: AdapterBackend<TTx>,
@@ -129,13 +331,24 @@ function buildQueuedWriteUnits<TTx>(
     }
   };
   const overlay: Partial<Record<keyof AdapterBackend<TTx>, unknown>> =
-    Object.fromEntries([...queuedEntries, ["close", close]]);
+    Object.fromEntries([
+      ...queuedEntries,
+      ["close", close],
+      [
+        "adoptTransaction",
+        (externalTransaction: TTx) =>
+          refuseCallerSerializedAdoption<TTx>(externalTransaction),
+      ],
+    ]);
   // `overlay` was built entirely from `QUEUED_ROOT_MEMBER_KEYS` — a subset of
-  // `keyof AdapterBackend<TTx>` derived from the write-member taxonomy plus
-  // the two transaction openers — and every value either re-wraps that exact
-  // member's own function (same signature, same return type) or narrows
-  // `commands` to the identical `GraphCommandPort` shape. The cast states a
-  // fact the loop above already establishes; it is not a widening.
+  // `keyof AdapterBackend<TTx>` derived from the member-classification's
+  // mutation-capable classes plus the transaction openers — and every value
+  // either re-wraps that exact member's own function (same signature, same
+  // return type), narrows `commands` to the identical `GraphCommandPort`
+  // shape, or (for `close`/`adoptTransaction`) implements the exact member
+  // signature `AdapterBackend<TTx>` declares. The cast states a fact the
+  // loop above and the two named entries already establish; it is not a
+  // widening.
   return overlay as unknown as ExactBackendOverlay<
     AdapterBackend<TTx>,
     Partial<AdapterBackend<TTx>>
@@ -161,7 +374,14 @@ function buildQueuedWriteUnits<TTx>(
 export function buildCallerSerializedBackend<TTx>(
   backend: AdapterBackend<TTx>,
 ): AdapterBackend<TTx> {
-  const queue = createSerializedExecutionQueue();
+  const queue = createSerializedExecutionQueue({
+    // "require": a caller-serialized declaration's in-process promise
+    // depends on this queue's reentrancy detection actually working — an
+    // undetected nested root write would deadlock a transaction rather than
+    // refuse loudly, silently breaking the promise instead of degrading it.
+    reentrancy: "require",
+    subject: "caller-serialized",
+  });
   return deriveBackend(backend, buildQueuedWriteUnits(backend, queue));
 }
 

--- a/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
@@ -16,8 +16,8 @@ import { requireDefined } from "../../../utils/presence";
 import {
   isFirstPartyProfile,
   markFirstPartyFactory,
-  pessimisticLockDeclarationLine,
   resolveWriteFencePlan,
+  writeFenceDeclarationLine,
   type WriteFenceTarget,
 } from "../../capabilities/write-fence";
 import { auditBackendResource } from "../../transaction-resource";
@@ -41,13 +41,14 @@ import type { EngineAssemblyContext, SqlEngineProfile } from "./profile";
 /**
  * Assembles one `AdapterBackend` from a {@link SqlEngineProfile}.
  *
- * The pessimistic-locks refusal below is what makes the marking
+ * The write-fence-declaration refusal below is what makes the marking
  * `applyEngineMarks` (`./marks`) performs sound for a profile this factory
  * did not write itself, not only for the two bundled ones: a profile whose
- * resolved capabilities omit `pessimisticLocks` is refused outright, because
- * every mark and registration `applyEngineMarks` applies assumes a
- * resolvable write-fence decision, and `resolveWriteFencePlan`'s
- * dialect-derivation fallback is sound only for the two bundled dialects.
+ * resolved capabilities name neither `writeFence` nor the legacy
+ * `pessimisticLocks` is refused outright, because every mark and
+ * registration `applyEngineMarks` applies assumes a resolvable write-fence
+ * decision, and `resolveWriteFencePlan`'s dialect-derivation fallback is
+ * sound only for the two bundled dialects.
  * `applyEngineMarks`'s own doc comment covers its two further gates —
  * `markBundledRootAutocommitEligible` on the profile's `autocommit`
  * declaration, `markSchemaFencedInsertEligible` on the resolved fence plan.
@@ -73,13 +74,17 @@ export function createSqlBackend<TTx>(
     },
   );
 
-  if (capabilities.pessimisticLocks === undefined) {
+  if (
+    capabilities.writeFence === undefined &&
+    capabilities.pessimisticLocks === undefined
+  ) {
     throw new ConfigurationError(
-      "This engine profile declares no usable write fence: " +
-        "capabilities.pessimisticLocks is absent, so createSqlBackend " +
-        "cannot resolve a write-fence decision for it and refuses to mark " +
-        "it as fenced. Add ONE line to the capabilities the profile " +
-        `declares:\n\n  ${pessimisticLockDeclarationLine(profile.dialect)}\n\n` +
+      "This engine profile declares no usable write fence: neither " +
+        "capabilities.writeFence nor the legacy capabilities.pessimisticLocks " +
+        "is present, so createSqlBackend cannot resolve a write-fence " +
+        "decision for it and refuses to mark it as fenced. Add ONE " +
+        "declaration to the capabilities the profile declares:\n\n" +
+        `${writeFenceDeclarationLine(profile.dialect, "  ")}\n\n` +
         "(that is the correct declaration for this profile's dialect).",
       {
         code: "ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION",
@@ -87,7 +92,7 @@ export function createSqlBackend<TTx>(
       },
       {
         suggestion:
-          "Declare capabilities.pessimisticLocks on this profile's declaredCapabilities.",
+          "Declare capabilities.writeFence (or the deprecated capabilities.pessimisticLocks) on this profile's declaredCapabilities.",
       },
     );
   }

--- a/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/create-sql-backend.ts
@@ -102,27 +102,34 @@ function buildQueuedWriteUnits<TTx>(
   backend: AdapterBackend<TTx>,
   queue: SerializedExecutionQueue,
 ): ExactBackendOverlay<AdapterBackend<TTx>, Partial<AdapterBackend<TTx>>> {
-  const overlay: Partial<Record<keyof AdapterBackend<TTx>, unknown>> = {};
-  for (const key of QUEUED_ROOT_MEMBER_KEYS) {
-    const member: unknown = Reflect.get(backend, key);
-    if (key === "commands") {
-      overlay[key] = queueCommandPort(member as GraphCommandPort, queue);
-      continue;
-    }
-    if (typeof member !== "function") continue;
-    const original = member as (
-      ...args: readonly unknown[]
-    ) => Promise<unknown>;
-    overlay[key] = (...args: readonly unknown[]) =>
-      runWithSerializedQueue(queue, () => original(...args));
-  }
-  overlay.close = async () => {
+  const queuedEntries = QUEUED_ROOT_MEMBER_KEYS.flatMap(
+    (key): readonly (readonly [keyof AdapterBackend<TTx>, unknown])[] => {
+      const member: unknown = Reflect.get(backend, key);
+      if (key === "commands") {
+        return [[key, queueCommandPort(member as GraphCommandPort, queue)]];
+      }
+      if (typeof member !== "function") return [];
+      const original = member as (
+        ...args: readonly unknown[]
+      ) => Promise<unknown>;
+      return [
+        [
+          key,
+          (...args: readonly unknown[]) =>
+            runWithSerializedQueue(queue, () => original(...args)),
+        ],
+      ];
+    },
+  );
+  const close = async (): Promise<void> => {
     try {
       await backend.close();
     } finally {
       queue.dispose();
     }
   };
+  const overlay: Partial<Record<keyof AdapterBackend<TTx>, unknown>> =
+    Object.fromEntries([...queuedEntries, ["close", close]]);
   // `overlay` was built entirely from `QUEUED_ROOT_MEMBER_KEYS` — a subset of
   // `keyof AdapterBackend<TTx>` derived from the write-member taxonomy plus
   // the two transaction openers — and every value either re-wraps that exact

--- a/packages/typegraph/src/backend/drizzle/engine/derive-profile.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/derive-profile.ts
@@ -22,7 +22,7 @@
  * enforcing the base builder's value. `assertAdapterBackedCapabilitiesUnchanged`
  * below refuses exactly those three sub-values when they would change;
  * every other sub-field on `declaredCapabilities` and `resourceAudit`
- * (`pessimisticLocks`, `windowFunctions`, `clearValidTo`, `returning`,
+ * (`writeFence`, `windowFunctions`, `clearValidTo`, `returning`,
  * `claims`, `graphAnalytics`, `resourceAudit`'s `resource` /
  * `identityLeaseResource`, …) stays freely derivable, because none of those
  * reach the adapter's construction. Every other field — `dialect`,
@@ -55,13 +55,13 @@
  * dialect-derivation fallback (sound only for the two bundled dialects, so it
  * never applies to a derived profile regardless — irrelevant in practice as
  * long as `declaredCapabilities` is kept, since both bundled declarations
- * already carry `pessimisticLocks` explicitly), and the lazy per-transaction
+ * already carry `writeFence` explicitly), and the lazy per-transaction
  * schema-fence lease `store/operations/write-transaction.ts` takes out under
  * `isFirstPartyFactory` (a derived profile's backend takes its own fence on
  * every managed write instead). Every gate `createSqlBackend` runs — the
- * `pessimisticLocks` refusal, the `advisoryLocks: true` without `fenceSql`
- * refusal, the schema-fenced-insert and autocommit marks — still applies to
- * a derived profile exactly as it does to a bundled one.
+ * missing-`writeFence` refusal, the `mechanism: "advisory"` without
+ * `fenceSql` refusal, the schema-fenced-insert and autocommit marks — still
+ * applies to a derived profile exactly as it does to a bundled one.
  */
 import { ConfigurationError } from "../../../errors";
 import type { FenceSql } from "../../capabilities/write-fence";
@@ -111,13 +111,12 @@ const DERIVABLE_ENGINE_PROFILE_KEY_SET: ReadonlySet<string> = new Set(
  *
  * Dropping `fenceSql` alone is not enough to reach a working profile:
  * `createSqlBackend` still resolves a write-fence plan eagerly, and a
- * profile whose `declaredCapabilities.pessimisticLocks.advisoryLocks` is
- * still `true` with no `fenceSql` to spell the lock refuses with
+ * profile whose `declaredCapabilities.writeFence.mechanism` is still
+ * `"advisory"` with no `fenceSql` to spell the lock refuses with
  * `WRITE_FENCE_SQL_UNAVAILABLE`. Pairing `fenceSql: undefined` with a
- * `declaredCapabilities` override that also stops claiming `advisoryLocks`
- * (for example `serializedWriters: true`, resolving `engine-serialized`) is
- * what actually removes the spelling successfully; see
- * `tests/engine-profile-derivation.test.ts`.
+ * `declaredCapabilities` override that also stops claiming `"advisory"`
+ * (for example `mechanism: "engine-serialized"`) is what actually removes
+ * the spelling successfully; see `tests/engine-profile-derivation.test.ts`.
  */
 export type DerivableEngineProfileOverrides<TTx> = Partial<
   Omit<Pick<SqlEngineProfile<TTx>, DerivableEngineProfileKey>, "fenceSql">

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -927,22 +927,10 @@ export function buildPostgresEngineProfile(
         ),
       }
     : {};
-  const requestedPessimisticLocks = options.capabilities?.pessimisticLocks;
-  if (requestedPessimisticLocks?.serializedWriters === true) {
-    throw new ConfigurationError(
-      "PostgreSQL backend capability overrides cannot claim serialized writers.",
-      { requestedPessimisticLocks },
-      {
-        suggestion:
-          "Keep serializedWriters: false. A PostgreSQL pool requires its advisory-lock fence; use a custom backend only when the underlying engine really provides a single writer slot.",
-      },
-    );
-  }
-  // The preferred-declaration twin of the refusal above: a PostgreSQL pool is
-  // never itself an engine with a single writer slot, so `mechanism:
-  // "engine-serialized"` is exactly as false a claim as `serializedWriters:
-  // true`, whichever spelling a caller reaches for. `"caller-serialized"` is
-  // a different claim — a promise about the DEPLOYMENT, not the engine — and
+  // A PostgreSQL pool is never itself an engine with a single writer slot,
+  // so `mechanism: "engine-serialized"` is a false claim about this engine —
+  // the one shape this factory refuses. `"caller-serialized"` is a
+  // different claim — a promise about the DEPLOYMENT, not the engine — and
   // is accepted: this pool still carries its own `fenceSql` underneath it
   // (harmless, since every keyed and drain site under `caller-serialized`
   // already takes no statement), so nothing about this factory's assembly
@@ -958,28 +946,9 @@ export function buildPostgresEngineProfile(
       },
     );
   }
-  // A caller who declares `capabilities.writeFence` is replacing the
-  // legacy declaration, not layering under it: injecting the bundled
-  // `pessimisticLocks` default beneath their `writeFence` would collide the
-  // two declarations at `resolveWriteFencePlan` and blame the caller for a
-  // default THIS factory added. Only fall back to the bundled default when
-  // the caller has declared neither shape — and, since `baseCapabilities`
-  // (`POSTGRES_CAPABILITIES`) itself already carries that default, this has
-  // to be dropped from the spread below, not merely skipped as an override.
-  const declaresWriteFence = options.capabilities?.writeFence !== undefined;
-  const { pessimisticLocks: basePessimisticLocks, ...baseCapabilitiesRest } =
-    baseCapabilities;
-  const pessimisticLocks =
-    requestedPessimisticLocks === undefined ?
-      (declaresWriteFence ? undefined : basePessimisticLocks)
-    : {
-        advisoryLocks: requestedPessimisticLocks.advisoryLocks,
-        tableLocks: requestedPessimisticLocks.tableLocks,
-        serializedWriters: false,
-      };
   const declaredCapabilities = sealCapabilityDeclaration(
     normalizeGraphAnalyticsCapabilities({
-      ...baseCapabilitiesRest,
+      ...baseCapabilities,
       ...httpOnlyOverrides,
       ...options.capabilities,
       execution: {
@@ -988,7 +957,6 @@ export function buildPostgresEngineProfile(
         ...options.capabilities?.execution,
       },
       ...driverBindParameterOverrides,
-      ...(pessimisticLocks === undefined ? {} : { pessimisticLocks }),
     }),
   );
   // Derived last and not overridable: how far up the contribution health
@@ -1579,7 +1547,7 @@ export function buildPostgresEngineProfile(
      * own: it is never taken without the advisory lock above it, so no shipped
      * or plausible engine distinguishes them. An engine that implements
      * `pg_advisory_xact_lock` but not `FOR UPDATE` is where a `rowLocks`
-     * member of `PessimisticLockCapabilities` would earn its place.
+     * member of `WriteFenceDeclaration` would earn its place.
      */
     async function acquireSchemaWriteFence(
       tx: AnyPgTransaction,
@@ -1588,7 +1556,7 @@ export function buildPostgresEngineProfile(
       const plan = requireWriteFence(
         resolveWriteFencePlan(fenceTarget),
         "The PostgreSQL schema-commit fence",
-        "advisory-lock",
+        "keyed",
       );
       switch (plan.kind) {
         case "lock": {
@@ -2954,7 +2922,7 @@ function createPostgresOperationBackend(
     const plan = requireWriteFence(
       resolveWriteFencePlan(fenceTarget),
       "The PostgreSQL schema write fence",
-      "advisory-lock",
+      "keyed",
     );
     const shareLock = plan.kind === "lock" ? sql`FOR SHARE` : sql``;
     const active = await execGet<{ version: number }>(sql`

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -938,6 +938,26 @@ export function buildPostgresEngineProfile(
       },
     );
   }
+  // The preferred-declaration twin of the refusal above: a PostgreSQL pool is
+  // never itself an engine with a single writer slot, so `mechanism:
+  // "engine-serialized"` is exactly as false a claim as `serializedWriters:
+  // true`, whichever spelling a caller reaches for. `"caller-serialized"` is
+  // a different claim — a promise about the DEPLOYMENT, not the engine — and
+  // is accepted: this pool still carries its own `fenceSql` underneath it
+  // (harmless, since every keyed and drain site under `caller-serialized`
+  // already takes no statement), so nothing about this factory's assembly
+  // needs to change to honor it.
+  const requestedWriteFence = options.capabilities?.writeFence;
+  if (requestedWriteFence?.mechanism === "engine-serialized") {
+    throw new ConfigurationError(
+      'PostgreSQL backend capability overrides cannot declare writeFence.mechanism: "engine-serialized".',
+      { requestedWriteFence },
+      {
+        suggestion:
+          'Declare writeFence.mechanism as "advisory" (this pool\'s own fence) or "caller-serialized" (a deployment-level promise); use a custom backend only when the underlying engine really provides a single writer slot.',
+      },
+    );
+  }
   // A caller who declares `capabilities.writeFence` is replacing the
   // legacy declaration, not layering under it: injecting the bundled
   // `pessimisticLocks` default beneath their `writeFence` would collide the
@@ -2637,11 +2657,22 @@ function createPostgresOperationBackend(
    * no schema-fenced insert program at all", which sends the Store down the
    * unfused fallback path. The fused program is still correct here; it is
    * the lock inside it that is not available.
+   *
+   * The resolved plan is also what gates whether `fenceTarget.fenceSql` is
+   * threaded into `fusion` below (which is what lets the fused
+   * `lockSchemaVersionAndGraphWrite` command build at all): this factory
+   * keeps carrying `fenceSql` regardless of what the declared write fence
+   * resolves to, so gating fusion on `fenceSql`'s mere presence rather than
+   * on this SAME plan would let a resolved `caller-serialized`/`unfenced`
+   * backend still take the advisory lock the declaration says it does not
+   * need — the one decision this module makes, read twice, must read the
+   * same answer both times.
    */
-  const schemaFenceInsertLockClause = ((): SQL => {
-    const plan = resolveWriteFencePlan(fenceTarget);
-    return plan.kind === "lock" ? sql.raw("FOR SHARE") : sql.raw("");
-  })();
+  const schemaFenceFusionPlan = resolveWriteFencePlan(fenceTarget);
+  const schemaFenceInsertLockClause: SQL =
+    schemaFenceFusionPlan.kind === "lock" ?
+      sql.raw("FOR SHARE")
+    : sql.raw("");
 
   const commonOperationMembers = createCommonOperationBackend(
     buildCommonOperationOptions({
@@ -2670,9 +2701,10 @@ function createPostgresOperationBackend(
         atomicProgramsAtTransactionScope: true,
         nodeProjectionInsertFusion: true,
         dynamicEdgeConvergence: true,
-        ...(fenceTarget.fenceSql === undefined ?
-          {}
-        : { fenceSql: fenceTarget.fenceSql }),
+        ...(schemaFenceFusionPlan.kind === "lock" &&
+        fenceTarget.fenceSql !== undefined ?
+          { fenceSql: fenceTarget.fenceSql }
+        : {}),
         async beforeNodeProjectionInsert(params, plan): Promise<void> {
           const vectorSlots = vectorSlotsFromManagedNodeCreatePlan(
             params,

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -938,9 +938,20 @@ export function buildPostgresEngineProfile(
       },
     );
   }
+  // A caller who declares `capabilities.writeFence` is replacing the
+  // legacy declaration, not layering under it: injecting the bundled
+  // `pessimisticLocks` default beneath their `writeFence` would collide the
+  // two declarations at `resolveWriteFencePlan` and blame the caller for a
+  // default THIS factory added. Only fall back to the bundled default when
+  // the caller has declared neither shape — and, since `baseCapabilities`
+  // (`POSTGRES_CAPABILITIES`) itself already carries that default, this has
+  // to be dropped from the spread below, not merely skipped as an override.
+  const declaresWriteFence = options.capabilities?.writeFence !== undefined;
+  const { pessimisticLocks: basePessimisticLocks, ...baseCapabilitiesRest } =
+    baseCapabilities;
   const pessimisticLocks =
     requestedPessimisticLocks === undefined ?
-      POSTGRES_CAPABILITIES.pessimisticLocks
+      (declaresWriteFence ? undefined : basePessimisticLocks)
     : {
         advisoryLocks: requestedPessimisticLocks.advisoryLocks,
         tableLocks: requestedPessimisticLocks.tableLocks,
@@ -948,7 +959,7 @@ export function buildPostgresEngineProfile(
       };
   const declaredCapabilities = sealCapabilityDeclaration(
     normalizeGraphAnalyticsCapabilities({
-      ...baseCapabilities,
+      ...baseCapabilitiesRest,
       ...httpOnlyOverrides,
       ...options.capabilities,
       execution: {
@@ -957,7 +968,7 @@ export function buildPostgresEngineProfile(
         ...options.capabilities?.execution,
       },
       ...driverBindParameterOverrides,
-      pessimisticLocks,
+      ...(pessimisticLocks === undefined ? {} : { pessimisticLocks }),
     }),
   );
   // Derived last and not overridable: how far up the contribution health
@@ -1599,10 +1610,13 @@ export function buildPostgresEngineProfile(
         `);
           return;
         }
-        case "engine-serialized": {
+        case "engine-serialized":
+        case "caller-serialized": {
           // The writer slot IS the fence; the commit already runs alone, which
           // is the guarantee `commitSchemaVersion`'s own comment names
-          // ("BEGIN IMMEDIATE on SQLite"). Nothing to take.
+          // ("BEGIN IMMEDIATE on SQLite"). Under `caller-serialized`, the
+          // deployment's own serialization promise plays the same role.
+          // Nothing to take.
           return;
         }
         default: {

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1296,9 +1296,26 @@ export function buildSqliteEngineProfile(
     transactionMode,
     maxBindParameters: executionAdapter.profile.maxBindParameters,
   });
+  // A caller who declares `capabilities.writeFence` (and no explicit
+  // `pessimisticLocks` of their own) is replacing the bundled
+  // `pessimisticLocks` default, not layering under it: carrying
+  // `baseCapabilities.pessimisticLocks` through the spread below would
+  // collide the two declarations at `resolveWriteFencePlan` and blame the
+  // caller for a default THIS factory added. Pulled out rather than left in
+  // `...baseCapabilities` so this decision runs explicitly instead of riding
+  // along on a spread the caller's own `pessimisticLocks` override (if any)
+  // still wins over via `...capabilityOverrides` below.
+  const { pessimisticLocks: basePessimisticLocks, ...baseCapabilitiesRest } =
+    baseCapabilities;
+  const declaresWriteFenceWithoutLegacyLocks =
+    capabilityOverrides.writeFence !== undefined &&
+    capabilityOverrides.pessimisticLocks === undefined;
   const declaredCapabilities = sealCapabilityDeclaration(
     normalizeGraphAnalyticsCapabilities({
-      ...baseCapabilities,
+      ...baseCapabilitiesRest,
+      ...(declaresWriteFenceWithoutLegacyLocks ?
+        {}
+      : { pessimisticLocks: basePessimisticLocks }),
       ...capabilityOverrides,
       execution: {
         ...baseCapabilities.execution,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1168,26 +1168,9 @@ export function buildSqliteEngineProfile(
     transactionMode,
     maxBindParameters: executionAdapter.profile.maxBindParameters,
   });
-  // A caller who declares `capabilities.writeFence` (and no explicit
-  // `pessimisticLocks` of their own) is replacing the bundled
-  // `pessimisticLocks` default, not layering under it: carrying
-  // `baseCapabilities.pessimisticLocks` through the spread below would
-  // collide the two declarations at `resolveWriteFencePlan` and blame the
-  // caller for a default THIS factory added. Pulled out rather than left in
-  // `...baseCapabilities` so this decision runs explicitly instead of riding
-  // along on a spread the caller's own `pessimisticLocks` override (if any)
-  // still wins over via `...capabilityOverrides` below.
-  const { pessimisticLocks: basePessimisticLocks, ...baseCapabilitiesRest } =
-    baseCapabilities;
-  const declaresWriteFenceWithoutLegacyLocks =
-    capabilityOverrides.writeFence !== undefined &&
-    capabilityOverrides.pessimisticLocks === undefined;
   const declaredCapabilities = sealCapabilityDeclaration(
     normalizeGraphAnalyticsCapabilities({
-      ...baseCapabilitiesRest,
-      ...(declaresWriteFenceWithoutLegacyLocks ?
-        {}
-      : { pessimisticLocks: basePessimisticLocks }),
+      ...baseCapabilities,
       ...capabilityOverrides,
       execution: {
         ...baseCapabilities.execution,

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -1249,7 +1249,16 @@ export function buildSqliteEngineProfile(
   // neon-http) have no transactions and manage their own concurrency, so they
   // stay unqueued.
   const serializedQueue =
-    transactionMode === "none" ? undefined : createSerializedExecutionQueue();
+    transactionMode === "none" ?
+      undefined
+    : createSerializedExecutionQueue({
+        // Best-effort: undetected reentrancy here degrades to the deadlock
+        // this queue has always risked when AsyncLocalStorage is
+        // unavailable, not a broken correctness promise — SQLite's own
+        // engine-serialized fence never depended on this detection.
+        reentrancy: "detect",
+        subject: "sqlite",
+      });
 
   // Durable fulltext + vector materialization (#135): the dialect-specific
   // marker-table primitives. Orchestration (materialize / assert /

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -50,11 +50,7 @@ import {
 } from "drizzle-orm";
 import { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core";
 
-import {
-  BackendDisposedError,
-  CompilerInvariantError,
-  ConfigurationError,
-} from "../../errors";
+import { CompilerInvariantError, ConfigurationError } from "../../errors";
 import { sqlValueList } from "../../query/compiler/predicate-utils";
 import type { ResolvedSqlTableNames } from "../../query/compiler/schema";
 import {
@@ -91,6 +87,11 @@ import {
 } from "../capabilities/write-fence";
 import { FIND_EDGES_ENDPOINT_FIXED_PARAM_COUNT } from "../edge-endpoint-sets";
 import { buildLiveNodeCandidates } from "../live-node-candidates";
+import {
+  createSerializedExecutionQueue,
+  runWithSerializedQueue,
+  type SerializedExecutionQueue,
+} from "../serialized-execution-queue";
 import {
   type AdapterBackend,
   type BackendCapabilities,
@@ -415,11 +416,6 @@ export function computeSqliteBatchChunkSizes(
   };
 }
 
-type SerializedExecutionQueue = Readonly<{
-  dispose: () => void;
-  runExclusive: <T>(task: () => Promise<T>) => Promise<T>;
-}>;
-
 // ============================================================
 // Utilities
 // ============================================================
@@ -430,130 +426,6 @@ const toUniqueRow = createUniqueRowMapper(SQLITE_ROW_MAPPER_CONFIG);
 const toSchemaVersionRow = createSchemaVersionRowMapper(
   SQLITE_ROW_MAPPER_CONFIG,
 );
-
-/** A shared promise that never settles — used to absorb post-dispose work. */
-const PENDING_FOREVER: Promise<never> = new Promise<never>(noop);
-
-function pendingForever<T>(): Promise<T> {
-  return PENDING_FOREVER;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-function
-function noop(): void {}
-
-/**
- * Tracks which serialized queue (if any) the current async execution is
- * running a task for, so a re-entrant submission — a root-backend operation
- * awaited from inside a transaction already occupying the same queue — can be
- * rejected with a typed error instead of deadlocking (the enclosing task holds
- * the queue slot until it completes, so the inner operation can never run).
- *
- * AsyncLocalStorage is loaded lazily and optionally: it is available on Node
- * and on Cloudflare workers with the `nodejs_als` compatibility flag, and a
- * runtime without it simply skips the detection (the queue behaves as before).
- */
-type QueueTaskContext = Readonly<{
-  getStore: () => unknown;
-  run: <T>(store: object, callback: () => T) => T;
-}>;
-
-let queueTaskContext: QueueTaskContext | undefined;
-
-async function loadQueueTaskContext(): Promise<void> {
-  try {
-    const asyncHooks = await import("node:async_hooks");
-    queueTaskContext = new asyncHooks.AsyncLocalStorage<object>();
-  } catch {
-    // AsyncLocalStorage unavailable on this runtime: re-entrant submissions
-    // stay undetected, matching the queue's previous behavior.
-  }
-}
-
-// eslint-disable-next-line unicorn/prefer-top-level-await -- the dual CJS/ESM build cannot use top-level await
-void loadQueueTaskContext();
-
-function rejectReentrantQueueSubmission(): Promise<never> {
-  return Promise.reject(
-    new ConfigurationError(
-      "This operation was awaited from inside a transaction running on the " +
-        "same SQLite backend and would deadlock: the transaction holds the " +
-        "backend's serialized execution slot until it completes, so the " +
-        "operation could never run.",
-      { backend: "sqlite", capability: "concurrentRootAccess" },
-      {
-        suggestion:
-          "Inside a store.transaction callback, use the transaction-scoped " +
-          "context (tx.nodes / tx.edges / tx.backend) instead of the root " +
-          "store or backend, or move the operation outside the transaction.",
-      },
-    ),
-  );
-}
-
-function createSerializedExecutionQueue(): SerializedExecutionQueue {
-  let tail: Promise<unknown> = Promise.resolve();
-  let disposed = false;
-  // Unique per queue: a task running on THIS queue must not submit back to it,
-  // but may freely submit to a different backend's queue.
-  const taskMarker: object = {};
-
-  function isDisposed(): boolean {
-    return disposed;
-  }
-
-  return {
-    dispose() {
-      disposed = true;
-    },
-
-    runExclusive<T>(task: () => Promise<T>): Promise<T> {
-      if (isDisposed()) return Promise.reject(new BackendDisposedError());
-      if (queueTaskContext?.getStore() === taskMarker) {
-        return rejectReentrantQueueSubmission();
-      }
-
-      // When disposed, runTask returns a never-settling promise so that no
-      // rejection propagates through the 7+ async wrappers between this
-      // queue and the store-level caller. A rejection here would become an
-      // unhandled rejection if the caller abandoned the promise during
-      // teardown — and JavaScript offers no way to `.catch()` a rejection
-      // at the bottom of a chain without every async wrapper above it also
-      // creating an independently-unhandled rejected promise.
-      //
-      // The tradeoff: an active caller whose operation was queued before
-      // dispose() will see a permanently-pending promise rather than a
-      // BackendDisposedError. Post-dispose submissions (the check above)
-      // still reject immediately since the caller actively holds that
-      // promise.
-      const runTask = async (): Promise<T> => {
-        if (isDisposed()) return pendingForever<T>();
-        try {
-          const context = queueTaskContext;
-          return context === undefined ?
-              await task()
-            : await context.run(taskMarker, () => task());
-        } catch (error) {
-          if (isDisposed()) return pendingForever<T>();
-          throw error;
-        }
-      };
-      const result = tail.then(runTask, runTask);
-      tail = result.then(
-        () => 0,
-        () => 0,
-      );
-      return result;
-    },
-  };
-}
-
-function runWithSerializedQueue<T>(
-  queue: SerializedExecutionQueue | undefined,
-  task: () => Promise<T>,
-): Promise<T> {
-  if (queue === undefined) return task();
-  return queue.runExclusive(task);
-}
 
 /** Every SQLite "atomic transactions unavailable" refusal shares this shape. */
 function throwSqliteTransactionsDisabled(message: string): never {

--- a/packages/typegraph/src/backend/drizzle/trusted-import.ts
+++ b/packages/typegraph/src/backend/drizzle/trusted-import.ts
@@ -114,6 +114,11 @@ export async function lockPostgresTrustedImportTables(
   const fence = requireWriteFence(plan, "trusted import", "table-lock");
   switch (fence.kind) {
     case "lock": {
+      if (fence.drain !== "table-lock") {
+        // `drain: "quiescent"`: the declaration already excludes concurrent
+        // writers by some other means, so this site takes no statement.
+        return;
+      }
       await executeStatement(
         asCompiledStatementSql(
           fence.sql.lockTables(

--- a/packages/typegraph/src/backend/drizzle/trusted-import.ts
+++ b/packages/typegraph/src/backend/drizzle/trusted-import.ts
@@ -98,8 +98,7 @@ export async function assertTrustedImportDatabaseEmpty(
  * transaction (`transactionWithNative` in the PostgreSQL profile builder), so
  * there is no wider fence above it for an advisory key to nest inside. This
  * is the one write-fence site that takes a table lock with no advisory lock
- * preceding it — see the note in `write-fence.ts` next to
- * `planFromLockCapabilities`.
+ * preceding it.
  *
  * Resolves the write-fence plan through {@link resolveWriteFencePlan}; the
  * `lock` arm takes the relation lock below, spelled by the target's own
@@ -111,7 +110,7 @@ export async function lockPostgresTrustedImportTables(
 ): Promise<void> {
   const executeStatement = requireStatementExecution(backend);
   const plan = resolveWriteFencePlan(backend);
-  const fence = requireWriteFence(plan, "trusted import", "table-lock");
+  const fence = requireWriteFence(plan, "trusted import", "drain");
   switch (fence.kind) {
     case "lock": {
       if (fence.drain !== "table-lock") {
@@ -136,8 +135,9 @@ export async function lockPostgresTrustedImportTables(
       // without ever calling this function: it is built by
       // `createSqliteTrustedImportSession`, which inserts under the writer
       // slot `BEGIN IMMEDIATE` already holds. Any target — SQLite dialect
-      // or not — that declares `serializedWriters: true` instead of locks
-      // reaches this arm directly through `resolveWriteFencePlan`, and
+      // or not — that declares `writeFence.mechanism: "engine-serialized"`
+      // instead of locks reaches this arm directly through
+      // `resolveWriteFencePlan`, and
       // taking no relation lock is the deliberate reading of that
       // declaration: the engine already excludes concurrent writers by
       // construction, so this function's own table lock would add nothing.

--- a/packages/typegraph/src/backend/drizzle/trusted-import.ts
+++ b/packages/typegraph/src/backend/drizzle/trusted-import.ts
@@ -124,10 +124,11 @@ export async function lockPostgresTrustedImportTables(
       );
       return;
     }
-    case "engine-serialized": {
-      // Two things read this arm as "take no relation lock". The bundled
-      // SQLite import session takes that reading its own way, without ever
-      // calling this function: it is built by
+    case "engine-serialized":
+    case "caller-serialized": {
+      // Two things read `engine-serialized` as "take no relation lock". The
+      // bundled SQLite import session takes that reading its own way,
+      // without ever calling this function: it is built by
       // `createSqliteTrustedImportSession`, which inserts under the writer
       // slot `BEGIN IMMEDIATE` already holds. Any target — SQLite dialect
       // or not — that declares `serializedWriters: true` instead of locks
@@ -135,6 +136,9 @@ export async function lockPostgresTrustedImportTables(
       // taking no relation lock is the deliberate reading of that
       // declaration: the engine already excludes concurrent writers by
       // construction, so this function's own table lock would add nothing.
+      // `caller-serialized` reads the same way: the deployment's own
+      // promise that no other client writes to this database already
+      // excludes the writer this table lock would otherwise hold off.
       return;
     }
     default: {

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -386,7 +386,6 @@ export type {
   NodePropertyExpectation,
   NodeRow,
   NormalizedColumnKind,
-  PessimisticLockCapabilities,
   PopulatedSchemaKind,
   PurgeEdgeClaimsParams,
   QueryExecutionBackend,

--- a/packages/typegraph/src/backend/index.ts
+++ b/packages/typegraph/src/backend/index.ts
@@ -435,6 +435,7 @@ export type {
   VectorSearchFrontierTuning,
   VectorSearchParams,
   VectorSearchResult,
+  WriteFenceDeclaration,
 } from "./types";
 export {
   D1_MAX_BIND_PARAMETERS,

--- a/packages/typegraph/src/backend/serialized-execution-queue.ts
+++ b/packages/typegraph/src/backend/serialized-execution-queue.ts
@@ -1,0 +1,156 @@
+/**
+ * The in-process half of a write-fence promise: a FIFO queue that runs one
+ * task at a time on the same JavaScript process, used wherever a backend (or
+ * a `caller-serialized` write-fence declaration built on top of one) needs to
+ * serialize the top-level operations it issues rather than relying on a
+ * database-side lock.
+ *
+ * Moved out of `./drizzle/sqlite.ts` (SQLite's own per-connection queue is
+ * still built by calling {@link createSerializedExecutionQueue} from there)
+ * so `src/backend/drizzle/engine/create-sql-backend.ts` can build a second,
+ * independent instance for a `caller-serialized` backend without importing a
+ * Drizzle-specific module to get it.
+ */
+import { BackendDisposedError, ConfigurationError } from "../errors";
+
+export type SerializedExecutionQueue = Readonly<{
+  dispose: () => void;
+  runExclusive: <T>(task: () => Promise<T>) => Promise<T>;
+}>;
+
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+function noop(): void {}
+
+/** A shared promise that never settles — used to absorb post-dispose work. */
+const PENDING_FOREVER: Promise<never> = new Promise<never>(noop);
+
+function pendingForever<T>(): Promise<T> {
+  return PENDING_FOREVER;
+}
+
+/**
+ * Tracks every serialized queue (if any) the current async execution is
+ * running a task FOR — every enclosing `runExclusive` call, not only the
+ * innermost one — so a re-entrant submission to ANY of them can be rejected
+ * with a typed error instead of deadlocking (the enclosing task holds the
+ * queue slot until it completes, so the inner operation can never run).
+ *
+ * A `caller-serialized` backend built on top of SQLite nests two queue
+ * instances: this module's own, and SQLite's per-connection one
+ * (`sqlite.ts`'s `transaction`/`transactionWithNative` run inside BOTH).
+ * `AsyncLocalStorage.run` replaces the ambient store for the DURATION of its
+ * own callback — it does not merge with whatever the enclosing `run` already
+ * set — so storing a single marker (as this module used to) would let the
+ * inner queue's `run` shadow the outer one's marker for exactly the window a
+ * reentrant submission to the OUTER queue needs it visible. Storing the SET
+ * of every marker still on the stack, accumulated as each `run` nests, is
+ * what keeps every enclosing queue's own reentrancy check correct regardless
+ * of how many other queues are nested inside it.
+ *
+ * AsyncLocalStorage is loaded lazily and optionally: it is available on Node
+ * and on Cloudflare workers with the `nodejs_als` compatibility flag, and a
+ * runtime without it simply skips the detection (the queue behaves as before).
+ */
+type QueueTaskContext = Readonly<{
+  getStore: () => ReadonlySet<object> | undefined;
+  run: <T>(store: ReadonlySet<object>, callback: () => T) => T;
+}>;
+
+let queueTaskContext: QueueTaskContext | undefined;
+
+async function loadQueueTaskContext(): Promise<void> {
+  try {
+    const asyncHooks = await import("node:async_hooks");
+    queueTaskContext = new asyncHooks.AsyncLocalStorage<ReadonlySet<object>>();
+  } catch {
+    // AsyncLocalStorage unavailable on this runtime: re-entrant submissions
+    // stay undetected, matching the queue's previous behavior.
+  }
+}
+
+// eslint-disable-next-line unicorn/prefer-top-level-await -- the dual CJS/ESM build cannot use top-level await
+void loadQueueTaskContext();
+
+function rejectReentrantQueueSubmission(): Promise<never> {
+  return Promise.reject(
+    new ConfigurationError(
+      "This operation was awaited from inside a transaction running on the " +
+        "same SQLite backend and would deadlock: the transaction holds the " +
+        "backend's serialized execution slot until it completes, so the " +
+        "operation could never run.",
+      { backend: "sqlite", capability: "concurrentRootAccess" },
+      {
+        suggestion:
+          "Inside a store.transaction callback, use the transaction-scoped " +
+          "context (tx.nodes / tx.edges / tx.backend) instead of the root " +
+          "store or backend, or move the operation outside the transaction.",
+      },
+    ),
+  );
+}
+
+export function createSerializedExecutionQueue(): SerializedExecutionQueue {
+  let tail: Promise<unknown> = Promise.resolve();
+  let disposed = false;
+  // Unique per queue: a task running on THIS queue must not submit back to it,
+  // but may freely submit to a different backend's queue.
+  const taskMarker: object = {};
+
+  function isDisposed(): boolean {
+    return disposed;
+  }
+
+  return {
+    dispose() {
+      disposed = true;
+    },
+
+    runExclusive<T>(task: () => Promise<T>): Promise<T> {
+      if (isDisposed()) return Promise.reject(new BackendDisposedError());
+      if (queueTaskContext?.getStore()?.has(taskMarker) === true) {
+        return rejectReentrantQueueSubmission();
+      }
+
+      // When disposed, runTask returns a never-settling promise so that no
+      // rejection propagates through the 7+ async wrappers between this
+      // queue and the store-level caller. A rejection here would become an
+      // unhandled rejection if the caller abandoned the promise during
+      // teardown — and JavaScript offers no way to `.catch()` a rejection
+      // at the bottom of a chain without every async wrapper above it also
+      // creating an independently-unhandled rejected promise.
+      //
+      // The tradeoff: an active caller whose operation was queued before
+      // dispose() will see a permanently-pending promise rather than a
+      // BackendDisposedError. Post-dispose submissions (the check above)
+      // still reject immediately since the caller actively holds that
+      // promise.
+      const runTask = async (): Promise<T> => {
+        if (isDisposed()) return pendingForever<T>();
+        try {
+          const context = queueTaskContext;
+          if (context === undefined) return await task();
+          const activeMarkers = new Set(context.getStore());
+          activeMarkers.add(taskMarker);
+          return await context.run(activeMarkers, () => task());
+        } catch (error) {
+          if (isDisposed()) return pendingForever<T>();
+          throw error;
+        }
+      };
+      const result = tail.then(runTask, runTask);
+      tail = result.then(
+        () => 0,
+        () => 0,
+      );
+      return result;
+    },
+  };
+}
+
+export function runWithSerializedQueue<T>(
+  queue: SerializedExecutionQueue | undefined,
+  task: () => Promise<T>,
+): Promise<T> {
+  if (queue === undefined) return task();
+  return queue.runExclusive(task);
+}

--- a/packages/typegraph/src/backend/serialized-execution-queue.ts
+++ b/packages/typegraph/src/backend/serialized-execution-queue.ts
@@ -36,7 +36,7 @@ export type SerializedExecutionQueue = Readonly<{
  *   Under `"require"`, an unavailable context refuses EVERY submission with
  *   `CALLER_SERIALIZED_REQUIRES_ASYNC_CONTEXT` instead of running undetected.
  */
-export type ReentrancyMode = "detect" | "require";
+type ReentrancyMode = "detect" | "require";
 
 export type SerializedExecutionQueueOptions = Readonly<{
   reentrancy: ReentrancyMode;

--- a/packages/typegraph/src/backend/serialized-execution-queue.ts
+++ b/packages/typegraph/src/backend/serialized-execution-queue.ts
@@ -18,6 +18,39 @@ export type SerializedExecutionQueue = Readonly<{
   runExclusive: <T>(task: () => Promise<T>) => Promise<T>;
 }>;
 
+/**
+ * How a queue behaves when the AsyncLocalStorage-based reentrancy detection
+ * below is unavailable (or has not finished loading yet):
+ *
+ * - `"detect"` — best-effort. If the context is unavailable, the queue runs
+ *   the task WITHOUT detection, exactly as it always has. SQLite's own
+ *   per-connection queue (`sqlite.ts`) uses this: undetected reentrancy there
+ *   is a quality-of-life deadlock guard, not a correctness promise a caller
+ *   is relying on to hold.
+ * - `"require"` — reentrancy detection IS part of the promise this queue
+ *   makes. A `caller-serialized` write-fence declaration says every write
+ *   unit this backend issues is serialized in-process; a transaction that
+ *   silently deadlocks on a nested root write (because detection happened to
+ *   be unavailable on this runtime, or the loader had not yet resolved on a
+ *   cold start) would falsify that promise instead of merely degrading it.
+ *   Under `"require"`, an unavailable context refuses EVERY submission with
+ *   `CALLER_SERIALIZED_REQUIRES_ASYNC_CONTEXT` instead of running undetected.
+ */
+export type ReentrancyMode = "detect" | "require";
+
+export type SerializedExecutionQueueOptions = Readonly<{
+  reentrancy: ReentrancyMode;
+  /**
+   * Names this queue in the reentrancy / async-context refusal's message and
+   * structured details — a SQLite dialect string for SQLite's own queue, or
+   * `"caller-serialized"` for the in-process write-unit queue
+   * `createSqlBackend` builds from a `caller-serialized` write-fence
+   * declaration. Replaces a hardcoded `"sqlite"` the refusal used to report
+   * regardless of which queue actually rejected the submission.
+   */
+  subject: string;
+}>;
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function noop(): void {}
 
@@ -48,8 +81,10 @@ function pendingForever<T>(): Promise<T> {
  * of how many other queues are nested inside it.
  *
  * AsyncLocalStorage is loaded lazily and optionally: it is available on Node
- * and on Cloudflare workers with the `nodejs_als` compatibility flag, and a
- * runtime without it simply skips the detection (the queue behaves as before).
+ * and on Cloudflare workers with the `nodejs_als` compatibility flag. Under
+ * `reentrancy: "detect"`, a runtime without it simply skips the detection
+ * (the queue behaves as before); under `"require"`, its absence is refused —
+ * see {@link ReentrancyMode}.
  */
 type QueueTaskContext = Readonly<{
   getStore: () => ReadonlySet<object> | undefined;
@@ -64,21 +99,59 @@ async function loadQueueTaskContext(): Promise<void> {
     queueTaskContext = new asyncHooks.AsyncLocalStorage<ReadonlySet<object>>();
   } catch {
     // AsyncLocalStorage unavailable on this runtime: re-entrant submissions
-    // stay undetected, matching the queue's previous behavior.
+    // stay undetected under `reentrancy: "detect"`, and every submission is
+    // refused under `reentrancy: "require"` — see `runExclusive` below.
   }
 }
 
-// eslint-disable-next-line unicorn/prefer-top-level-await -- the dual CJS/ESM build cannot use top-level await
-void loadQueueTaskContext();
+/**
+ * Resolves once {@link loadQueueTaskContext} has settled — successfully or
+ * not; the function above never throws, so this promise never rejects.
+ * `runExclusive` awaits it before running ANY task body, on both
+ * {@link ReentrancyMode}s: that is what turns "the dynamic import has not
+ * resolved yet" from a silent detection gap into, at worst, one microtask of
+ * latency before the first task of this queue's lifetime ever runs — by the
+ * time a task's own body executes (and could make a nested submission to
+ * this same queue), `queueTaskContext` has already reached its final value.
+ */
+let queueTaskContextReadyPromise: Promise<void> = loadQueueTaskContext();
 
-function rejectReentrantQueueSubmission(): Promise<never> {
+/**
+ * @internal Test seam for `tests/caller-serialized-queue.test.ts`: replaces
+ * the module's cached AsyncLocalStorage context and readiness state with a
+ * caller-controlled value, so a test can simulate a runtime with no
+ * AsyncLocalStorage (`context: undefined`) or a cold start where the loader
+ * has not resolved yet (a `readyDelayMs` the test's own assertions run
+ * within) deterministically, instead of racing the real dynamic
+ * `import("node:async_hooks")`. Not reachable from published entrypoints.
+ */
+export function __setQueueTaskContextForTesting(
+  context: QueueTaskContext | undefined,
+  readyDelayMs = 0,
+): void {
+  queueTaskContext = undefined;
+  queueTaskContextReadyPromise = new Promise((resolve) => {
+    setTimeout(() => {
+      queueTaskContext = context;
+      resolve();
+    }, readyDelayMs);
+  });
+}
+
+/** @internal Restores the real loader after a test uses the seam above. */
+export function __restoreQueueTaskContextForTesting(): void {
+  queueTaskContext = undefined;
+  queueTaskContextReadyPromise = loadQueueTaskContext();
+}
+
+function rejectReentrantQueueSubmission(subject: string): Promise<never> {
   return Promise.reject(
     new ConfigurationError(
       "This operation was awaited from inside a transaction running on the " +
-        "same SQLite backend and would deadlock: the transaction holds the " +
-        "backend's serialized execution slot until it completes, so the " +
-        "operation could never run.",
-      { backend: "sqlite", capability: "concurrentRootAccess" },
+        `same ${subject} backend and would deadlock: the transaction holds ` +
+        "the backend's serialized execution slot until it completes, so " +
+        "the operation could never run.",
+      { code: "SERIALIZED_QUEUE_REENTRANT_SUBMISSION", subject },
       {
         suggestion:
           "Inside a store.transaction callback, use the transaction-scoped " +
@@ -89,7 +162,37 @@ function rejectReentrantQueueSubmission(): Promise<never> {
   );
 }
 
-export function createSerializedExecutionQueue(): SerializedExecutionQueue {
+/**
+ * THE refusal `runExclusive` throws under `reentrancy: "require"` when the
+ * AsyncLocalStorage context this queue's promise depends on never became
+ * available (an unsupported runtime) or had not resolved by the time this
+ * submission's turn came up. Refusing beats running without detection: a
+ * `caller-serialized` in-process promise with no working reentrancy guard is
+ * a promise this queue cannot actually keep.
+ */
+function rejectAsyncContextUnavailable(subject: string): Promise<never> {
+  return Promise.reject(
+    new ConfigurationError(
+      `The ${subject} write-unit queue requires AsyncLocalStorage ` +
+        "(node:async_hooks) to detect a reentrant submission, but it is " +
+        "unavailable on this runtime, so this submission is refused rather " +
+        "than run without the detection this queue's caller-serialized " +
+        "promise depends on.",
+      { code: "CALLER_SERIALIZED_REQUIRES_ASYNC_CONTEXT", subject },
+      {
+        suggestion:
+          "Run on a runtime that supports node:async_hooks' " +
+          "AsyncLocalStorage (Node.js, or Cloudflare Workers with the " +
+          "nodejs_als compatibility flag), or avoid declaring " +
+          '`writeFence.mechanism: "caller-serialized"` on this runtime.',
+      },
+    ),
+  );
+}
+
+export function createSerializedExecutionQueue(
+  options: SerializedExecutionQueueOptions,
+): SerializedExecutionQueue {
   let tail: Promise<unknown> = Promise.resolve();
   let disposed = false;
   // Unique per queue: a task running on THIS queue must not submit back to it,
@@ -107,8 +210,16 @@ export function createSerializedExecutionQueue(): SerializedExecutionQueue {
 
     runExclusive<T>(task: () => Promise<T>): Promise<T> {
       if (isDisposed()) return Promise.reject(new BackendDisposedError());
+      // Synchronous, at call time, deliberately NOT deferred behind
+      // `queueTaskContextReadyPromise`: a submission made from INSIDE a task
+      // this same queue is currently running only ever reaches this point
+      // after `runTask` (below) already awaited that readiness promise for
+      // the ENCLOSING task, so `queueTaskContext` is already resolved by
+      // then. Waiting here too would let two concurrent top-level
+      // submissions race the promise instead of strictly ordering by call
+      // time, which is what keeps the FIFO guarantee below correct.
       if (queueTaskContext?.getStore()?.has(taskMarker) === true) {
-        return rejectReentrantQueueSubmission();
+        return rejectReentrantQueueSubmission(options.subject);
       }
 
       // When disposed, runTask returns a never-settling promise so that no
@@ -127,8 +238,20 @@ export function createSerializedExecutionQueue(): SerializedExecutionQueue {
       const runTask = async (): Promise<T> => {
         if (isDisposed()) return pendingForever<T>();
         try {
+          // Awaited before the context is read (on BOTH reentrancy modes),
+          // so a nested submission made from inside `task()` — whether this
+          // queue was constructed a microtask ago or a minute ago — always
+          // observes `queueTaskContext`'s FINAL value rather than a
+          // still-loading `undefined`. See the module doc above.
+          await queueTaskContextReadyPromise;
+          if (isDisposed()) return await pendingForever<T>();
           const context = queueTaskContext;
-          if (context === undefined) return await task();
+          if (context === undefined) {
+            if (options.reentrancy === "require") {
+              return await rejectAsyncContextUnavailable(options.subject);
+            }
+            return await task();
+          }
           const activeMarkers = new Set(context.getStore());
           activeMarkers.add(taskMarker);
           return await context.run(activeMarkers, () => task());

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -4465,7 +4465,6 @@ export const SQLITE_CAPABILITIES: BackendCapabilities = Object.freeze({
   recursiveTraversal: Object.freeze({ supported: true }),
   writeFence: Object.freeze({
     mechanism: "engine-serialized",
-    drain: "table-lock",
   }),
 });
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -282,13 +282,11 @@ export type { RecursiveTraversalCapability } from "./capabilities/recursive-trav
 
 import {
   type FenceSql,
-  type PessimisticLockCapabilities,
   type WriteFenceDeclaration,
 } from "./capabilities/write-fence";
 
 export type {
   FenceSql,
-  PessimisticLockCapabilities,
   WriteFenceDeclaration,
 } from "./capabilities/write-fence";
 
@@ -422,41 +420,21 @@ export type BackendCapabilities = Readonly<{
    * {@link WriteFenceDeclaration} for the full `mechanism`/`drain` contract.
    *
    * Absent means `unfenced` for any backend the first-party factories did
-   * not build (`resolveWriteFencePlan`, `src/backend/capabilities/write-fence.ts`),
-   * unless the deprecated `pessimisticLocks` below is declared instead: an
-   * undeclared custom backend is refused at construction for Operational
-   * Identity and for TypeGraph-owned recorded-clock allocation
-   * (`history` / `revisionTracking`) rather than silently emitting locks the
-   * engine may not honor. Declaring both this and `pessimisticLocks` is a
-   * `ConfigurationError` (`WRITE_FENCE_DECLARATION_CONFLICT`) — exactly one
-   * of the two may describe a backend.
+   * not build (`resolveWriteFencePlan`, `src/backend/capabilities/write-fence.ts`):
+   * an undeclared custom backend is refused at construction for Operational
+   * Identity and for TypeGraph-owned recorded-clock allocation (`history` /
+   * `revisionTracking`) rather than silently emitting locks the engine may
+   * not honor.
    */
   writeFence?: WriteFenceDeclaration | undefined;
-  /**
-   * Whether this engine can serialize concurrent writers, and how: keyed
-   * advisory locks, relation-level table locks, or a single writer slot that
-   * serializes by construction.
-   *
-   * Deprecated in favor of {@link BackendCapabilities.writeFence} — declare
-   * that instead on a new backend. Not machine-`@deprecated`: both bundled
-   * factories (`SQLITE_CAPABILITIES`, `POSTGRES_CAPABILITIES`) still declare
-   * this shape, and `resolveWriteFencePlan` maps it onto `writeFence` through
-   * `writeFenceFromLegacyLocks` (`src/backend/capabilities/write-fence.ts`)
-   * rather than treating it as an error, so behavior for an existing backend
-   * is unchanged. Absent means `unfenced` for any backend the first-party
-   * factories did not build: an undeclared custom backend is refused at
-   * construction for Operational Identity and for TypeGraph-owned
-   * recorded-clock allocation (`history` / `revisionTracking`) rather than
-   * silently emitting locks the engine may not honor.
-   */
-  pessimisticLocks?: PessimisticLockCapabilities | undefined;
   /**
    * Who allocates recorded-time revisions. `"typegraph-relations"` (the
    * default, and every first-party backend) means TypeGraph owns a clock row
    * and performs the read/advance/write that `lockRecordedClock` fences —
    * which is undegradable, so an `unfenced` engine is refused at
    * construction. `"engine-native"` means the engine supplies the recorded
-   * axis itself (WS9's ruled BraidDB posture: pinned-handle `AS OF`).
+   * axis itself (an engine that supplies the recorded axis natively via
+   * pinned-handle `AS OF`).
    *
    * TODAY THE ENGINE-NATIVE READ/WRITE PATH DOES NOT EXIST YET (follow-up
    * F8, owned by WS9). The capture path allocates the TypeGraph clock
@@ -2214,8 +2192,8 @@ export type GraphBackend = Readonly<{
    */
   vectorStrategy?: VectorStrategy | undefined;
   /**
-   * The lock-statement spelling this backend's `capabilities.pessimisticLocks`
-   * declaration requires when `advisoryLocks` is `true` — resolved through
+   * The lock-statement spelling this backend's `capabilities.writeFence`
+   * declaration requires when `mechanism` is `"advisory"` — resolved through
    * {@link resolveWriteFencePlan} rather than read directly by a lock site.
    * Absent on a backend that serializes writers instead (SQLite's writer
    * slot needs no lock statement at all) or that declares no usable fence.
@@ -4485,10 +4463,9 @@ export const SQLITE_CAPABILITIES: BackendCapabilities = Object.freeze({
   // better-sqlite3 factory overrides this flag for its bundled build contract.
   graphAnalytics: Object.freeze({ supported: true, mathFunctions: false }),
   recursiveTraversal: Object.freeze({ supported: true }),
-  pessimisticLocks: Object.freeze({
-    advisoryLocks: false,
-    tableLocks: false,
-    serializedWriters: true,
+  writeFence: Object.freeze({
+    mechanism: "engine-serialized",
+    drain: "table-lock",
   }),
 });
 
@@ -4512,9 +4489,8 @@ export const POSTGRES_CAPABILITIES: BackendCapabilities = Object.freeze({
   maxBindParameters: POSTGRES_MAX_BIND_PARAMETERS,
   graphAnalytics: Object.freeze({ supported: true, mathFunctions: true }),
   recursiveTraversal: Object.freeze({ supported: true }),
-  pessimisticLocks: Object.freeze({
-    advisoryLocks: true,
-    tableLocks: true,
-    serializedWriters: false,
+  writeFence: Object.freeze({
+    mechanism: "advisory",
+    drain: "table-lock",
   }),
 });

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -283,11 +283,13 @@ export type { RecursiveTraversalCapability } from "./capabilities/recursive-trav
 import {
   type FenceSql,
   type PessimisticLockCapabilities,
+  type WriteFenceDeclaration,
 } from "./capabilities/write-fence";
 
 export type {
   FenceSql,
   PessimisticLockCapabilities,
+  WriteFenceDeclaration,
 } from "./capabilities/write-fence";
 
 import { type BackendCatalogProbes } from "./capabilities/catalog";
@@ -413,18 +415,39 @@ export type BackendCapabilities = Readonly<{
    */
   recursiveTraversal?: RecursiveTraversalCapability | undefined;
   /**
+   * How this backend excludes concurrent writers: a keyed advisory lock, a
+   * single writer slot the engine serializes by construction, or a
+   * deployment-level promise that this process serializes its own writes and
+   * no other client writes to the database — see
+   * {@link WriteFenceDeclaration} for the full `mechanism`/`drain` contract.
+   *
+   * Absent means `unfenced` for any backend the first-party factories did
+   * not build (`resolveWriteFencePlan`, `src/backend/capabilities/write-fence.ts`),
+   * unless the deprecated `pessimisticLocks` below is declared instead: an
+   * undeclared custom backend is refused at construction for Operational
+   * Identity and for TypeGraph-owned recorded-clock allocation
+   * (`history` / `revisionTracking`) rather than silently emitting locks the
+   * engine may not honor. Declaring both this and `pessimisticLocks` is a
+   * `ConfigurationError` (`WRITE_FENCE_DECLARATION_CONFLICT`) — exactly one
+   * of the two may describe a backend.
+   */
+  writeFence?: WriteFenceDeclaration | undefined;
+  /**
    * Whether this engine can serialize concurrent writers, and how: keyed
    * advisory locks, relation-level table locks, or a single writer slot that
    * serializes by construction.
    *
-   * Absent means `unfenced` for any backend the first-party factories did
-   * not build (`resolveWriteFencePlan`, `src/backend/capabilities/write-fence.ts`):
-   * an undeclared custom backend is refused at construction for Operational
-   * Identity and for TypeGraph-owned recorded-clock allocation
-   * (`history` / `revisionTracking`) rather than silently emitting locks the
-   * engine may not honor. Every first-party backend declares this member
-   * (`SQLITE_CAPABILITIES`, `POSTGRES_CAPABILITIES`), so the refusal is
-   * reachable only by a backend this library did not build.
+   * Deprecated in favor of {@link BackendCapabilities.writeFence} — declare
+   * that instead on a new backend. Not machine-`@deprecated`: both bundled
+   * factories (`SQLITE_CAPABILITIES`, `POSTGRES_CAPABILITIES`) still declare
+   * this shape, and `resolveWriteFencePlan` maps it onto `writeFence` through
+   * `writeFenceFromLegacyLocks` (`src/backend/capabilities/write-fence.ts`)
+   * rather than treating it as an error, so behavior for an existing backend
+   * is unchanged. Absent means `unfenced` for any backend the first-party
+   * factories did not build: an undeclared custom backend is refused at
+   * construction for Operational Identity and for TypeGraph-owned
+   * recorded-clock allocation (`history` / `revisionTracking`) rather than
+   * silently emitting locks the engine may not honor.
    */
   pessimisticLocks?: PessimisticLockCapabilities | undefined;
   /**

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -428,15 +428,15 @@ type SidecarClaimPort = SidecarInspectionPort &
  * `DEFERRED` transaction, so that premise holds unconditionally.
  *
  * Resolves a {@link resolveWriteFencePlan}: the `lock` arm takes the relation
- * lock below (needs `tableLocks`), and the `engine-serialized` arm is the
- * SQLite writer-slot case this doc already describes.
+ * lock below (needs `drain: "table-lock"`), and the `engine-serialized` arm
+ * is the SQLite writer-slot case this doc already describes.
  */
 async function drainUnfencedRowWriters(tx: SidecarClaimPort): Promise<void> {
   const plan = resolveWriteFencePlan(tx);
   const fence = requireWriteFence(
     plan,
     "graph-merge provenance fence",
-    "table-lock",
+    "drain",
   );
   switch (fence.kind) {
     case "lock": {

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -455,7 +455,8 @@ async function drainUnfencedRowWriters(tx: SidecarClaimPort): Promise<void> {
       );
       return;
     }
-    case "engine-serialized": {
+    case "engine-serialized":
+    case "caller-serialized": {
       return;
     }
     default: {

--- a/packages/typegraph/src/graph-merge/provenance-store.ts
+++ b/packages/typegraph/src/graph-merge/provenance-store.ts
@@ -440,6 +440,11 @@ async function drainUnfencedRowWriters(tx: SidecarClaimPort): Promise<void> {
   );
   switch (fence.kind) {
     case "lock": {
+      if (fence.drain !== "table-lock") {
+        // `drain: "quiescent"`: the declaration already excludes concurrent
+        // writers by some other means, so this site takes no statement.
+        return;
+      }
       // Built fresh from `tx.tableNames` — always the live-relation schema,
       // never a recorded-read view — so `schema.tables.nodes/.edges` (the
       // physical names `lockTables` needs) name the same relations

--- a/packages/typegraph/src/identity/schema-transition.ts
+++ b/packages/typegraph/src/identity/schema-transition.ts
@@ -424,7 +424,7 @@ export async function withIdentityDdlRaceRetry<T>(
  */
 async function lockIdentityDdl(target: IdentityTarget): Promise<void> {
   const plan = resolveWriteFencePlan(target);
-  const fence = requireWriteFence(plan, "identity DDL", "advisory-lock");
+  const fence = requireWriteFence(plan, "identity DDL", "keyed");
   switch (fence.kind) {
     case "lock": {
       await target.execute(

--- a/packages/typegraph/src/identity/schema-transition.ts
+++ b/packages/typegraph/src/identity/schema-transition.ts
@@ -432,7 +432,8 @@ async function lockIdentityDdl(target: IdentityTarget): Promise<void> {
       );
       return;
     }
-    case "engine-serialized": {
+    case "engine-serialized":
+    case "caller-serialized": {
       return;
     }
     default: {

--- a/packages/typegraph/src/identity/service-read.ts
+++ b/packages/typegraph/src/identity/service-read.ts
@@ -301,6 +301,13 @@ export async function lockIdentityEnablementNodes(
   );
   switch (fence.kind) {
     case "lock": {
+      if (fence.drain !== "table-lock") {
+        // `drain: "quiescent"`: the declaration already excludes concurrent
+        // writers by some other means (`requireWriteFence` already refused
+        // `drain: "none"` above), so this site takes no statement rather
+        // than one the resource does not need.
+        return;
+      }
       await executeIdentityStatement(
         target,
         fence.sql.lockTables([schema.tables.nodes], "share"),

--- a/packages/typegraph/src/identity/service-read.ts
+++ b/packages/typegraph/src/identity/service-read.ts
@@ -251,7 +251,7 @@ export async function lockIdentityGraph(
   graphId: string,
 ): Promise<void> {
   const plan = resolveWriteFencePlan(target);
-  const fence = requireWriteFence(plan, "identity graph lock", "advisory-lock");
+  const fence = requireWriteFence(plan, "identity graph lock", "keyed");
   switch (fence.kind) {
     case "lock": {
       await target.execute(
@@ -279,7 +279,7 @@ export async function lockIdentityGraph(
 /**
  * Drains in-flight legacy node writes before the first identity snapshot.
  * Resolves a {@link resolveWriteFencePlan}; the `lock` arm takes the relation
- * lock (needs `tableLocks`), and the `engine-serialized` arm is the SQLite
+ * lock (needs `drain: "table-lock"`), and the `engine-serialized` arm is the SQLite
  * writer-slot case, which has already drained every writer.
  *
  * `schema.tables.nodes` — the physical name, not `schema.nodesTable` — is
@@ -294,11 +294,7 @@ export async function lockIdentityEnablementNodes(
   schema: SqlSchema,
 ): Promise<void> {
   const plan = resolveWriteFencePlan(target);
-  const fence = requireWriteFence(
-    plan,
-    "identity enablement drain",
-    "table-lock",
-  );
+  const fence = requireWriteFence(plan, "identity enablement drain", "drain");
   switch (fence.kind) {
     case "lock": {
       if (fence.drain !== "table-lock") {

--- a/packages/typegraph/src/identity/service-read.ts
+++ b/packages/typegraph/src/identity/service-read.ts
@@ -261,10 +261,13 @@ export async function lockIdentityGraph(
       );
       return;
     }
-    case "engine-serialized": {
-      // No lock is taken because the engine's single writer slot already
-      // serializes writers — see the DEFERRED-frame caveat above, which
-      // `executeIdentityStatement` turns into a typed refusal (#447).
+    case "engine-serialized":
+    case "caller-serialized": {
+      // No lock is taken because the engine's single writer slot (or, under
+      // `caller-serialized`, the deployment's own serialization promise)
+      // already excludes concurrent writers — see the DEFERRED-frame caveat
+      // above, which `executeIdentityStatement` turns into a typed refusal
+      // (#447).
       return;
     }
     default: {
@@ -304,9 +307,11 @@ export async function lockIdentityEnablementNodes(
       );
       return;
     }
-    case "engine-serialized": {
-      // No lock is taken because the engine's single writer slot already
-      // drained every writer before the fence opened.
+    case "engine-serialized":
+    case "caller-serialized": {
+      // No lock is taken because the engine's single writer slot (or, under
+      // `caller-serialized`, the deployment's own serialization promise)
+      // already drained every writer before the fence opened.
       return;
     }
     default: {

--- a/packages/typegraph/src/store/recorded-capture/clock.ts
+++ b/packages/typegraph/src/store/recorded-capture/clock.ts
@@ -245,10 +245,12 @@ export async function lockRecordedGraphWrite(
     "advisory-lock",
   );
   switch (fence.kind) {
-    case "engine-serialized": {
-      // A writer slot can serialize ordinary row work, but it is not an
-      // advisory acquisition bound to this graph/port. It cannot authorize
-      // the PostgreSQL convergence command.
+    case "engine-serialized":
+    case "caller-serialized": {
+      // A writer slot — or, under `caller-serialized`, the deployment's own
+      // serialization promise — can serialize ordinary row work, but
+      // neither is an advisory acquisition bound to this graph/port. It
+      // cannot authorize the PostgreSQL convergence command.
       return uncapturedGraphWriteLock();
     }
     case "lock": {
@@ -560,6 +562,17 @@ async function lockRecordedClock(
           ON CONFLICT (graph_id) DO UPDATE SET revision = revision
         `,
       );
+      return;
+    }
+    case "caller-serialized": {
+      // Unlike `engine-serialized`, this is never conditional on
+      // `ownsWriteLock`: the seed-UPSERT above exists to take a row-level
+      // write lock SQLite's `BEGIN IMMEDIATE` might not already hold, which
+      // is a proof about that one engine's transaction, not about this
+      // declaration. `caller-serialized` is the deployment's own promise
+      // that no other client writes to this database at all, so there is no
+      // concurrent writer for a seed row to exclude regardless of which
+      // transaction opened this one.
       return;
     }
     default: {

--- a/packages/typegraph/src/store/recorded-capture/clock.ts
+++ b/packages/typegraph/src/store/recorded-capture/clock.ts
@@ -239,11 +239,7 @@ export async function lockRecordedGraphWrite(
   memo?: RecordedGraphLockMemo,
 ): Promise<GraphWriteLock> {
   const plan = resolveWriteFencePlan(target);
-  const fence = requireWriteFence(
-    plan,
-    "recorded graph write",
-    "advisory-lock",
-  );
+  const fence = requireWriteFence(plan, "recorded graph write", "keyed");
   switch (fence.kind) {
     case "engine-serialized":
     case "caller-serialized": {
@@ -532,11 +528,7 @@ async function lockRecordedClock(
   // concurrent transactions can read the same previous clock value and
   // allocate the same recorded instant.
   const plan = resolveWriteFencePlan(target);
-  const fence = requireWriteFence(
-    plan,
-    "recorded clock allocation",
-    "advisory-lock",
-  );
+  const fence = requireWriteFence(plan, "recorded clock allocation", "keyed");
   switch (fence.kind) {
     case "lock": {
       await target.execute(

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -1130,10 +1130,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     if (graph.identity !== undefined) {
       const identityFencePlan = resolveWriteFencePlan(backend);
       if (identityFencePlan.kind === "unfenced") {
-        refuseUnfencedOperationalIdentity(
-          backend.dialect,
-          identityFencePlan.reason,
-        );
+        refuseUnfencedOperationalIdentity(backend.dialect);
       }
     }
     this.#baseBackend = asRawBackend(backend);
@@ -1154,7 +1151,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       }
       const clockFencePlan = resolveWriteFencePlan(backend);
       if (clockFencePlan.kind === "unfenced") {
-        refuseUnfencedClockAllocation(backend.dialect, clockFencePlan.reason);
+        refuseUnfencedClockAllocation(backend.dialect);
       }
       assertRevisionTrackableBackend(backend);
     }

--- a/packages/typegraph/tests/__snapshots__/engine-profile-parity.test.ts.snap
+++ b/packages/typegraph/tests/__snapshots__/engine-profile-parity.test.ts.snap
@@ -473,7 +473,6 @@ exports[`engine-profile parity: member keys, capabilities, marks > better-sqlite
   },
   "windowFunctions": true,
   "writeFence": {
-    "drain": "table-lock",
     "mechanism": "engine-serialized",
   },
 }
@@ -657,7 +656,6 @@ exports[`engine-profile parity: member keys, capabilities, marks > better-sqlite
   },
   "windowFunctions": true,
   "writeFence": {
-    "drain": "table-lock",
     "mechanism": "engine-serialized",
   },
 }

--- a/packages/typegraph/tests/__snapshots__/engine-profile-parity.test.ts.snap
+++ b/packages/typegraph/tests/__snapshots__/engine-profile-parity.test.ts.snap
@@ -38,11 +38,6 @@ exports[`engine-profile parity: member keys, capabilities, marks > PGlite root >
     "supported": true,
   },
   "maxBindParameters": 32767,
-  "pessimisticLocks": {
-    "advisoryLocks": true,
-    "serializedWriters": false,
-    "tableLocks": true,
-  },
   "recursiveTraversal": {
     "supported": true,
   },
@@ -72,6 +67,10 @@ exports[`engine-profile parity: member keys, capabilities, marks > PGlite root >
     "supported": true,
   },
   "windowFunctions": true,
+  "writeFence": {
+    "drain": "table-lock",
+    "mechanism": "advisory",
+  },
 }
 `;
 
@@ -242,11 +241,6 @@ exports[`engine-profile parity: member keys, capabilities, marks > PGlite root, 
     "supported": true,
   },
   "maxBindParameters": 32767,
-  "pessimisticLocks": {
-    "advisoryLocks": true,
-    "serializedWriters": false,
-    "tableLocks": true,
-  },
   "recursiveTraversal": {
     "supported": true,
   },
@@ -276,6 +270,10 @@ exports[`engine-profile parity: member keys, capabilities, marks > PGlite root, 
     "supported": true,
   },
   "windowFunctions": true,
+  "writeFence": {
+    "drain": "table-lock",
+    "mechanism": "advisory",
+  },
 }
 `;
 
@@ -449,11 +447,6 @@ exports[`engine-profile parity: member keys, capabilities, marks > better-sqlite
     "supported": true,
   },
   "maxBindParameters": 32766,
-  "pessimisticLocks": {
-    "advisoryLocks": false,
-    "serializedWriters": true,
-    "tableLocks": false,
-  },
   "recursiveTraversal": {
     "supported": true,
   },
@@ -479,6 +472,10 @@ exports[`engine-profile parity: member keys, capabilities, marks > better-sqlite
     "supported": true,
   },
   "windowFunctions": true,
+  "writeFence": {
+    "drain": "table-lock",
+    "mechanism": "engine-serialized",
+  },
 }
 `;
 
@@ -634,11 +631,6 @@ exports[`engine-profile parity: member keys, capabilities, marks > better-sqlite
     "supported": true,
   },
   "maxBindParameters": 32766,
-  "pessimisticLocks": {
-    "advisoryLocks": false,
-    "serializedWriters": true,
-    "tableLocks": false,
-  },
   "recursiveTraversal": {
     "supported": true,
   },
@@ -664,6 +656,10 @@ exports[`engine-profile parity: member keys, capabilities, marks > better-sqlite
     "supported": true,
   },
   "windowFunctions": true,
+  "writeFence": {
+    "drain": "table-lock",
+    "mechanism": "engine-serialized",
+  },
 }
 `;
 

--- a/packages/typegraph/tests/backend-construction-lint.test.ts
+++ b/packages/typegraph/tests/backend-construction-lint.test.ts
@@ -131,6 +131,7 @@ function banColumns(modules: readonly string[]): readonly BanColumn[] {
       exempt: [
         "src/backend/derive-backend.ts",
         "src/backend/drizzle/contribution-materializations.ts",
+        "src/backend/drizzle/engine/create-sql-backend.ts",
         "src/backend/drizzle/postgres.ts",
         "src/store/operations/edge-batch-validation.ts",
         "src/store/operations/node-operations.ts",

--- a/packages/typegraph/tests/backend-derivation-inventory.test.ts
+++ b/packages/typegraph/tests/backend-derivation-inventory.test.ts
@@ -79,6 +79,12 @@ type InventoryEntry = Readonly<{
 
 const INVENTORY: readonly InventoryEntry[] = [
   {
+    file: "backend/drizzle/engine/create-sql-backend.ts",
+    line: "return deriveBackend(backend, buildQueuedWriteUnits(backend, queue));",
+    reason:
+      "A caller-serialized root decorates its own write members and transaction openers with the per-backend serialized queue; deriving keeps every mark and proof the assembled root already carries.",
+  },
+  {
     file: "backend/derive-backend.ts",
     line: "return deriveBackend(base, overrides);",
     reason:

--- a/packages/typegraph/tests/backend-derivation.test.ts
+++ b/packages/typegraph/tests/backend-derivation.test.ts
@@ -383,17 +383,17 @@ describe("factories audit unconditionally", () => {
 
 /**
  * A backend carrying the first-party write-fence mark whose declared
- * capabilities omit `pessimisticLocks` — the shape that exercises
+ * capabilities omit `writeFence` — the shape that exercises
  * `resolveWriteFencePlan`'s dialect-derivation fallback arm. The bundled
  * factories can no longer mint this shape themselves: `createSqlBackend`
- * refuses to build a backend whose resolved capabilities omit
- * `pessimisticLocks`, so the only way left to reach the fallback arm on a
- * first-party-marked backend is to mark a plain literal directly.
+ * refuses to build a backend whose resolved capabilities omit `writeFence`,
+ * so the only way left to reach the fallback arm on a first-party-marked
+ * backend is to mark a plain literal directly.
  */
-function createFirstPartyMarkedBackendWithoutPessimisticLocks(): GraphBackend {
+function createFirstPartyMarkedBackendWithoutWriteFence(): GraphBackend {
   const backend = {
     dialect: "sqlite",
-    capabilities: { ...SQLITE_CAPABILITIES, pessimisticLocks: undefined },
+    capabilities: { ...SQLITE_CAPABILITIES, writeFence: undefined },
     close: () => Promise.resolve(),
   } as GraphBackend;
   return markFirstPartyFactory(backend);
@@ -405,7 +405,7 @@ describe("the seam carries the first-party write-fence mark (§5.3)", () => {
   // derived/projected backend would resolve `unfenced` here while the source
   // still resolves `engine-serialized` — two answers to one question.
   it("a deriveBackend-decorated first-party backend resolves the same plan as its source", () => {
-    const backend = createFirstPartyMarkedBackendWithoutPessimisticLocks();
+    const backend = createFirstPartyMarkedBackendWithoutWriteFence();
 
     const decorated = deriveBackend(backend, {});
 
@@ -418,7 +418,7 @@ describe("the seam carries the first-party write-fence mark (§5.3)", () => {
   });
 
   it("a projectGraphBackend-projected first-party backend resolves the same plan as its source", () => {
-    const backend = createFirstPartyMarkedBackendWithoutPessimisticLocks();
+    const backend = createFirstPartyMarkedBackendWithoutWriteFence();
 
     const projected = projectGraphBackend(backend);
 

--- a/packages/typegraph/tests/backends/integration-test-suite.ts
+++ b/packages/typegraph/tests/backends/integration-test-suite.ts
@@ -92,6 +92,7 @@ import {
   registerValidityEndClearingIntegrationTests,
   registerValidityLowerBoundIntegrationTests,
   registerWeightedShortestPathExtractionIntegrationTests,
+  registerWriteFenceConformanceIntegrationTests,
 } from "./integration";
 import type {
   InspectableHistoryStore,
@@ -325,5 +326,6 @@ export function createIntegrationTestSuite<
     registerCrossBackendConsistencyTests(context);
     registerDurableEdgeMatchIdentityIntegrationTests(context);
     registerTrustedImportIntegrationTests(context);
+    registerWriteFenceConformanceIntegrationTests(context);
   });
 }

--- a/packages/typegraph/tests/backends/integration/index.ts
+++ b/packages/typegraph/tests/backends/integration/index.ts
@@ -65,3 +65,4 @@ export { registerTrustedImportIntegrationTests } from "./trusted-import";
 export { registerValidityEndClearingIntegrationTests } from "./validity-end-clearing";
 export { registerValidityLowerBoundIntegrationTests } from "./validity-lower-bound";
 export { registerWeightedShortestPathExtractionIntegrationTests } from "./weighted-shortest-path-extraction";
+export { registerWriteFenceConformanceIntegrationTests } from "./write-fence-conformance";

--- a/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
+++ b/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
@@ -9,7 +9,7 @@
  * `{advisory, table-lock}`; SQLite resolves `engine-serialized`), plus three
  * backends derived from `buildPostgresEngineProfile` through
  * `deriveEngineProfile` with `declaredCapabilities.writeFence` overridden —
- * `{advisory, quiescent}`, `{caller-serialized, quiescent}`, and
+ * `{advisory, quiescent}`, `{caller-serialized}`, and
  * `{advisory, none}`. Every derived case only applies on a PostgreSQL-dialect
  * lane (SQLite and libsql skip it: there is no SQLite equivalent of "a
  * PostgreSQL profile with a different drain").
@@ -112,7 +112,7 @@ function deriveWriteFenceProfile(
 
 function withAdvisoryDrainCapabilities(
   capabilities: BackendCapabilities,
-  drain: WriteFenceDeclaration["drain"],
+  drain: Extract<WriteFenceDeclaration, { mechanism: "advisory" }>["drain"],
 ): BackendCapabilities {
   return {
     ...capabilities,
@@ -142,7 +142,7 @@ function withAdvisoryDrainCapabilities(
  */
 function deriveAdvisoryDrainOverride(
   backend: GraphBackend,
-  drain: WriteFenceDeclaration["drain"],
+  drain: Extract<WriteFenceDeclaration, { mechanism: "advisory" }>["drain"],
 ): GraphBackend {
   return deriveBackend(backend, {
     capabilities: withAdvisoryDrainCapabilities(backend.capabilities, drain),
@@ -253,7 +253,7 @@ export function registerWriteFenceConformanceIntegrationTests(
       }
     });
 
-    it('derived PostgreSQL profile {caller-serialized, quiescent}: resolves "caller-serialized" and the drain site takes no statement', async (ctx) => {
+    it('derived PostgreSQL profile {caller-serialized}: resolves "caller-serialized" and the drain site takes no statement', async (ctx) => {
       if (context.getBackend().dialect !== "postgres") {
         ctx.skip();
         return;
@@ -263,7 +263,6 @@ export function registerWriteFenceConformanceIntegrationTests(
         const backend = createSqlBackend(
           deriveWriteFenceProfile(fixture.profile, {
             mechanism: "caller-serialized",
-            drain: "quiescent",
           }),
         );
         expect(resolveWriteFencePlan(backend)).toEqual({
@@ -327,11 +326,10 @@ export function registerWriteFenceConformanceIntegrationTests(
         ctx.skip();
         return;
       }
-      const advisoryDrains: readonly WriteFenceDeclaration["drain"][] = [
-        "table-lock",
-        "quiescent",
-        "none",
-      ];
+      const advisoryDrains: readonly Extract<
+        WriteFenceDeclaration,
+        { mechanism: "advisory" }
+      >["drain"][] = ["table-lock", "quiescent", "none"];
       for (const drain of advisoryDrains) {
         const fixture = await createConformancePostgresFixture();
         try {
@@ -366,7 +364,6 @@ export function registerWriteFenceConformanceIntegrationTests(
         const backend = createSqlBackend(
           deriveWriteFenceProfile(fixture.profile, {
             mechanism: "caller-serialized",
-            drain: "quiescent",
           }),
         );
         await backend.transaction(async (tx) => {
@@ -454,11 +451,10 @@ export function registerWriteFenceConformanceIntegrationTests(
           ctx.skip();
           return;
         }
-        const advisoryDrains: readonly WriteFenceDeclaration["drain"][] = [
-          "table-lock",
-          "quiescent",
-          "none",
-        ];
+        const advisoryDrains: readonly Extract<
+          WriteFenceDeclaration,
+          { mechanism: "advisory" }
+        >["drain"][] = ["table-lock", "quiescent", "none"];
         for (const drain of advisoryDrains) {
           const connectionA = await context.createSerializedBackend();
           const connectionB = await context.createSerializedBackend();

--- a/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
+++ b/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
@@ -94,8 +94,7 @@ function postgresServerLaneAvailable(): boolean {
 /**
  * Overrides a real `buildPostgresEngineProfile` result's declared write
  * fence through `deriveEngineProfile` — never a hand-copied profile
- * literal — clearing the legacy `pessimisticLocks` the bundled builder
- * injects so the two declarations never collide.
+ * literal.
  */
 function deriveWriteFenceProfile(
   base: SqlEngineProfile<AnyPgTransaction>,
@@ -105,7 +104,6 @@ function deriveWriteFenceProfile(
   return deriveEngineProfile(base, {
     declaredCapabilities: {
       ...base.declaredCapabilities,
-      pessimisticLocks: undefined,
       writeFence,
     },
     ...(fenceSqlOverride === undefined ? {} : { fenceSql: fenceSqlOverride }),
@@ -118,7 +116,6 @@ function withAdvisoryDrainCapabilities(
 ): BackendCapabilities {
   return {
     ...capabilities,
-    pessimisticLocks: undefined,
     writeFence: { mechanism: "advisory", drain },
   };
 }
@@ -210,7 +207,7 @@ export function registerWriteFenceConformanceIntegrationTests(
       const plan = resolveWriteFencePlan(backend);
       const expectedPlan =
         backend.dialect === "postgres" ?
-          { kind: "lock", drain: "table-lock", tableLocks: true }
+          { kind: "lock", drain: "table-lock" }
         : { kind: "engine-serialized" };
       expect(plan).toMatchObject(expectedPlan);
     });
@@ -242,7 +239,6 @@ export function registerWriteFenceConformanceIntegrationTests(
           expect.objectContaining({
             kind: "lock",
             drain: "quiescent",
-            tableLocks: false,
           }),
         );
 
@@ -308,7 +304,6 @@ export function registerWriteFenceConformanceIntegrationTests(
           expect.objectContaining({
             kind: "lock",
             drain: "none",
-            tableLocks: false,
           }),
         );
 

--- a/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
+++ b/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
@@ -491,6 +491,9 @@ export function registerWriteFenceConformanceIntegrationTests(
             let holderFinished = false;
             const holderTransaction = backendA
               .transaction(async (tx) => {
+                // The override must reach the transaction handle the lock
+                // site actually resolves, not only the root proxy.
+                expect(resolveWriteFencePlan(tx)).toMatchObject({ drain });
                 await lockIdentityGraph(tx, graphId);
                 await tx.execute(
                   asCompiledRowsSql(sql`

--- a/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
+++ b/packages/typegraph/tests/backends/integration/write-fence-conformance.ts
@@ -1,0 +1,627 @@
+/**
+ * Conformance coverage for the write-fence declaration: does a real backend
+ * built from a given `mechanism`/`drain` pair actually behave the way that
+ * declaration promises, end to end, rather than only at the level of the
+ * pure `resolveWriteFencePlan`/`requireWriteFence` functions (already
+ * covered exhaustively by `tests/lock-fence-plan.test.ts`)?
+ *
+ * Five configurations: this lane's own bundled backend (PostgreSQL resolves
+ * `{advisory, table-lock}`; SQLite resolves `engine-serialized`), plus three
+ * backends derived from `buildPostgresEngineProfile` through
+ * `deriveEngineProfile` with `declaredCapabilities.writeFence` overridden —
+ * `{advisory, quiescent}`, `{caller-serialized, quiescent}`, and
+ * `{advisory, none}`. Every derived case only applies on a PostgreSQL-dialect
+ * lane (SQLite and libsql skip it: there is no SQLite equivalent of "a
+ * PostgreSQL profile with a different drain").
+ *
+ * Three things are checked wherever the configuration makes them
+ * meaningful: a keyed acquisition blocks a concurrent acquisition of the
+ * same key, and the read that follows observes the previous holder's
+ * commit; a drain site (the identity-enablement node
+ * lock, `lockIdentityEnablementNodes`) takes the table lock under
+ * `"table-lock"`, takes no statement under `"quiescent"`, and refuses naming
+ * the drain under `"none"`; and the session's real isolation level reaches
+ * the coordination token `lockRecordedGraphWrite` mints, which match-key
+ * convergence later reads back.
+ *
+ * Two of those need genuinely independent physical connections to mean
+ * anything (a single-process engine cannot demonstrate one session blocking
+ * another), so they run only when `POSTGRES_URL` is set — the same real
+ * PostgreSQL a caller gets from `pnpm test:postgres`. Rather than provision a
+ * database of their own (this module is imported by every lane's shared
+ * suite at once, so a module-scoped `provisionPostgresTestDatabase` call
+ * would race every one of those lanes over the SAME isolated database name),
+ * they reuse `context.createSerializedBackend()` twice: two independent
+ * connections to the CURRENT lane's own already-migrated database. Every
+ * other assertion needs only one live PostgreSQL-dialect connection and runs
+ * on an in-process PGlite client, so it exercises every PostgreSQL-dialect
+ * lane (the Docker lane, the `postgres-js` lane, and the zero-Docker PGlite
+ * lane) without any of them needing `POSTGRES_URL`.
+ *
+ * `row` (the portable, non-advisory keyed fence) is a later mechanism and is
+ * out of scope here.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  type FenceSql,
+  resolveWriteFencePlan,
+  type WriteFenceDeclaration,
+} from "../../../src/backend/capabilities/write-fence";
+import {
+  assertGraphCommandConvergenceIsolation,
+  graphCommandCoordinationIsolation,
+  mintGraphCommandCoordination,
+} from "../../../src/backend/command-contract";
+import { deriveBackend } from "../../../src/backend/derive-backend";
+import { generateVectorlessPostgresMigrationSQL } from "../../../src/backend/drizzle/ddl";
+import {
+  createSqlBackend,
+  deriveEngineProfile,
+  type SqlEngineProfile,
+} from "../../../src/backend/drizzle/engine";
+import { type AnyPgTransaction } from "../../../src/backend/drizzle/execution/postgres-execution";
+import { buildPostgresEngineProfile } from "../../../src/backend/drizzle/postgres";
+import { postgresFenceSql } from "../../../src/backend/drizzle/postgres-fence-sql";
+import {
+  type BackendCapabilities,
+  type GraphBackend,
+} from "../../../src/backend/types";
+import {
+  lockIdentityEnablementNodes,
+  lockIdentityGraph,
+} from "../../../src/identity/service-read";
+import { createSqlSchema } from "../../../src/query/compiler/schema";
+import { sql } from "../../../src/query/sql-fragment";
+import { asCompiledRowsSql } from "../../../src/query/sql-intent";
+import { lockRecordedGraphWrite } from "../../../src/store/recorded-capture";
+import { generateId } from "../../../src/utils/id";
+import { requireDefined } from "../../../src/utils/presence";
+import { createLoggedPgliteClient } from "../../lock-fence-test-utils";
+import { type IntegrationTestContext } from "./test-context";
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+function postgresServerLaneAvailable(): boolean {
+  const configured = process.env["POSTGRES_URL"];
+  return configured !== undefined && configured !== "";
+}
+
+/**
+ * Overrides a real `buildPostgresEngineProfile` result's declared write
+ * fence through `deriveEngineProfile` — never a hand-copied profile
+ * literal — clearing the legacy `pessimisticLocks` the bundled builder
+ * injects so the two declarations never collide.
+ */
+function deriveWriteFenceProfile(
+  base: SqlEngineProfile<AnyPgTransaction>,
+  writeFence: WriteFenceDeclaration,
+  fenceSqlOverride?: FenceSql,
+): SqlEngineProfile<AnyPgTransaction> {
+  return deriveEngineProfile(base, {
+    declaredCapabilities: {
+      ...base.declaredCapabilities,
+      pessimisticLocks: undefined,
+      writeFence,
+    },
+    ...(fenceSqlOverride === undefined ? {} : { fenceSql: fenceSqlOverride }),
+  });
+}
+
+function withAdvisoryDrainCapabilities(
+  capabilities: BackendCapabilities,
+  drain: WriteFenceDeclaration["drain"],
+): BackendCapabilities {
+  return {
+    ...capabilities,
+    pessimisticLocks: undefined,
+    writeFence: { mechanism: "advisory", drain },
+  };
+}
+
+/**
+ * Overrides an already-live backend's declared write fence in place, through
+ * `deriveBackend` — never a spread — for the two real-connection tests below,
+ * which have a ready-made `GraphBackend` from
+ * `context.createSerializedBackend()` rather than the raw Drizzle database a
+ * profile needs to be built from.
+ *
+ * `deriveBackend` decorates the ROOT object only: `transaction` still
+ * delegates to the base factory's own closure, which builds its `tx`
+ * argument from the capabilities it closed over at construction, not from
+ * whatever this wrapper's `capabilities` property reports. So the override
+ * also replaces `transaction` itself, deriving the SAME override onto the
+ * `tx` handle the real implementation hands to its callback — every lock
+ * site a test below reaches runs inside `backend.transaction(...)`, and
+ * without this the override would never reach `resolveWriteFencePlan` at
+ * all. Each level re-derives from its OWN base capabilities (root's, or the
+ * live transaction's) rather than reusing one captured copy, so a real
+ * transaction's own `execution.atomicBatch: "session"` fact survives the
+ * override instead of being replaced by the root's `"none"`.
+ */
+function deriveAdvisoryDrainOverride(
+  backend: GraphBackend,
+  drain: WriteFenceDeclaration["drain"],
+): GraphBackend {
+  return deriveBackend(backend, {
+    capabilities: withAdvisoryDrainCapabilities(backend.capabilities, drain),
+    transaction: (fn, options) =>
+      backend.transaction(
+        (tx) =>
+          fn(
+            deriveBackend(tx, {
+              capabilities: withAdvisoryDrainCapabilities(
+                tx.capabilities,
+                drain,
+              ),
+            }),
+          ),
+        options,
+      ),
+  });
+}
+
+type ConformanceStatement = Readonly<{
+  query: string;
+  params: readonly unknown[];
+}>;
+
+/**
+ * A real, in-process PostgreSQL-dialect connection (PGlite, no Docker), built
+ * from the one shared capture primitive
+ * (`tests/lock-fence-test-utils.ts`'s `createLoggedPgliteClient`) rather than
+ * a second, independent driver-patch-plus-logger implementation — as a
+ * profile rather than a backend, so a test can derive it through
+ * `deriveEngineProfile` afterward. Seeded with
+ * `generateVectorlessPostgresMigrationSQL`, the same DDL source
+ * `buildPostgresEngineProfile`'s own `{ vector: false }` call below declares
+ * this backend runs without.
+ */
+async function createConformancePostgresFixture(): Promise<
+  Readonly<{
+    profile: SqlEngineProfile<AnyPgTransaction>;
+    statements: ConformanceStatement[];
+    close: () => Promise<void>;
+  }>
+> {
+  const { db, statements, close } = await createLoggedPgliteClient({
+    ddl: generateVectorlessPostgresMigrationSQL(),
+  });
+  const profile = buildPostgresEngineProfile(db, { vector: false });
+  return { profile, statements, close };
+}
+
+function capturedLockTableStatement(
+  statements: readonly ConformanceStatement[],
+): boolean {
+  return statements.some((statement) => statement.query.includes("LOCK TABLE"));
+}
+
+export function registerWriteFenceConformanceIntegrationTests(
+  context: IntegrationTestContext,
+): void {
+  describe("write-fence conformance: mechanism and drain, end to end", () => {
+    it("resolves this lane's own bundled mechanism and drain", () => {
+      const backend = context.getBackend();
+      const plan = resolveWriteFencePlan(backend);
+      const expectedPlan =
+        backend.dialect === "postgres" ?
+          { kind: "lock", drain: "table-lock", tableLocks: true }
+        : { kind: "engine-serialized" };
+      expect(plan).toMatchObject(expectedPlan);
+    });
+
+    it("the identity-enablement drain site behaves per the bundled mechanism", async () => {
+      const backend = context.getBackend();
+      const schema = createSqlSchema();
+      const attempt =
+        backend.dialect === "sqlite" ?
+          lockIdentityEnablementNodes(backend, schema)
+        : backend.transaction((tx) => lockIdentityEnablementNodes(tx, schema));
+      await expect(attempt).resolves.toBeUndefined();
+    });
+
+    it('derived PostgreSQL profile {advisory, quiescent}: resolves "quiescent" and the drain site takes no table lock', async (ctx) => {
+      if (context.getBackend().dialect !== "postgres") {
+        ctx.skip();
+        return;
+      }
+      const fixture = await createConformancePostgresFixture();
+      try {
+        const backend = createSqlBackend(
+          deriveWriteFenceProfile(fixture.profile, {
+            mechanism: "advisory",
+            drain: "quiescent",
+          }),
+        );
+        expect(resolveWriteFencePlan(backend)).toEqual(
+          expect.objectContaining({
+            kind: "lock",
+            drain: "quiescent",
+            tableLocks: false,
+          }),
+        );
+
+        fixture.statements.splice(0);
+        const schema = createSqlSchema();
+        await backend.transaction((tx) =>
+          lockIdentityEnablementNodes(tx, schema),
+        );
+        expect(capturedLockTableStatement(fixture.statements)).toBe(false);
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it('derived PostgreSQL profile {caller-serialized, quiescent}: resolves "caller-serialized" and the drain site takes no statement', async (ctx) => {
+      if (context.getBackend().dialect !== "postgres") {
+        ctx.skip();
+        return;
+      }
+      const fixture = await createConformancePostgresFixture();
+      try {
+        const backend = createSqlBackend(
+          deriveWriteFenceProfile(fixture.profile, {
+            mechanism: "caller-serialized",
+            drain: "quiescent",
+          }),
+        );
+        expect(resolveWriteFencePlan(backend)).toEqual({
+          kind: "caller-serialized",
+        });
+
+        fixture.statements.splice(0);
+        const schema = createSqlSchema();
+        await backend.transaction((tx) =>
+          lockIdentityEnablementNodes(tx, schema),
+        );
+        expect(
+          fixture.statements.some(
+            (statement) =>
+              statement.query.includes("LOCK TABLE") ||
+              statement.query.includes("pg_advisory"),
+          ),
+        ).toBe(false);
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it('derived PostgreSQL profile {advisory, none}: resolves "none" and the drain site refuses, naming the drain', async (ctx) => {
+      if (context.getBackend().dialect !== "postgres") {
+        ctx.skip();
+        return;
+      }
+      const fixture = await createConformancePostgresFixture();
+      try {
+        const backend = createSqlBackend(
+          deriveWriteFenceProfile(fixture.profile, {
+            mechanism: "advisory",
+            drain: "none",
+          }),
+        );
+        expect(resolveWriteFencePlan(backend)).toEqual(
+          expect.objectContaining({
+            kind: "lock",
+            drain: "none",
+            tableLocks: false,
+          }),
+        );
+
+        const schema = createSqlSchema();
+        await expect(
+          backend.transaction((tx) => lockIdentityEnablementNodes(tx, schema)),
+        ).rejects.toEqual(
+          expect.objectContaining({
+            details: expect.objectContaining({
+              code: "WRITE_FENCE_UNAVAILABLE",
+            }) as unknown,
+          }),
+        );
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it("the session's real isolation reaches the coordination token for every advisory-mechanism config, and never for caller-serialized", async (ctx) => {
+      if (context.getBackend().dialect !== "postgres") {
+        ctx.skip();
+        return;
+      }
+      const advisoryDrains: readonly WriteFenceDeclaration["drain"][] = [
+        "table-lock",
+        "quiescent",
+        "none",
+      ];
+      for (const drain of advisoryDrains) {
+        const fixture = await createConformancePostgresFixture();
+        try {
+          const backend = createSqlBackend(
+            deriveWriteFenceProfile(fixture.profile, {
+              mechanism: "advisory",
+              drain,
+            }),
+          );
+          const graphId = `write-fence-conformance-${generateId()}`;
+          await backend.transaction(async (tx) => {
+            const lock = await lockRecordedGraphWrite(tx, graphId);
+            const coordination = requireDefined(
+              lock.coordination,
+              "an advisory-mechanism lock always mints coordination",
+            );
+            expect(
+              graphCommandCoordinationIsolation(
+                tx.commands,
+                graphId,
+                coordination,
+              ),
+            ).toBe("read_committed");
+          });
+        } finally {
+          await fixture.close();
+        }
+      }
+
+      const fixture = await createConformancePostgresFixture();
+      try {
+        const backend = createSqlBackend(
+          deriveWriteFenceProfile(fixture.profile, {
+            mechanism: "caller-serialized",
+            drain: "quiescent",
+          }),
+        );
+        await backend.transaction(async (tx) => {
+          const lock = await lockRecordedGraphWrite(
+            tx,
+            `write-fence-conformance-${generateId()}`,
+          );
+          // No key was ever acquired, so there is nothing to certify: a
+          // caller-serialized mechanism never mints a coordination token.
+          expect(lock.coordination).toBeUndefined();
+        });
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    it("a target with no isolationFactExpression refuses at construction, and an uncertified coordination refuses convergence", async (ctx) => {
+      if (context.getBackend().dialect !== "postgres") {
+        ctx.skip();
+        return;
+      }
+      const fixture = await createConformancePostgresFixture();
+      try {
+        const incompleteFenceSql = {
+          advisoryLockExpression: postgresFenceSql.advisoryLockExpression,
+          lockTables: postgresFenceSql.lockTables,
+        } as unknown as FenceSql;
+
+        // `createSqlBackend` resolves the write-fence plan eagerly at
+        // construction (the same gate that lets both bundled factories
+        // refuse an incomplete `fenceSql` before a caller can reach it), so
+        // this declaration never produces a usable backend to test
+        // `lockRecordedGraphWrite` against — the refusal is synchronous,
+        // right here.
+        expect(() =>
+          createSqlBackend(
+            deriveWriteFenceProfile(
+              fixture.profile,
+              { mechanism: "advisory", drain: "table-lock" },
+              incompleteFenceSql,
+            ),
+          ),
+        ).toThrow(
+          expect.objectContaining({
+            details: expect.objectContaining({
+              code: "WRITE_FENCE_SQL_UNAVAILABLE",
+              member: "isolationFactExpression",
+            }) as unknown,
+          }),
+        );
+
+        // A coordination that never had a real isolation fact read into it
+        // (exactly what the target above could never have produced, since it
+        // cannot even be constructed) fails match-key convergence's own gate
+        // the same way — the fact never reaches the token, so convergence
+        // never trusts it. Any working command port demonstrates the gate;
+        // this reuses the fixture's own default-declared backend rather than
+        // building a third one.
+        const backend = createSqlBackend(fixture.profile);
+        const uncertified = mintGraphCommandCoordination(
+          backend.commands,
+          "write-fence-conformance-uncertified",
+          "unknown",
+        );
+        expect(() => {
+          assertGraphCommandConvergenceIsolation(backend.commands, uncertified);
+        }).toThrow(
+          expect.objectContaining({
+            details: expect.objectContaining({
+              code: "MATCH_KEY_CONVERGENCE_REQUIRES_FRESH_SNAPSHOT",
+            }) as unknown,
+          }),
+        );
+      } finally {
+        await fixture.close();
+      }
+    });
+
+    describe("server-lane concurrency (requires POSTGRES_URL: a single process cannot demonstrate one session blocking another)", () => {
+      it("a keyed advisory acquisition blocks a concurrent acquisition of the same key and then sees its commit, under every advisory-mechanism drain", async (ctx) => {
+        if (
+          context.getBackend().dialect !== "postgres" ||
+          !postgresServerLaneAvailable()
+        ) {
+          ctx.skip();
+          return;
+        }
+        const advisoryDrains: readonly WriteFenceDeclaration["drain"][] = [
+          "table-lock",
+          "quiescent",
+          "none",
+        ];
+        for (const drain of advisoryDrains) {
+          const connectionA = await context.createSerializedBackend();
+          const connectionB = await context.createSerializedBackend();
+          try {
+            const backendA = deriveAdvisoryDrainOverride(
+              connectionA.backend,
+              drain,
+            );
+            const backendB = deriveAdvisoryDrainOverride(
+              connectionB.backend,
+              drain,
+            );
+            const graphId = `write-fence-conformance-${generateId()}`;
+            const nodeId = generateId();
+            const marker = generateId();
+
+            // The two transactions below share ONE key (`graphId`), so if
+            // the advisory lock genuinely excludes a concurrent acquisition
+            // of that key, B cannot even start reading until A commits —
+            // sequential `await`s on two backends could never distinguish
+            // that from B simply running after A finished on its own.
+            // Mutation-proven: deleting the `advisoryLock` call from
+            // `lockIdentityGraph`'s `lock` arm (`src/identity/service-read.ts`)
+            // left `stillBlocked` false, since nothing then stopped B's
+            // transaction from starting immediately.
+            let releaseHolder: (() => void) | undefined;
+            const holdLockOpen = new Promise<void>((resolve) => {
+              releaseHolder = resolve;
+            });
+            let holderFinished = false;
+            const holderTransaction = backendA
+              .transaction(async (tx) => {
+                await lockIdentityGraph(tx, graphId);
+                await tx.execute(
+                  asCompiledRowsSql(sql`
+                    INSERT INTO typegraph_nodes
+                      (graph_id, kind, id, props, created_at, updated_at)
+                    VALUES
+                      ('write-fence-conformance', 'ConformanceProbe', ${nodeId}, ${JSON.stringify({ marker })}::jsonb, now(), now())
+                  `),
+                );
+                await holdLockOpen;
+              })
+              .then(() => {
+                holderFinished = true;
+              });
+
+            // No earlier signal than "the lock is actually held" is
+            // available from the driver, so this waits a fixed interval for
+            // connection A's advisory lock to land before connection B
+            // races it.
+            await delay(100);
+
+            const readerTransaction = backendB.transaction(async (tx) => {
+              await lockIdentityGraph(tx, graphId);
+              const rows = await tx.execute<{ props: { marker: string } }>(
+                asCompiledRowsSql(sql`
+                  SELECT props FROM typegraph_nodes
+                  WHERE graph_id = 'write-fence-conformance' AND id = ${nodeId}
+                `),
+              );
+              return rows[0]?.props.marker;
+            });
+
+            const stillBlocked = await Promise.race([
+              readerTransaction.then(() => false),
+              delay(300).then(() => true),
+            ]);
+            // Snapshot and release before asserting, exactly as the
+            // table-lock test below does: a failing `expect` must never
+            // leave connection A parked on `holdLockOpen` forever.
+            const holderFinishedBeforeRelease = holderFinished;
+            releaseHolder?.();
+            await holderTransaction;
+            const markerSeenByReader = await readerTransaction;
+
+            expect(stillBlocked).toBe(true);
+            expect(holderFinishedBeforeRelease).toBe(false);
+            expect(holderFinished).toBe(true);
+            expect(markerSeenByReader).toBe(marker);
+          } finally {
+            await connectionA.close();
+            await connectionB.close();
+          }
+        }
+      });
+
+      it("a table-lock drain blocks a concurrent row writer until the holder commits", async (ctx) => {
+        if (
+          context.getBackend().dialect !== "postgres" ||
+          !postgresServerLaneAvailable()
+        ) {
+          ctx.skip();
+          return;
+        }
+        const connectionA = await context.createSerializedBackend();
+        const connectionB = await context.createSerializedBackend();
+        try {
+          const backendA = connectionA.backend;
+          const backendB = connectionB.backend;
+          const schema = createSqlSchema();
+          const nodeId = generateId();
+
+          let releaseHolder: (() => void) | undefined;
+          const holdLockOpen = new Promise<void>((resolve) => {
+            releaseHolder = resolve;
+          });
+          let holderFinished = false;
+          const holderTransaction = backendA
+            .transaction(async (tx) => {
+              await lockIdentityEnablementNodes(tx, schema);
+              await holdLockOpen;
+            })
+            .then(() => {
+              holderFinished = true;
+            });
+
+          // No earlier signal than "the lock is actually held" is available
+          // from the driver, so this waits a fixed interval for connection
+          // A's `LOCK TABLE` to land before connection B races it.
+          await delay(100);
+
+          const writerTransaction = backendB.transaction((tx) =>
+            tx.execute(
+              asCompiledRowsSql(sql`
+                INSERT INTO typegraph_nodes
+                  (graph_id, kind, id, props, created_at, updated_at)
+                VALUES
+                  ('write-fence-conformance', 'ConformanceProbe', ${nodeId}, '{}'::jsonb, now(), now())
+              `),
+            ),
+          );
+
+          const stillBlocked = await Promise.race([
+            writerTransaction.then(() => false),
+            delay(300).then(() => true),
+          ]);
+          // Snapshot before releasing: if the drain never actually blocked
+          // (a broken guard), `writerTransaction` already settled above and
+          // holding the lock open any longer serves nothing. Releasing and
+          // awaiting both transactions BEFORE any assertion — rather than
+          // after — means a failing `expect` below never leaves connection
+          // A's transaction parked on `holdLockOpen` forever, which would
+          // otherwise hang this test's `finally` on a connection that can
+          // never close.
+          const holderFinishedBeforeRelease = holderFinished;
+          releaseHolder?.();
+          await holderTransaction;
+          await writerTransaction;
+
+          expect(stillBlocked).toBe(true);
+          expect(holderFinishedBeforeRelease).toBe(false);
+          expect(holderFinished).toBe(true);
+        } finally {
+          await connectionA.close();
+          await connectionB.close();
+        }
+      });
+    });
+  });
+}

--- a/packages/typegraph/tests/caller-serialized-queue.test.ts
+++ b/packages/typegraph/tests/caller-serialized-queue.test.ts
@@ -4,9 +4,10 @@
  * of the promise a `writeFence: { mechanism: "caller-serialized" }`
  * declaration makes — every write unit this backend issues is serialized
  * through one queue, reads are not, a root write submitted from inside a
- * transaction callback is refused rather than deadlocking, and the members
- * wrapped are exactly the write-member taxonomy plus the two transaction
- * openers.
+ * transaction callback is refused rather than deadlocking, adopting an
+ * externally owned transaction is refused outright, and the members wrapped
+ * are exactly the taxonomy's mutation-capable classes plus the two
+ * transaction openers.
  *
  * Both bundled dialects declare a `caller-serialized` write fence here
  * through `capabilities.writeFence` — the SAME override shape
@@ -14,8 +15,12 @@
  * factories accept it — so every case below exercises the real
  * `createSqlBackend` path, not a hand-built fixture.
  */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { PGlite } from "@electric-sql/pglite";
 import Database from "better-sqlite3";
 import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 import { afterEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
@@ -25,10 +30,20 @@ import {
   defineGraph,
   defineNode,
 } from "../src";
-import { buildCallerSerializedBackend } from "../src/backend/drizzle/engine/create-sql-backend";
+import {
+  buildCallerSerializedBackend,
+  QUEUED_ROOT_MEMBER_KEYS,
+  UNQUEUED_ROOT_MEMBER_REASONS,
+} from "../src/backend/drizzle/engine/create-sql-backend";
 import type { AnySqliteDatabase } from "../src/backend/drizzle/execution/sqlite-execution";
 import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
 import { GRAPH_BACKEND_MEMBER_CLASSES } from "../src/backend/member-classes";
+import { createPostgresBackend } from "../src/backend/postgres";
+import {
+  __restoreQueueTaskContextForTesting,
+  __setQueueTaskContextForTesting,
+  createSerializedExecutionQueue,
+} from "../src/backend/serialized-execution-queue";
 import { type AdapterBackend } from "../src/backend/types";
 import { WRITE_MEMBER_KEYS } from "../src/store/operations/write-members";
 import {
@@ -37,8 +52,8 @@ import {
   type LoggedBackend,
 } from "./lock-fence-test-utils";
 
-const CALLER_SERIALIZED_QUIESCENT = {
-  writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+const CALLER_SERIALIZED_CAPABILITIES = {
+  writeFence: { mechanism: "caller-serialized" },
 } as const;
 
 const QueuePerson = defineNode("Person", {
@@ -75,11 +90,13 @@ const QUEUED_ENGINES: readonly QueuedEngine[] = [
   {
     name: "sqlite",
     build: () =>
-      Promise.resolve(createLoggedSqliteBackend(CALLER_SERIALIZED_QUIESCENT)),
+      Promise.resolve(
+        createLoggedSqliteBackend(CALLER_SERIALIZED_CAPABILITIES),
+      ),
   },
   {
     name: "postgres",
-    build: () => createLoggedPostgresBackend(CALLER_SERIALIZED_QUIESCENT),
+    build: () => createLoggedPostgresBackend(CALLER_SERIALIZED_CAPABILITIES),
   },
 ];
 
@@ -121,16 +138,26 @@ describe.each(QUEUED_ENGINES)(
       expect(alphaThenBravo || bravoThenAlpha).toBe(true);
     });
 
-    it("refuses a root write submitted from inside a transaction callback", async () => {
+    it("refuses a root write submitted from inside a transaction callback, naming the reentrant-submission code and subject", async () => {
       const logged = await build();
       cleanups.push(logged.close);
       const [store] = await createStoreWithSchema(queueGraph, logged.backend);
 
-      await expect(
-        store.transaction(async () => {
+      let caught: unknown;
+      try {
+        await store.transaction(async () => {
           await store.nodes.Person.create({ name: "Reentrant" });
+        });
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ConfigurationError);
+      expect((caught as ConfigurationError).details).toEqual(
+        expect.objectContaining({
+          code: "SERIALIZED_QUEUE_REENTRANT_SUBMISSION",
+          subject: "caller-serialized",
         }),
-      ).rejects.toThrow(ConfigurationError);
+      );
 
       // The rejected transaction rolled back cleanly; the queue is not stuck
       // holding a slot the failed submission never released.
@@ -142,6 +169,136 @@ describe.each(QUEUED_ENGINES)(
     });
   },
 );
+
+// ============================================================
+// adoptTransaction is refused outright, not queued and not left unqueued.
+// ============================================================
+
+describe("adoptTransaction is refused under caller-serialized", () => {
+  it("sqlite: refuses with CALLER_SERIALIZED_REFUSES_ADOPTION", () => {
+    const client = new Database(":memory:");
+    try {
+      const backend = createSqliteBackend(drizzleBetterSqlite3(client), {
+        capabilities: CALLER_SERIALIZED_CAPABILITIES,
+      });
+      let caught: unknown;
+      try {
+        backend.adoptTransaction(undefined as unknown as AnySqliteDatabase);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ConfigurationError);
+      expect((caught as ConfigurationError).details).toEqual(
+        expect.objectContaining({
+          code: "CALLER_SERIALIZED_REFUSES_ADOPTION",
+          member: "adoptTransaction",
+        }),
+      );
+    } finally {
+      client.close();
+    }
+  });
+
+  it("postgres (PGlite): refuses with CALLER_SERIALIZED_REFUSES_ADOPTION", async () => {
+    const client = await PGlite.create();
+    try {
+      const backend = createPostgresBackend(drizzlePglite(client), {
+        capabilities: CALLER_SERIALIZED_CAPABILITIES,
+        vector: false,
+      });
+      let caught: unknown;
+      try {
+        backend.adoptTransaction(undefined as never);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ConfigurationError);
+      expect((caught as ConfigurationError).details).toEqual(
+        expect.objectContaining({
+          code: "CALLER_SERIALIZED_REFUSES_ADOPTION",
+          member: "adoptTransaction",
+        }),
+      );
+    } finally {
+      await client.close();
+    }
+  });
+});
+
+// ============================================================
+// Reentrancy detection modes: "detect" (best-effort, SQLite's own queue)
+// vs. "require" (the caller-serialized promise depends on it working).
+// ============================================================
+
+describe("serialized-execution-queue reentrancy modes", () => {
+  afterEach(() => {
+    __restoreQueueTaskContextForTesting();
+  });
+
+  it("require: refuses every submission with CALLER_SERIALIZED_REQUIRES_ASYNC_CONTEXT when the AsyncLocalStorage context is unavailable", async () => {
+    __setQueueTaskContextForTesting(undefined);
+    const queue = createSerializedExecutionQueue({
+      reentrancy: "require",
+      subject: "test-subject",
+    });
+
+    let caught: unknown;
+    try {
+      await queue.runExclusive(() => Promise.resolve("ok"));
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(ConfigurationError);
+    expect((caught as ConfigurationError).details).toEqual(
+      expect.objectContaining({
+        code: "CALLER_SERIALIZED_REQUIRES_ASYNC_CONTEXT",
+        subject: "test-subject",
+      }),
+    );
+  });
+
+  it("detect: runs the task without detection when the AsyncLocalStorage context is unavailable", async () => {
+    __setQueueTaskContextForTesting(undefined);
+    const queue = createSerializedExecutionQueue({
+      reentrancy: "detect",
+      subject: "test-subject",
+    });
+
+    await expect(queue.runExclusive(() => Promise.resolve("ok"))).resolves.toBe(
+      "ok",
+    );
+  });
+
+  it("require: a submission made before the AsyncLocalStorage loader resolves still detects a nested reentrant submission", async () => {
+    const realContext = new AsyncLocalStorage<ReadonlySet<object>>();
+    // The loader "resolves" 20ms after this queue is constructed — the
+    // submission below is made synchronously, well before that.
+    __setQueueTaskContextForTesting(realContext, 20);
+    const queue = createSerializedExecutionQueue({
+      reentrancy: "require",
+      subject: "test-subject",
+    });
+
+    let nestedError: unknown;
+    const outerResult = queue.runExclusive(async () => {
+      try {
+        await queue.runExclusive(() => Promise.resolve("nested"));
+      } catch (error) {
+        nestedError = error;
+      }
+      return "outer-done";
+    });
+
+    await expect(outerResult).resolves.toBe("outer-done");
+    expect(nestedError).toBeInstanceOf(ConfigurationError);
+    expect((nestedError as ConfigurationError).details).toEqual(
+      expect.objectContaining({
+        code: "SERIALIZED_QUEUE_REENTRANT_SUBMISSION",
+        subject: "test-subject",
+      }),
+    );
+  });
+});
 
 // Racing two root writes' internal steps, or a read against a slow root
 // write, through a REAL driver is not a clean proof either way: both
@@ -258,18 +415,12 @@ describe("caller-serialized queue: reads bypass it", () => {
 });
 
 // ============================================================
-// Direct proof that the wrapping covers exactly the write-member taxonomy
-// plus the two transaction openers, and nothing else — isolated from the
-// closures `createSqlBackend` builds fresh on every construction (see
-// `buildCallerSerializedBackend`'s own doc comment for why this needs a
-// single shared base object rather than two independent backends).
+// Direct proof that the wrapping covers exactly QUEUED_ROOT_MEMBER_KEYS,
+// isolated from the closures `createSqlBackend` builds fresh on every
+// construction (see `buildCallerSerializedBackend`'s own doc comment for why
+// this needs a single shared base object rather than two independent
+// backends).
 // ============================================================
-
-const QUEUED_ROOT_MEMBER_KEYS = [
-  ...WRITE_MEMBER_KEYS,
-  "transaction",
-  "transactionWithNative",
-] as const;
 
 function buildPlainSqliteBackend(): Readonly<{
   backend: AdapterBackend<AnySqliteDatabase>;
@@ -287,18 +438,18 @@ function buildPlainSqliteBackend(): Readonly<{
 }
 
 describe("buildCallerSerializedBackend member coverage", () => {
-  it("wraps every taxonomy write member and the two transaction openers, and leaves every read member alone", () => {
+  it("wraps every QUEUED_ROOT_MEMBER_KEYS member this backend implements, replaces adoptTransaction, and leaves every read/identity member alone", () => {
     const { backend: plainBackend, close } = buildPlainSqliteBackend();
     cleanups.push(close);
     const queuedBackend = buildCallerSerializedBackend(plainBackend);
 
     const wrapped: string[] = [];
     const untouched: string[] = [];
-    // Every taxonomy write member this plain SQLite backend actually
-    // implements — an in-memory backend with no vector strategy omits the
-    // OPTIONAL embedding members, exactly as `buildQueuedWriteUnits` itself
-    // skips a member `Reflect.get` reports as absent, so the set this test
-    // expects to see wrapped is the same subset, not the full taxonomy.
+    // Every QUEUED_ROOT_MEMBER_KEYS member this plain SQLite backend
+    // actually implements — an in-memory backend with no vector strategy
+    // omits the OPTIONAL embedding members, exactly as `buildQueuedWriteUnits`
+    // itself skips a member `Reflect.get` reports as absent, so the set this
+    // test expects to see wrapped is that subset, not the full list.
     const implementedKeys = QUEUED_ROOT_MEMBER_KEYS.filter(
       (key) =>
         key === "commands" ||
@@ -321,10 +472,84 @@ describe("buildCallerSerializedBackend member coverage", () => {
     expect(wrapped.toSorted()).toEqual([...implementedKeys].toSorted());
     expect(queuedCommandsExecute).not.toBe(plainCommandsExecute);
 
-    for (const key of GRAPH_BACKEND_MEMBER_CLASSES.read) {
+    // adoptTransaction is REPLACED (with the refusal), not merely absent
+    // from the wrap loop above and left to fall through to the plain
+    // backend's own implementation.
+    expect(queuedBackend.adoptTransaction).not.toBe(
+      plainBackend.adoptTransaction,
+    );
+
+    for (const key of [
+      ...GRAPH_BACKEND_MEMBER_CLASSES.read,
+      ...GRAPH_BACKEND_MEMBER_CLASSES.identity,
+    ]) {
       const plainMember: unknown = Reflect.get(plainBackend, key);
       if (typeof plainMember !== "function") continue;
       expect(Reflect.get(queuedBackend, key)).toBe(plainMember);
     }
+  });
+});
+
+// ============================================================
+// Totality ratchet: every member the taxonomy classifies (plus the two
+// `AdapterBackend`-only members `transactionWithNative`/`adoptTransaction`)
+// falls into EXACTLY ONE of QUEUED_ROOT_MEMBER_KEYS or
+// UNQUEUED_ROOT_MEMBER_REASONS, so a member reclassified into a
+// mutation-capable class, or a brand-new backend member, cannot land
+// unqueued (or double-counted) silently.
+//
+// Mutation check: delete the `close` entry from
+// `UNQUEUED_ROOT_MEMBER_REASONS` in create-sql-backend.ts — `close` then
+// appears in neither bucket and the "every member is covered" assertion
+// below fails, naming `close` as uncovered. Restoring the entry passes
+// again.
+// ============================================================
+
+const ASSEMBLED_ROOT_MEMBER_KEYS: readonly string[] = [
+  ...Object.values(GRAPH_BACKEND_MEMBER_CLASSES).flat(),
+  "transactionWithNative",
+  "adoptTransaction",
+];
+
+describe("caller-serialized queue: total member inventory", () => {
+  it("QUEUED_ROOT_MEMBER_KEYS is exactly the mutation-capable classes and the two transaction openers, matching WRITE_MEMBER_KEYS at minimum", () => {
+    const queuedSet = new Set<string>(QUEUED_ROOT_MEMBER_KEYS);
+    for (const key of WRITE_MEMBER_KEYS) {
+      expect(queuedSet.has(key)).toBe(true);
+    }
+    expect(queuedSet.has("transaction")).toBe(true);
+    expect(queuedSet.has("transactionWithNative")).toBe(true);
+    expect(queuedSet.has("clearGraph")).toBe(true);
+  });
+
+  it("partitions every assembled-root member into queued or a documented unqueued reason, with no member in both", () => {
+    const queuedSet = new Set<string>(QUEUED_ROOT_MEMBER_KEYS);
+    const unqueuedKeys = Object.keys(UNQUEUED_ROOT_MEMBER_REASONS);
+    const unqueuedSet = new Set(unqueuedKeys);
+    const assembledSet = new Set(ASSEMBLED_ROOT_MEMBER_KEYS);
+
+    const overlap = [...queuedSet].filter((key) => unqueuedSet.has(key));
+    expect(overlap).toEqual([]);
+
+    const uncovered = ASSEMBLED_ROOT_MEMBER_KEYS.filter(
+      (key) => !queuedSet.has(key) && !unqueuedSet.has(key),
+    );
+    expect(uncovered).toEqual([]);
+
+    const stray = [...queuedSet, ...unqueuedSet].filter(
+      (key) => !assembledSet.has(key),
+    );
+    expect(stray).toEqual([]);
+
+    for (const reason of Object.values(UNQUEUED_ROOT_MEMBER_REASONS)) {
+      expect(reason.length).toBeGreaterThan(10);
+    }
+  });
+
+  it("adoptTransaction is the one member documented as refused rather than queued or silently unqueued", () => {
+    expect(QUEUED_ROOT_MEMBER_KEYS).not.toContain("adoptTransaction");
+    expect(UNQUEUED_ROOT_MEMBER_REASONS["adoptTransaction"]).toMatch(
+      /refused/i,
+    );
   });
 });

--- a/packages/typegraph/tests/caller-serialized-queue.test.ts
+++ b/packages/typegraph/tests/caller-serialized-queue.test.ts
@@ -1,0 +1,330 @@
+/**
+ * `createSqlBackend`'s `caller-serialized` write-fence queue
+ * (`src/backend/drizzle/engine/create-sql-backend.ts`): the in-process half
+ * of the promise a `writeFence: { mechanism: "caller-serialized" }`
+ * declaration makes — every write unit this backend issues is serialized
+ * through one queue, reads are not, a root write submitted from inside a
+ * transaction callback is refused rather than deadlocking, and the members
+ * wrapped are exactly the write-member taxonomy plus the two transaction
+ * openers.
+ *
+ * Both bundled dialects declare a `caller-serialized` write fence here
+ * through `capabilities.writeFence` — the SAME override shape
+ * `tests/engine-profile-refusals.test.ts` uses to prove the two bundled
+ * factories accept it — so every case below exercises the real
+ * `createSqlBackend` path, not a hand-built fixture.
+ */
+import Database from "better-sqlite3";
+import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import {
+  ConfigurationError,
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "../src";
+import { buildCallerSerializedBackend } from "../src/backend/drizzle/engine/create-sql-backend";
+import type { AnySqliteDatabase } from "../src/backend/drizzle/execution/sqlite-execution";
+import { createSqliteBackend } from "../src/backend/drizzle/sqlite";
+import { GRAPH_BACKEND_MEMBER_CLASSES } from "../src/backend/member-classes";
+import { type AdapterBackend } from "../src/backend/types";
+import { WRITE_MEMBER_KEYS } from "../src/store/operations/write-members";
+import {
+  createLoggedPostgresBackend,
+  createLoggedSqliteBackend,
+  type LoggedBackend,
+} from "./lock-fence-test-utils";
+
+const CALLER_SERIALIZED_QUIESCENT = {
+  writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+} as const;
+
+const QueuePerson = defineNode("Person", {
+  schema: z.object({ name: z.string() }),
+});
+
+const queueGraph = defineGraph({
+  id: "caller_serialized_queue",
+  nodes: { Person: { type: QueuePerson } },
+  edges: {},
+});
+
+const cleanups: (() => void | Promise<void>)[] = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+
+/** Every statement in `logged` whose params (JSON-stringified) mention `needle`. */
+function statementIndicesMentioning(
+  logged: LoggedBackend,
+  needle: string,
+): number[] {
+  return logged.statements.flatMap((statement, index) =>
+    JSON.stringify(statement.params).includes(needle) ? [index] : [],
+  );
+}
+
+type QueuedEngine = Readonly<{
+  name: "sqlite" | "postgres";
+  build: () => Promise<LoggedBackend>;
+}>;
+
+const QUEUED_ENGINES: readonly QueuedEngine[] = [
+  {
+    name: "sqlite",
+    build: () =>
+      Promise.resolve(createLoggedSqliteBackend(CALLER_SERIALIZED_QUIESCENT)),
+  },
+  {
+    name: "postgres",
+    build: () => createLoggedPostgresBackend(CALLER_SERIALIZED_QUIESCENT),
+  },
+];
+
+describe.each(QUEUED_ENGINES)(
+  "caller-serialized queue ($name)",
+  ({ build }) => {
+    it("never interleaves two concurrent root creates' statements", async () => {
+      const logged = await build();
+      cleanups.push(logged.close);
+      const [store] = await createStoreWithSchema(queueGraph, logged.backend);
+      logged.reset();
+
+      await Promise.all([
+        store.nodes.Person.create({ name: "QueueOrderAlpha" }),
+        store.nodes.Person.create({ name: "QueueOrderBravo" }),
+      ]);
+
+      const alphaIndices = statementIndicesMentioning(
+        logged,
+        "QueueOrderAlpha",
+      );
+      const bravoIndices = statementIndicesMentioning(
+        logged,
+        "QueueOrderBravo",
+      );
+      expect(alphaIndices.length).toBeGreaterThan(0);
+      expect(bravoIndices.length).toBeGreaterThan(0);
+
+      const lastAlpha = Math.max(...alphaIndices);
+      const firstBravo = Math.min(...bravoIndices);
+      const lastBravo = Math.max(...bravoIndices);
+      const firstAlpha = Math.min(...alphaIndices);
+
+      // Whichever create the queue ran first, EVERY one of its statements —
+      // through its commit — precedes every statement of the other: the two
+      // index ranges never overlap.
+      const alphaThenBravo = lastAlpha < firstBravo;
+      const bravoThenAlpha = lastBravo < firstAlpha;
+      expect(alphaThenBravo || bravoThenAlpha).toBe(true);
+    });
+
+    it("refuses a root write submitted from inside a transaction callback", async () => {
+      const logged = await build();
+      cleanups.push(logged.close);
+      const [store] = await createStoreWithSchema(queueGraph, logged.backend);
+
+      await expect(
+        store.transaction(async () => {
+          await store.nodes.Person.create({ name: "Reentrant" });
+        }),
+      ).rejects.toThrow(ConfigurationError);
+
+      // The rejected transaction rolled back cleanly; the queue is not stuck
+      // holding a slot the failed submission never released.
+      await store.nodes.Person.create({ name: "AfterRejection" });
+      const people = await store.nodes.Person.find({ limit: 10 });
+      expect(people.map((person) => person.name).toSorted()).toEqual([
+        "AfterRejection",
+      ]);
+    });
+  },
+);
+
+// Racing two root writes' internal steps, or a read against a slow root
+// write, through a REAL driver is not a clean proof either way: both
+// bundled dialects self-serialize independently of this feature — PGlite
+// processes every `.query()`/`.transaction()` call on its one client through
+// its own internal queue, and better-sqlite3's per-connection queue
+// (`sqlite.ts`, unrelated to `buildCallerSerializedBackend`) already
+// serializes every `transaction()` call — so two concurrent root creates
+// never interleaving, or a slow write blocking a read, would be true with or
+// without the wrapping this suite targets; dropping the queue could not
+// reveal that. A minimal stub backend sidesteps this: `insertNode` and
+// `getNode` are the only two members with a real implementation, so any
+// ordering or blocking observed can only be evidence about the wrapping
+// itself, and removing it changes these tests' outcome for real.
+type StubBackendMember = (...args: readonly unknown[]) => Promise<unknown>;
+
+function notUsedStubMember(): Promise<never> {
+  return Promise.reject(new Error("not used by this test"));
+}
+
+function buildStubBackend(
+  members: Readonly<{
+    insertNode: StubBackendMember;
+    getNode: StubBackendMember;
+  }>,
+): AdapterBackend<unknown> {
+  const notUsed: StubBackendMember = notUsedStubMember;
+  const stub = {
+    dialect: "sqlite",
+    commands: { session: "root" as const, execute: notUsed },
+    insertNode: members.insertNode,
+    getNode: members.getNode,
+    transaction: notUsed,
+    transactionWithNative: notUsed,
+    close: () => Promise.resolve(),
+  };
+  // Deliberately partial: `buildQueuedWriteUnits` reads every member through
+  // `Reflect.get` and skips whatever is absent, so a stub naming only the
+  // two members this test exercises is a faithful (if minimal) backend for
+  // it, not a shortcut around real member resolution.
+  return stub as unknown as AdapterBackend<unknown>;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("caller-serialized queue: write serialization (stub)", () => {
+  it("never interleaves two concurrent queued writes' internal steps", async () => {
+    const steps: string[] = [];
+    // Each call logs a step, YIELDS (twice), then logs the next — real room
+    // for a second concurrent call's steps to land in between if this
+    // backend's `insertNode` were not routed through one queue.
+    let callCount = 0;
+    const stub = buildStubBackend({
+      insertNode: async () => {
+        callCount += 1;
+        const label = callCount === 1 ? "A" : "B";
+        steps.push(`${label}:start`);
+        await delay(10);
+        steps.push(`${label}:middle`);
+        await delay(10);
+        steps.push(`${label}:end`);
+        return { id: label };
+      },
+      getNode: () => Promise.resolve({ id: "unused" }),
+    });
+    const queuedBackend = buildCallerSerializedBackend(stub);
+    const queuedInsertNode =
+      queuedBackend.insertNode as unknown as StubBackendMember;
+
+    await Promise.all([queuedInsertNode(), queuedInsertNode()]);
+
+    const aEnd = steps.indexOf("A:end");
+    const bStart = steps.indexOf("B:start");
+    const bEnd = steps.indexOf("B:end");
+    const aStart = steps.indexOf("A:start");
+    // Whichever call the queue ran first, every one of its steps — through
+    // its own last step — precedes every step of the other.
+    const aThenB = aEnd < bStart;
+    const bThenA = bEnd < aStart;
+    expect(aThenB || bThenA).toBe(true);
+  });
+});
+
+describe("caller-serialized queue: reads bypass it", () => {
+  it("resolves a concurrent read before a slow queued write settles", async () => {
+    let writeSettled = false;
+    const stub = buildStubBackend({
+      insertNode: async () => {
+        await delay(150);
+        writeSettled = true;
+        return { id: "slow-write" };
+      },
+      getNode: () => Promise.resolve({ id: "read" }),
+    });
+    const queuedBackend = buildCallerSerializedBackend(stub);
+    const queuedInsertNode =
+      queuedBackend.insertNode as unknown as StubBackendMember;
+    const queuedGetNode = queuedBackend.getNode as unknown as StubBackendMember;
+
+    const writePromise = queuedInsertNode();
+    await delay(20);
+
+    const readResult = await queuedGetNode();
+    expect(readResult).toEqual({ id: "read" });
+    // The read above resolved while the slow write was still pending — it
+    // was never queued behind it.
+    expect(writeSettled).toBe(false);
+
+    await writePromise;
+    expect(writeSettled).toBe(true);
+  });
+});
+
+// ============================================================
+// Direct proof that the wrapping covers exactly the write-member taxonomy
+// plus the two transaction openers, and nothing else — isolated from the
+// closures `createSqlBackend` builds fresh on every construction (see
+// `buildCallerSerializedBackend`'s own doc comment for why this needs a
+// single shared base object rather than two independent backends).
+// ============================================================
+
+const QUEUED_ROOT_MEMBER_KEYS = [
+  ...WRITE_MEMBER_KEYS,
+  "transaction",
+  "transactionWithNative",
+] as const;
+
+function buildPlainSqliteBackend(): Readonly<{
+  backend: AdapterBackend<AnySqliteDatabase>;
+  close: () => Promise<void>;
+}> {
+  const client = new Database(":memory:");
+  const backend = createSqliteBackend(drizzleBetterSqlite3(client));
+  return {
+    backend,
+    close: () => {
+      client.close();
+      return Promise.resolve();
+    },
+  };
+}
+
+describe("buildCallerSerializedBackend member coverage", () => {
+  it("wraps every taxonomy write member and the two transaction openers, and leaves every read member alone", () => {
+    const { backend: plainBackend, close } = buildPlainSqliteBackend();
+    cleanups.push(close);
+    const queuedBackend = buildCallerSerializedBackend(plainBackend);
+
+    const wrapped: string[] = [];
+    const untouched: string[] = [];
+    // Every taxonomy write member this plain SQLite backend actually
+    // implements — an in-memory backend with no vector strategy omits the
+    // OPTIONAL embedding members, exactly as `buildQueuedWriteUnits` itself
+    // skips a member `Reflect.get` reports as absent, so the set this test
+    // expects to see wrapped is the same subset, not the full taxonomy.
+    const implementedKeys = QUEUED_ROOT_MEMBER_KEYS.filter(
+      (key) =>
+        key === "commands" ||
+        typeof Reflect.get(plainBackend, key) === "function",
+    );
+    // `commands` is a port object, not a bare function: its own identity
+    // changing is not proof that its `execute` changed, so that one member's
+    // `execute` is compared separately below rather than inside this loop.
+    const plainCommandsExecute = plainBackend.commands.execute;
+    const queuedCommandsExecute = queuedBackend.commands.execute;
+    for (const key of implementedKeys) {
+      const plainMember: unknown = Reflect.get(plainBackend, key);
+      if (Reflect.get(queuedBackend, key) === plainMember) {
+        untouched.push(key);
+      } else {
+        wrapped.push(key);
+      }
+    }
+    expect(untouched).toEqual([]);
+    expect(wrapped.toSorted()).toEqual([...implementedKeys].toSorted());
+    expect(queuedCommandsExecute).not.toBe(plainCommandsExecute);
+
+    for (const key of GRAPH_BACKEND_MEMBER_CLASSES.read) {
+      const plainMember: unknown = Reflect.get(plainBackend, key);
+      if (typeof plainMember !== "function") continue;
+      expect(Reflect.get(queuedBackend, key)).toBe(plainMember);
+    }
+  });
+});

--- a/packages/typegraph/tests/contribution-health.test.ts
+++ b/packages/typegraph/tests/contribution-health.test.ts
@@ -125,7 +125,7 @@ function createRefusingMaterializer(
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+        writeFence: { mechanism: "engine-serialized" },
       },
     },
     fulltextStrategy: options.fulltextStrategy ?? fts5Strategy,

--- a/packages/typegraph/tests/contribution-health.test.ts
+++ b/packages/typegraph/tests/contribution-health.test.ts
@@ -125,11 +125,7 @@ function createRefusingMaterializer(
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: true,
-        },
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
       },
     },
     fulltextStrategy: options.fulltextStrategy ?? fts5Strategy,

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -186,7 +186,6 @@ function createMockMaterializer(
             { mechanism: "advisory" as const, drain: "table-lock" as const }
           : {
               mechanism: "engine-serialized" as const,
-              drain: "table-lock" as const,
             },
       },
     },
@@ -535,7 +534,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+          writeFence: { mechanism: "engine-serialized" },
         },
       },
       fulltextStrategy: fts5Strategy,

--- a/packages/typegraph/tests/contribution-materializer.test.ts
+++ b/packages/typegraph/tests/contribution-materializer.test.ts
@@ -181,13 +181,12 @@ function createMockMaterializer(
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        pessimisticLocks:
+        writeFence:
           dialect === "postgres" ?
-            { advisoryLocks: true, tableLocks: true, serializedWriters: false }
+            { mechanism: "advisory" as const, drain: "table-lock" as const }
           : {
-              advisoryLocks: false,
-              tableLocks: false,
-              serializedWriters: true,
+              mechanism: "engine-serialized" as const,
+              drain: "table-lock" as const,
             },
       },
     },
@@ -536,11 +535,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          pessimisticLocks: {
-            advisoryLocks: false,
-            tableLocks: false,
-            serializedWriters: true,
-          },
+          writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
         },
       },
       fulltextStrategy: fts5Strategy,
@@ -605,11 +600,7 @@ describe("#149 ensureRuntimeContributions is read-only when already materialized
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          pessimisticLocks: {
-            advisoryLocks: true,
-            tableLocks: true,
-            serializedWriters: false,
-          },
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
         },
       },
       fulltextStrategy: fts5Strategy,

--- a/packages/typegraph/tests/data-keyed-bag-ratchet.test.ts
+++ b/packages/typegraph/tests/data-keyed-bag-ratchet.test.ts
@@ -71,7 +71,7 @@ const ALLOWLIST: readonly AllowedSite[] = [
       "`gated` is keyed by `keyof GatableFulltextBackend` — a closed set of method names written in this file, not data.",
   },
   {
-    file: "backend/drizzle/sqlite.ts",
+    file: "backend/serialized-execution-queue.ts",
     line: "const taskMarker: object = {};",
     reason:
       "An identity sentinel compared by reference; no key is ever assigned to it.",

--- a/packages/typegraph/tests/edge-convergence-command.test.ts
+++ b/packages/typegraph/tests/edge-convergence-command.test.ts
@@ -230,6 +230,40 @@ describe("PostgreSQL edge convergence command", () => {
     }
   });
 
+  it('refuses a PostgreSQL override that declares writeFence.mechanism: "engine-serialized" (the preferred-declaration twin of the pessimisticLocks refusal above)', async () => {
+    const client = await PGlite.create();
+    try {
+      expect(() =>
+        createPostgresBackend(drizzlePglite(client), {
+          capabilities: {
+            writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+          },
+          vector: false,
+        }),
+      ).toThrow('cannot declare writeFence.mechanism: "engine-serialized"');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('accepts a PostgreSQL override that declares writeFence.mechanism: "caller-serialized" — a deployment claim, not an engine claim', async () => {
+    const client = await PGlite.create();
+    try {
+      const backend = createPostgresBackend(drizzlePglite(client), {
+        capabilities: {
+          writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        },
+        vector: false,
+      });
+      expect(backend.capabilities.writeFence).toEqual({
+        mechanism: "caller-serialized",
+        drain: "quiescent",
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
   it("uses exact match-key equality and deterministic winner ordering", () => {
     const strategy = createPostgresOperationStrategy(
       postgresTables,

--- a/packages/typegraph/tests/edge-convergence-command.test.ts
+++ b/packages/typegraph/tests/edge-convergence-command.test.ts
@@ -216,7 +216,7 @@ describe("PostgreSQL edge convergence command", () => {
       expect(() =>
         createPostgresBackend(drizzlePglite(client), {
           capabilities: {
-            writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+            writeFence: { mechanism: "engine-serialized" },
           },
           vector: false,
         }),
@@ -231,13 +231,12 @@ describe("PostgreSQL edge convergence command", () => {
     try {
       const backend = createPostgresBackend(drizzlePglite(client), {
         capabilities: {
-          writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+          writeFence: { mechanism: "caller-serialized" },
         },
         vector: false,
       });
       expect(backend.capabilities.writeFence).toEqual({
         mechanism: "caller-serialized",
-        drain: "quiescent",
       });
     } finally {
       await client.close();

--- a/packages/typegraph/tests/edge-convergence-command.test.ts
+++ b/packages/typegraph/tests/edge-convergence-command.test.ts
@@ -210,27 +210,7 @@ describe("PostgreSQL edge convergence command", () => {
     }
   });
 
-  it("refuses a PostgreSQL override that falsely claims serialized writers", async () => {
-    const client = await PGlite.create();
-    try {
-      expect(() =>
-        createPostgresBackend(drizzlePglite(client), {
-          capabilities: {
-            pessimisticLocks: {
-              advisoryLocks: false,
-              tableLocks: false,
-              serializedWriters: true,
-            },
-          },
-          vector: false,
-        }),
-      ).toThrow("cannot claim serialized writers");
-    } finally {
-      await client.close();
-    }
-  });
-
-  it('refuses a PostgreSQL override that declares writeFence.mechanism: "engine-serialized" (the preferred-declaration twin of the pessimisticLocks refusal above)', async () => {
+  it('refuses a PostgreSQL override that declares writeFence.mechanism: "engine-serialized" (a PostgreSQL pool is never a single-writer-slot engine)', async () => {
     const client = await PGlite.create();
     try {
       expect(() =>

--- a/packages/typegraph/tests/engine-profile-derivation.test.ts
+++ b/packages/typegraph/tests/engine-profile-derivation.test.ts
@@ -243,7 +243,7 @@ const derivationIdentityGraph = defineGraph({
 // opening recorded-time capture, which on PostgreSQL needs `fenceSql` for an
 // entirely different, dialect-gated reason (its own isolation-level read,
 // `assertRecordedCaptureTransactionIsolation` in `store/recorded-capture/
-// guards.ts`) that a `pessimisticLocks` posture cannot satisfy either way.
+// guards.ts`) that a `writeFence` posture cannot satisfy either way.
 // ============================================================
 
 const PortableFenceProbePerson = defineNode("Person", {
@@ -350,18 +350,14 @@ describe("deriveEngineProfile", () => {
     expect(portableStatementText).toBe(`SELECT ${fusedEmbeddedExpressionText}`);
   });
 
-  it("case 1b: a derived PostgreSQL profile with fenceSql: undefined and pessimisticLocks.serializedWriters has no lockSchemaVersionAndGraphWrite member on the root or a transaction() handle, and a graph-write-lock-needing write still succeeds through the portable path", async () => {
+  it('case 1b: a derived PostgreSQL profile with fenceSql: undefined and writeFence.mechanism: "engine-serialized" has no lockSchemaVersionAndGraphWrite member on the root or a transaction() handle, and a graph-write-lock-needing write still succeeds through the portable path', async () => {
     const { profile: baseProfile } =
       await createRealPostgresProfileWithClient();
     const derivedProfile = deriveEngineProfile(baseProfile, {
       fenceSql: undefined,
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: true,
-        },
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
       },
     });
 
@@ -402,37 +398,31 @@ describe("deriveEngineProfile", () => {
     expect(edge).toBeDefined();
   });
 
-  it("case 2: a derived SQLite profile with an all-false pessimisticLocks declaration refuses the identity lock as unfenced (declared-none)", async () => {
+  it("case 2: a derived SQLite profile with writeFence omitted refuses at createSqlBackend, before any identity lock is reached", () => {
     const baseProfile = createRealSqliteProfile();
+    const { writeFence: _writeFence, ...declaredCapabilitiesWithoutFence } =
+      baseProfile.declaredCapabilities;
     const derivedProfile = deriveEngineProfile(baseProfile, {
-      declaredCapabilities: {
-        ...baseProfile.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: false,
-        },
-      },
+      declaredCapabilities: declaredCapabilitiesWithoutFence,
     });
 
-    const backend = createSqlBackend(derivedProfile);
-
-    // An identity-enabled graph's FIRST schema commit runs the identity
-    // subsystem's own schema-commit preflight (`identitySchemaCommitPreflight`,
-    // `src/identity/schema-transition.ts`), which takes this same per-graph
-    // fence before a single row is ever written — so the refusal fires here,
-    // opening the store, rather than needing a write afterward to reach it.
+    // `writeFence` has no arm that means "no fence" the way the deleted
+    // legacy `pessimisticLocks` all-false shape once did, so the only way
+    // left to reach an unfenced declaration is to omit `writeFence`
+    // entirely — which `createSqlBackend`'s own construction-time gate now
+    // refuses outright, before a backend (and so an identity lock) exists.
     let thrown: unknown;
     try {
-      await createAdapterStoreWithSchema(derivationIdentityGraph, backend);
+      createSqlBackend(derivedProfile);
     } catch (error) {
       thrown = error;
     }
 
     expect(thrown).toBeInstanceOf(ConfigurationError);
     const configurationError = thrown as ConfigurationError;
-    expect(configurationError.details["code"]).toBe("WRITE_FENCE_UNAVAILABLE");
-    expect(configurationError.details["reason"]).toBe("declared-none");
+    expect(configurationError.details["code"]).toBe(
+      "ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION",
+    );
   });
 
   it("case 3: an override outside the derivable set throws ENGINE_PROFILE_OVERRIDE_UNSUPPORTED naming the key", () => {
@@ -478,28 +468,19 @@ describe("deriveEngineProfile", () => {
     const derivedProfile = deriveEngineProfile(baseProfile, {
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: true,
-          serializedWriters: false,
-        },
+        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
       },
     });
 
     const backend = createSqlBackend(derivedProfile);
 
     const rootPlan = resolveWriteFencePlan(backend);
-    const rootReason =
-      rootPlan.kind === "unfenced" ? rootPlan.reason : undefined;
-    expect(rootPlan.kind).toBe("unfenced");
-    expect(rootReason).toBe("table-locks-only");
-    expect(isSchemaFencedInsertEligible(backend)).toBe(false);
+    expect(rootPlan).toEqual({ kind: "caller-serialized" });
+    expect(isSchemaFencedInsertEligible(backend)).toBe(true);
 
     await backend.transaction((tx) => {
       const txPlan = resolveWriteFencePlan(tx);
-      const txReason = txPlan.kind === "unfenced" ? txPlan.reason : undefined;
-      expect(txPlan.kind).toBe(rootPlan.kind);
-      expect(txReason).toBe(rootReason);
+      expect(txPlan).toEqual(rootPlan);
       expect(isSchemaFencedInsertEligible(tx)).toBe(
         isSchemaFencedInsertEligible(backend),
       );
@@ -507,14 +488,14 @@ describe("deriveEngineProfile", () => {
     });
   });
 
-  it("case 6: fenceSql: undefined alone still refuses at createSqlBackend (WRITE_FENCE_SQL_UNAVAILABLE); paired with a declaredCapabilities override that also stops claiming advisoryLocks it resolves engine-serialized", async () => {
+  it('case 6: fenceSql: undefined alone still refuses at createSqlBackend (WRITE_FENCE_SQL_UNAVAILABLE); paired with a declaredCapabilities override that also stops claiming "advisory" it resolves engine-serialized', async () => {
     const { profile: baseProfile } =
       await createRealPostgresProfileWithClient();
 
     // Half 1: dropping the spelling alone leaves `declaredCapabilities
-    // .pessimisticLocks.advisoryLocks: true` in place (the bundled
-    // PostgreSQL declaration), so `createSqlBackend`'s eager fence-plan
-    // resolution has a lock plan with nothing to spell it with.
+    // .writeFence.mechanism: "advisory"` in place (the bundled PostgreSQL
+    // declaration), so `createSqlBackend`'s eager fence-plan resolution has
+    // a lock plan with nothing to spell it with.
     const droppedFenceSqlOnly = deriveEngineProfile(baseProfile, {
       fenceSql: undefined,
     });
@@ -529,22 +510,18 @@ describe("deriveEngineProfile", () => {
       "WRITE_FENCE_SQL_UNAVAILABLE",
     );
 
-    // Half 2: pairing the dropped spelling with a `pessimisticLocks`
-    // declaration that claims `serializedWriters` instead of
-    // `advisoryLocks` gives `resolveWriteFencePlan` an `engine-serialized`
-    // plan, which needs no `fenceSql` at all — this is what successfully
-    // removes the spelling, not `fenceSql: undefined` on its own.
+    // Half 2: pairing the dropped spelling with a `writeFence` declaration
+    // that claims `"engine-serialized"` instead of `"advisory"` gives
+    // `resolveWriteFencePlan` an `engine-serialized` plan, which needs no
+    // `fenceSql` at all — this is what successfully removes the spelling,
+    // not `fenceSql: undefined` on its own.
     const droppedFenceSqlWithSerializedWriters = deriveEngineProfile(
       baseProfile,
       {
         fenceSql: undefined,
         declaredCapabilities: {
           ...baseProfile.declaredCapabilities,
-          pessimisticLocks: {
-            advisoryLocks: false,
-            tableLocks: false,
-            serializedWriters: true,
-          },
+          writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
         },
       },
     );
@@ -649,18 +626,14 @@ describe("deriveEngineProfile refuses the declaredCapabilities/resourceAudit sub
     expect(configurationError.details["key"]).toBe("resourceAudit.kind");
   });
 
-  it("still allows a declaredCapabilities override that changes only pessimisticLocks, keeping maxBindParameters and execution.interactiveTransactions equal to the base profile's own values", async () => {
+  it("still allows a declaredCapabilities override that changes only writeFence, keeping maxBindParameters and execution.interactiveTransactions equal to the base profile's own values", async () => {
     const { profile: baseProfile } =
       await createRealPostgresProfileWithClient();
 
     const derivedProfile = deriveEngineProfile(baseProfile, {
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: true,
-        },
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
       },
     });
 
@@ -724,7 +697,7 @@ describe("registerFirstPartyProfile freezes the trust-bearing bags a derived pro
     ).toBe(originalInteractiveTransactions);
   });
 
-  it("a derived PostgreSQL profile's shared resourceAudit and declaredCapabilities.pessimisticLocks throw on assignment and leave the base unchanged", async () => {
+  it("a derived PostgreSQL profile's shared resourceAudit and declaredCapabilities.writeFence throw on assignment and leave the base unchanged", async () => {
     const { profile: baseProfile } =
       await createRealPostgresProfileWithClient();
     const derivedProfile = deriveEngineProfile(baseProfile, {
@@ -738,15 +711,14 @@ describe("registerFirstPartyProfile freezes the trust-bearing bags a derived pro
     }).toThrow(TypeError);
     expect(baseProfile.resourceAudit.kind).toBe(originalResourceAuditKind);
 
-    const originalPessimisticLocks =
-      baseProfile.declaredCapabilities.pessimisticLocks;
+    const originalWriteFence = baseProfile.declaredCapabilities.writeFence;
     expect(() => {
       (
-        derivedProfile.declaredCapabilities as { pessimisticLocks: unknown }
-      ).pessimisticLocks = undefined;
+        derivedProfile.declaredCapabilities as { writeFence: unknown }
+      ).writeFence = undefined;
     }).toThrow(TypeError);
-    expect(baseProfile.declaredCapabilities.pessimisticLocks).toBe(
-      originalPessimisticLocks,
+    expect(baseProfile.declaredCapabilities.writeFence).toBe(
+      originalWriteFence,
     );
   });
 

--- a/packages/typegraph/tests/engine-profile-derivation.test.ts
+++ b/packages/typegraph/tests/engine-profile-derivation.test.ts
@@ -357,7 +357,7 @@ describe("deriveEngineProfile", () => {
       fenceSql: undefined,
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+        writeFence: { mechanism: "engine-serialized" },
       },
     });
 
@@ -468,7 +468,7 @@ describe("deriveEngineProfile", () => {
     const derivedProfile = deriveEngineProfile(baseProfile, {
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        writeFence: { mechanism: "caller-serialized" },
       },
     });
 
@@ -521,7 +521,7 @@ describe("deriveEngineProfile", () => {
         fenceSql: undefined,
         declaredCapabilities: {
           ...baseProfile.declaredCapabilities,
-          writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+          writeFence: { mechanism: "engine-serialized" },
         },
       },
     );
@@ -633,7 +633,7 @@ describe("deriveEngineProfile refuses the declaredCapabilities/resourceAudit sub
     const derivedProfile = deriveEngineProfile(baseProfile, {
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+        writeFence: { mechanism: "engine-serialized" },
       },
     });
 

--- a/packages/typegraph/tests/engine-profile-parity.test.ts
+++ b/packages/typegraph/tests/engine-profile-parity.test.ts
@@ -256,7 +256,6 @@ describe("engine-profile parity: member keys, capabilities, marks", () => {
     );
     expect(backend.capabilities.writeFence).toEqual({
       mechanism: "engine-serialized",
-      drain: "table-lock",
     });
     // better-sqlite3 probes the compiled SQLITE_MAX_VARIABLE_NUMBER at
     // construction; on the version this suite runs against that resolves

--- a/packages/typegraph/tests/engine-profile-parity.test.ts
+++ b/packages/typegraph/tests/engine-profile-parity.test.ts
@@ -13,7 +13,7 @@
  * 1. The backend's own member-key set and its resolved capabilities
  *    (sorted, so key order never causes a spurious diff), plus explicit
  *    assertions on the two capabilities a shared-code refusal keys off
- *    (`pessimisticLocks`, `maxBindParameters`).
+ *    (`writeFence`, `maxBindParameters`).
  * 2. The three trust marks a bundled root — and a `transaction()` handle
  *    opened on it — carry (`isFirstPartyFactory`,
  *    `isSchemaFencedInsertEligible`, `isBundledRootAutocommitEligible`).
@@ -229,10 +229,9 @@ describe("engine-profile parity: member keys, capabilities, marks", () => {
     expect(deepSortKeys(backend.capabilities)).toMatchSnapshot(
       "pglite-root-capabilities",
     );
-    expect(backend.capabilities.pessimisticLocks).toEqual({
-      advisoryLocks: true,
-      tableLocks: true,
-      serializedWriters: false,
+    expect(backend.capabilities.writeFence).toEqual({
+      mechanism: "advisory",
+      drain: "table-lock",
     });
     expect(backend.capabilities.maxBindParameters).toBe(
       PGLITE_MAX_BIND_PARAMETERS,
@@ -255,10 +254,9 @@ describe("engine-profile parity: member keys, capabilities, marks", () => {
     expect(deepSortKeys(backend.capabilities)).toMatchSnapshot(
       "sqlite-root-capabilities",
     );
-    expect(backend.capabilities.pessimisticLocks).toEqual({
-      advisoryLocks: false,
-      tableLocks: false,
-      serializedWriters: true,
+    expect(backend.capabilities.writeFence).toEqual({
+      mechanism: "engine-serialized",
+      drain: "table-lock",
     });
     // better-sqlite3 probes the compiled SQLITE_MAX_VARIABLE_NUMBER at
     // construction; on the version this suite runs against that resolves

--- a/packages/typegraph/tests/engine-profile-refusals.test.ts
+++ b/packages/typegraph/tests/engine-profile-refusals.test.ts
@@ -26,11 +26,14 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { isBundledRootAutocommitEligible } from "../src/backend/capabilities/autocommit-single-statement";
 import { requireCatalog } from "../src/backend/capabilities/catalog";
-import { isSchemaFencedInsertEligible } from "../src/backend/capabilities/schema-fenced-insert";
+import {
+  isSchemaFencedInsertEligible,
+  markSchemaFencedInsertEligibleUnderFence,
+} from "../src/backend/capabilities/schema-fenced-insert";
 import {
   isFirstPartyFactory,
-  pessimisticLockDeclarationLine,
   resolveWriteFencePlan,
+  writeFenceDeclarationLine,
 } from "../src/backend/capabilities/write-fence";
 import {
   createSqlBackend,
@@ -74,13 +77,13 @@ async function createRealPostgresProfile(): Promise<
 }
 
 describe("createSqlBackend refusals", () => {
-  it("refuses a profile whose resolved capabilities omit pessimisticLocks", () => {
+  it("refuses a profile whose resolved capabilities omit writeFence", () => {
     const base = createRealSqliteProfile();
     const profile = {
       ...base,
       declaredCapabilities: {
         ...base.declaredCapabilities,
-        pessimisticLocks: undefined,
+        writeFence: undefined,
       },
     };
 
@@ -97,7 +100,7 @@ describe("createSqlBackend refusals", () => {
       "ENGINE_PROFILE_REQUIRES_WRITE_FENCE_DECLARATION",
     );
     expect(configurationError.message).toContain(
-      pessimisticLockDeclarationLine("sqlite"),
+      writeFenceDeclarationLine("sqlite"),
     );
   });
 
@@ -145,16 +148,15 @@ describe("createSqlBackend refusals", () => {
     expect(isSchemaFencedInsertEligible(backend)).toBe(true);
   });
 
-  it("refuses a profile that declares advisoryLocks: true but supplies no fenceSql", () => {
+  it('refuses a profile that declares writeFence.mechanism: "advisory" but supplies no fenceSql', () => {
     const base = createRealSqliteProfile();
     const profile = {
       ...base,
       declaredCapabilities: {
         ...base.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: true,
-          tableLocks: true,
-          serializedWriters: false,
+        writeFence: {
+          mechanism: "advisory" as const,
+          drain: "table-lock" as const,
         },
       },
     };
@@ -176,54 +178,20 @@ describe("createSqlBackend refusals", () => {
   });
 
   it("marks isSchemaFencedInsertEligible only when the resolved fence plan is not unfenced", () => {
-    const base = createRealSqliteProfile();
-    const profile = {
-      ...base,
-      declaredCapabilities: {
-        ...base.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: false,
-        },
-      },
-    };
-
-    const backend = createSqlBackend(profile);
-
-    expect(isSchemaFencedInsertEligible(backend)).toBe(false);
-    // The refusal above already required a declared value, so this profile
-    // still constructs. A spread copy is a new object and is never
-    // first-party regardless of which field the spread overrode; the
-    // autocommit mark is otherwise unaffected by this gate.
-    expect(isFirstPartyFactory(backend)).toBe(false);
-    expect(isBundledRootAutocommitEligible(backend)).toBe(true);
-  });
-
-  it("resolves the same unfenced plan and schema-fenced-insert eligibility on the root and on a transaction() handle it opens", async () => {
-    const base = createRealSqliteProfile();
-    const profile = {
-      ...base,
-      declaredCapabilities: {
-        ...base.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: false,
-        },
-      },
-    };
-
-    const backend = createSqlBackend(profile);
-
-    expect(resolveWriteFencePlan(backend).kind).toBe("unfenced");
-    expect(isSchemaFencedInsertEligible(backend)).toBe(false);
-
-    await backend.transaction((tx) => {
-      expect(resolveWriteFencePlan(tx).kind).toBe("unfenced");
-      expect(isSchemaFencedInsertEligible(tx)).toBe(false);
-      return Promise.resolve();
+    // `createSqlBackend` itself can never resolve `unfenced` — its own
+    // construction-time gate refuses a profile with no `writeFence` before a
+    // backend exists — so this exercises the mark directly, the same way
+    // `markSchemaFencedInsertEligibleUnderFence`'s one caller
+    // (`createSqlBackend`) would for a hypothetical unfenced resolution.
+    const fenced = {};
+    const unfenced = {};
+    markSchemaFencedInsertEligibleUnderFence(fenced, {
+      kind: "engine-serialized",
     });
+    markSchemaFencedInsertEligibleUnderFence(unfenced, { kind: "unfenced" });
+
+    expect(isSchemaFencedInsertEligible(fenced)).toBe(true);
+    expect(isSchemaFencedInsertEligible(unfenced)).toBe(false);
   });
 
   it("reports isFirstPartyFactory true for both bundled roots, and false for a spread copy of each — including on a transaction() handle each backend opens", async () => {
@@ -420,7 +388,7 @@ describe("finalizeEngineCapabilities", () => {
 });
 
 describe("resolveWriteFencePlan refusals", () => {
-  it("refuses a postgres-dialect target that declares advisoryLocks: true but supplies no fenceSql, naming postgresFenceSql", () => {
+  it('refuses a postgres-dialect target that declares writeFence.mechanism: "advisory" but supplies no fenceSql, naming postgresFenceSql', () => {
     const base = createRealSqliteProfile();
 
     let thrown: unknown;
@@ -429,11 +397,7 @@ describe("resolveWriteFencePlan refusals", () => {
         dialect: "postgres",
         capabilities: {
           ...base.declaredCapabilities,
-          pessimisticLocks: {
-            advisoryLocks: true,
-            tableLocks: true,
-            serializedWriters: false,
-          },
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
         },
         // No `fenceSql` — the exact shape a lock declaration without a
         // spelling refuses, reached this time through `resolveWriteFencePlan`
@@ -450,43 +414,14 @@ describe("resolveWriteFencePlan refusals", () => {
       "WRITE_FENCE_SQL_UNAVAILABLE",
     );
     expect(configurationError.suggestion).toContain("postgresFenceSql");
-  });
-
-  it("names the declared writeFence, not the legacy pessimisticLocks wording, when the declaration came from capabilities.writeFence directly", () => {
-    let thrown: unknown;
-    try {
-      resolveWriteFencePlan({
-        dialect: "postgres",
-        capabilities: {
-          execution: { interactiveTransactions: true, atomicBatch: "none" },
-          windowFunctions: true,
-          writeFence: { mechanism: "advisory", drain: "table-lock" },
-        },
-        // No `fenceSql` — this target declared `writeFence` directly, so the
-        // refusal must name THAT declaration, not the legacy
-        // `pessimisticLocks.advisoryLocks: true` phrasing the mapped-legacy
-        // arm above still uses.
-      });
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(ConfigurationError);
-    const configurationError = thrown as ConfigurationError;
-    expect(configurationError.details["code"]).toBe(
-      "WRITE_FENCE_SQL_UNAVAILABLE",
-    );
     expect(configurationError.message).toContain(
       'capabilities.writeFence: { mechanism: "advisory", drain: "table-lock" }',
-    );
-    expect(configurationError.message).not.toContain(
-      "pessimisticLocks.advisoryLocks: true",
     );
   });
 });
 
-describe("bundled factories accept capabilities.writeFence without colliding with their own pessimisticLocks default", () => {
-  it("buildSqliteEngineProfile + createSqlBackend resolves a declared writeFence instead of throwing WRITE_FENCE_DECLARATION_CONFLICT", () => {
+describe("bundled factories accept a declared writeFence", () => {
+  it("buildSqliteEngineProfile + createSqlBackend resolves a declared writeFence", () => {
     const sqlite = new RealDatabase(":memory:");
     cleanups.push(() => {
       sqlite.close();
@@ -498,10 +433,8 @@ describe("bundled factories accept capabilities.writeFence without colliding wit
       },
     });
 
-    // `createSqlBackend` must not throw: the bundled default `pessimisticLocks`
-    // this factory would otherwise inject has to be omitted underneath a
-    // caller-declared `writeFence`, and the construction-time gate above has
-    // to accept `writeFence` alone as a usable declaration.
+    // `createSqlBackend` must not throw: the construction-time gate above
+    // accepts a caller-declared `writeFence` overriding the bundled default.
     const backend = createSqlBackend(profile);
 
     expect(resolveWriteFencePlan(backend)).toEqual({
@@ -509,7 +442,7 @@ describe("bundled factories accept capabilities.writeFence without colliding wit
     });
   });
 
-  it("buildPostgresEngineProfile + createSqlBackend resolves a declared writeFence instead of throwing WRITE_FENCE_DECLARATION_CONFLICT", async () => {
+  it("buildPostgresEngineProfile + createSqlBackend resolves a declared writeFence", async () => {
     const client = await PGlite.create();
     cleanups.push(() => client.close());
     const profile = buildPostgresEngineProfile(drizzlePg(client), {
@@ -525,7 +458,6 @@ describe("bundled factories accept capabilities.writeFence without colliding wit
       expect.objectContaining({
         kind: "lock",
         drain: "table-lock",
-        tableLocks: true,
       }),
     );
   });
@@ -533,10 +465,10 @@ describe("bundled factories accept capabilities.writeFence without colliding wit
 
 describe("assertRecordedCaptureTransactionIsolation refusals", () => {
   it("refuses a postgres-dialect target with no fenceSql via the session-fact refusal, not the lock refusal", async () => {
-    // This target declares NO `pessimisticLocks` at all — the exact
-    // extensibility case (a custom backend with `serializedWriters: true`
-    // and no advisory locks) the lock-plan refusal's message would
-    // misdescribe by claiming `advisoryLocks: true`.
+    // This target declares no `capabilities` at all — the extensibility
+    // case (a custom backend with an `engine-serialized` mechanism and no
+    // advisory locks) the lock-plan refusal's message would misdescribe by
+    // claiming `mechanism: "advisory"`.
     const target = {
       dialect: "postgres" as const,
       fenceSql: undefined,
@@ -555,7 +487,7 @@ describe("assertRecordedCaptureTransactionIsolation refusals", () => {
     expect(configurationError.details["code"]).toBe(
       "WRITE_FENCE_SQL_UNAVAILABLE",
     );
-    expect(configurationError.message).not.toContain("advisoryLocks: true");
+    expect(configurationError.message).not.toContain('mechanism: "advisory"');
     expect(configurationError.message).toContain("fenceSql");
     expect(configurationError.suggestion).toContain("postgresFenceSql");
   });

--- a/packages/typegraph/tests/engine-profile-refusals.test.ts
+++ b/packages/typegraph/tests/engine-profile-refusals.test.ts
@@ -429,7 +429,7 @@ describe("bundled factories accept a declared writeFence", () => {
     const profile = buildSqliteEngineProfile(drizzleSqlite(sqlite), {
       executionProfile: { isSync: true },
       capabilities: {
-        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        writeFence: { mechanism: "caller-serialized" },
       },
     });
 

--- a/packages/typegraph/tests/engine-profile-refusals.test.ts
+++ b/packages/typegraph/tests/engine-profile-refusals.test.ts
@@ -451,6 +451,84 @@ describe("resolveWriteFencePlan refusals", () => {
     );
     expect(configurationError.suggestion).toContain("postgresFenceSql");
   });
+
+  it("names the declared writeFence, not the legacy pessimisticLocks wording, when the declaration came from capabilities.writeFence directly", () => {
+    let thrown: unknown;
+    try {
+      resolveWriteFencePlan({
+        dialect: "postgres",
+        capabilities: {
+          execution: { interactiveTransactions: true, atomicBatch: "none" },
+          windowFunctions: true,
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
+        },
+        // No `fenceSql` — this target declared `writeFence` directly, so the
+        // refusal must name THAT declaration, not the legacy
+        // `pessimisticLocks.advisoryLocks: true` phrasing the mapped-legacy
+        // arm above still uses.
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ConfigurationError);
+    const configurationError = thrown as ConfigurationError;
+    expect(configurationError.details["code"]).toBe(
+      "WRITE_FENCE_SQL_UNAVAILABLE",
+    );
+    expect(configurationError.message).toContain(
+      'capabilities.writeFence: { mechanism: "advisory", drain: "table-lock" }',
+    );
+    expect(configurationError.message).not.toContain(
+      "pessimisticLocks.advisoryLocks: true",
+    );
+  });
+});
+
+describe("bundled factories accept capabilities.writeFence without colliding with their own pessimisticLocks default", () => {
+  it("buildSqliteEngineProfile + createSqlBackend resolves a declared writeFence instead of throwing WRITE_FENCE_DECLARATION_CONFLICT", () => {
+    const sqlite = new RealDatabase(":memory:");
+    cleanups.push(() => {
+      sqlite.close();
+    });
+    const profile = buildSqliteEngineProfile(drizzleSqlite(sqlite), {
+      executionProfile: { isSync: true },
+      capabilities: {
+        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      },
+    });
+
+    // `createSqlBackend` must not throw: the bundled default `pessimisticLocks`
+    // this factory would otherwise inject has to be omitted underneath a
+    // caller-declared `writeFence`, and the construction-time gate above has
+    // to accept `writeFence` alone as a usable declaration.
+    const backend = createSqlBackend(profile);
+
+    expect(resolveWriteFencePlan(backend)).toEqual({
+      kind: "caller-serialized",
+    });
+  });
+
+  it("buildPostgresEngineProfile + createSqlBackend resolves a declared writeFence instead of throwing WRITE_FENCE_DECLARATION_CONFLICT", async () => {
+    const client = await PGlite.create();
+    cleanups.push(() => client.close());
+    const profile = buildPostgresEngineProfile(drizzlePg(client), {
+      vector: false,
+      capabilities: {
+        writeFence: { mechanism: "advisory", drain: "table-lock" },
+      },
+    });
+
+    const backend = createSqlBackend(profile);
+
+    expect(resolveWriteFencePlan(backend)).toEqual(
+      expect.objectContaining({
+        kind: "lock",
+        drain: "table-lock",
+        tableLocks: true,
+      }),
+    );
+  });
 });
 
 describe("assertRecordedCaptureTransactionIsolation refusals", () => {

--- a/packages/typegraph/tests/graph-merge/write-fence.test.ts
+++ b/packages/typegraph/tests/graph-merge/write-fence.test.ts
@@ -18,11 +18,7 @@ function makeBackend(
         atomicBatch: "none",
         unitOfWork: "interactive",
       },
-      pessimisticLocks: {
-        advisoryLocks: true,
-        tableLocks: true,
-        serializedWriters: false,
-      },
+      writeFence: { mechanism: "advisory", drain: "table-lock" },
     },
     fenceSql: postgresFenceSql,
     lockSchemaVersionForWrite: async () => {

--- a/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
@@ -19,9 +19,8 @@
  *     trusted import's PostgreSQL/SQLite split was always made by calling a
  *     different exported function per engine, never by a dialect literal.
  *     It joins the model here because its table lock now resolves the SAME
- *     plan the other lock sites do, and is the plan's one table-lock-alone
- *     consumer — see `write-fence.ts`'s note next to
- *     `planFromLockCapabilities`.
+ *     plan the other lock sites do: a PostgreSQL-only table lock with no
+ *     advisory lock preceding it.
  *
  *     J17 resolves the plan once, immediately after a profile's capability
  *     tail runs and before any member group is assembled, and gates
@@ -465,30 +464,15 @@ const FENCE_MODULE_FILE = "backend/drizzle/postgres-fence-sql.ts";
 
 /**
  * The only string or template literals anywhere under `src/`, outside
- * {@link FENCE_MODULE_FILE}, that mention one of {@link FENCE_TOKENS} — and
- * every one is prose, not a spelling: `unfencedRefusalMessage`'s two
- * dialect-description strings name the capability a backend should declare
- * ("an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"). The
- * whole source tree is scanned, so a new file that spells a lock statement
- * itself fails here; a new prose mention is declared as a row, with its
- * reason, or it fails too. Asserted both directions.
+ * {@link FENCE_MODULE_FILE}, that mention one of {@link FENCE_TOKENS}. Empty:
+ * `unfencedRefusalMessage`'s single declaration-line message names the
+ * capability to declare (`writeFenceDeclarationLine`), not a lock statement
+ * itself, so no prose row is needed today. The whole source tree is
+ * scanned, so a new file that spells a lock statement itself fails here; a
+ * new prose mention is declared as a row, with its reason, or it fails too.
+ * Asserted both directions.
  */
-const FENCE_TOKEN_PROSE_EXEMPTIONS: readonly InventoryEntry[] = [
-  {
-    file: "backend/capabilities/write-fence.ts",
-    line: '"an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"',
-    site: "prose",
-    reason:
-      "The PostgreSQL half of the unfenced refusal's dialect description — names the capability to declare, spells no statement.",
-  },
-  {
-    file: "backend/capabilities/write-fence.ts",
-    line: '"an engine that honors `pg_advisory_xact_lock` and `LOCK TABLE`"',
-    site: "prose",
-    reason:
-      "The same description for the other dialect's recommendation line in that message.",
-  },
-];
+const FENCE_TOKEN_PROSE_EXEMPTIONS: readonly InventoryEntry[] = [];
 
 /** String and template-literal AST tokens — comments and identifiers never match. */
 function isStringOrTemplatePart(

--- a/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan-inventory.test.ts
@@ -198,7 +198,7 @@ const CALL_SITES: readonly InventoryEntry[] = [
   },
   {
     file: "backend/drizzle/postgres.ts",
-    line: "const plan = resolveWriteFencePlan(fenceTarget);",
+    line: "const schemaFenceFusionPlan = resolveWriteFencePlan(fenceTarget);",
     site: "J16",
     reason:
       "schemaFenceInsertLockClause resolves the plan for the FOR SHARE the fused managed-insert programs carry INSIDE their own statement. The ONLY degrading site: an in-statement predicate cannot race itself, so an empty clause stays correct.",

--- a/packages/typegraph/tests/lock-fence-plan.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan.test.ts
@@ -7,8 +7,9 @@
  * `pg_advisory_xact_lock` / `LOCK TABLE` SQL when the plan resolves to
  * `"lock"`):
  *
- *  1. SQLite factory — declared `{mechanism: "engine-serialized", drain:
- *     "table-lock"}` (A1). Every site resolves `engine-serialized`.
+ *  1. SQLite factory — declared `{mechanism: "engine-serialized"}` (A1,
+ *     no `drain`: that field applies only to `mechanism: "advisory"`). Every
+ *     site resolves `engine-serialized`.
  *  2. PostgreSQL factory — declared `{mechanism: "advisory", drain:
  *     "table-lock"}` (A2). Every site resolves `lock`.
  *  3. declared-advisory-only — `{mechanism: "advisory", drain: "none"}`.
@@ -69,6 +70,7 @@ import {
 import {
   requireWriteFence,
   resolveWriteFencePlan,
+  type WriteFenceDeclaration,
   type WriteFenceTarget,
 } from "../src/backend/capabilities/write-fence";
 import {
@@ -287,9 +289,9 @@ describe("T15 — J1 lockRecordedGraphWrite", () => {
     }
   });
 
-  it("declared {caller-serialized, quiescent}: no advisory lock, no throw", async () => {
+  it("declared {caller-serialized}: no advisory lock, no throw", async () => {
     const logged = await createLoggedPostgresBackend({
-      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      writeFence: { mechanism: "caller-serialized" },
     });
     try {
       logged.reset();
@@ -410,10 +412,10 @@ describe("T15 — J2 lockRecordedClock (via allocateRecordedCommit)", () => {
   });
 
   it.each([false, true] as const)(
-    "declared {caller-serialized, quiescent}: no advisory lock and no seed-UPSERT, regardless of ownsWriteLock (ownsWriteLock: %s)",
+    "declared {caller-serialized}: no advisory lock and no seed-UPSERT, regardless of ownsWriteLock (ownsWriteLock: %s)",
     async (ownsWriteLock) => {
       const logged = await createLoggedPostgresBackend({
-        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        writeFence: { mechanism: "caller-serialized" },
       });
       try {
         logged.reset();
@@ -532,9 +534,9 @@ describe("T15 — J3 lockIdentityGraph", () => {
     }
   });
 
-  it("declared {caller-serialized, quiescent}: no advisory lock, no throw", async () => {
+  it("declared {caller-serialized}: no advisory lock, no throw", async () => {
     const logged = await createLoggedPostgresBackend({
-      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      writeFence: { mechanism: "caller-serialized" },
     });
     try {
       logged.reset();
@@ -649,9 +651,9 @@ describe("T15 — J4 lockIdentityEnablementNodes", () => {
     }
   });
 
-  it("declared {caller-serialized, quiescent}: no throw, no LOCK TABLE", async () => {
+  it("declared {caller-serialized}: no throw, no LOCK TABLE", async () => {
     const logged = await createLoggedPostgresBackend({
-      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      writeFence: { mechanism: "caller-serialized" },
     });
     try {
       logged.reset();
@@ -824,14 +826,14 @@ describe("T15 — J5 lockIdentityDdl (via ensureIdentitySchemaStorage)", () => {
     }
   });
 
-  it("declared {caller-serialized, quiescent}: no advisory lock, no throw", async () => {
+  it("declared {caller-serialized}: no advisory lock, no throw", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
       await seedIdentityUpgrade(logged);
       const { writeFence: _writeFence, ...rest } = logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, {
         ...rest,
-        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        writeFence: { mechanism: "caller-serialized" },
       });
       logged.reset();
       await expect(
@@ -952,9 +954,9 @@ describe("T15 — J6 drainUnfencedRowWriters (via openProvenanceStore)", () => {
     }
   });
 
-  it("declared {caller-serialized, quiescent}: no throw, no LOCK TABLE", async () => {
+  it("declared {caller-serialized}: no throw, no LOCK TABLE", async () => {
     const logged = await createLoggedPostgresBackend({
-      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      writeFence: { mechanism: "caller-serialized" },
     });
     try {
       logged.reset();
@@ -1080,7 +1082,7 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+          writeFence: { mechanism: "engine-serialized" },
         },
       },
       statements,
@@ -1175,7 +1177,7 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
     expect(hasTableLock(statements)).toBe(false);
   });
 
-  it("declared {caller-serialized, quiescent}: no lock statements, no throw", async () => {
+  it("declared {caller-serialized}: no lock statements, no throw", async () => {
     const statements: { query: string; params: readonly unknown[] }[] = [];
     const deps = mockContributionDeps(
       {
@@ -1187,7 +1189,7 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+          writeFence: { mechanism: "caller-serialized" },
         },
         fenceSql: postgresFenceSql,
       },
@@ -1301,7 +1303,7 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
     expect(statements).toHaveLength(0);
   });
 
-  it("declared {caller-serialized, quiescent}: no throw, no LOCK TABLE", async () => {
+  it("declared {caller-serialized}: no throw, no LOCK TABLE", async () => {
     const statements: { query: string; params: readonly unknown[] }[] = [];
     const backend = mockTrustedImportBackend(
       {
@@ -1311,7 +1313,7 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        writeFence: { mechanism: "caller-serialized" },
       },
       statements,
     );
@@ -1546,6 +1548,151 @@ describe("T15 — the writeFence declaration", () => {
     });
     expect(plan).toEqual(
       expect.objectContaining({ kind: "lock", drain: "quiescent" }),
+    );
+  });
+});
+
+/**
+ * `resolveWriteFencePlan`'s runtime validation of a raw `writeFence` value —
+ * exercised with JavaScript-shaped declarations (a string TypeScript's
+ * discriminated union would reject at compile time, but a plain-JS backend
+ * author or a value round-tripped through JSON can still supply at runtime).
+ *
+ * Mutation check: comment out the `mechanism` allowlist check inside
+ * `validateWriteFenceDeclaration` (`src/backend/capabilities/write-fence.ts`)
+ * — the first test below stops throwing (the invalid mechanism reaches the
+ * switch's `default` arm, which then throws for a DIFFERENT reason, so the
+ * `field: "mechanism"` assertion fails) — then restore it. Comment out the
+ * `drain` allowlist check instead — the second test's target resolves a
+ * `{ kind: "lock", drain: "orbiting" }` plan instead of throwing, which the
+ * third assertion below (that no plan is ever returned) catches directly.
+ */
+function invalidWriteFenceTarget(writeFence: unknown): WriteFenceTarget {
+  return writeFenceTestTarget({
+    ...MINIMAL_EXECUTION_CAPABILITIES,
+    writeFence: writeFence as WriteFenceDeclaration,
+  });
+}
+
+describe("T15 — validateWriteFenceDeclaration: runtime validation of a JS-shaped declaration", () => {
+  it('refuses an unrecognized "mechanism" string with WRITE_FENCE_DECLARATION_INVALID naming the field and the accepted values', () => {
+    let caught: unknown;
+    try {
+      resolveWriteFencePlan(
+        invalidWriteFenceTarget({ mechanism: "row-lock", drain: "table-lock" }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_INVALID",
+          field: "mechanism",
+          value: "row-lock",
+          accepted: ["advisory", "engine-serialized", "caller-serialized"],
+        }) as unknown,
+      }),
+    );
+  });
+
+  it('refuses an unrecognized "drain" string under mechanism: "advisory" with WRITE_FENCE_DECLARATION_INVALID naming the field, never resolving a plan (an invalid drain must never behave like "quiescent")', () => {
+    let plan: unknown;
+    let caught: unknown;
+    try {
+      plan = resolveWriteFencePlan(
+        invalidWriteFenceTarget({ mechanism: "advisory", drain: "orbiting" }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(plan).toBeUndefined();
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_INVALID",
+          field: "drain",
+          value: "orbiting",
+          accepted: ["table-lock", "quiescent", "none"],
+        }) as unknown,
+      }),
+    );
+  });
+
+  it('refuses a "drain" key attached to mechanism: "engine-serialized" with WRITE_FENCE_DECLARATION_INVALID ("drain applies only to advisory")', () => {
+    let caught: unknown;
+    try {
+      resolveWriteFencePlan(
+        invalidWriteFenceTarget({
+          mechanism: "engine-serialized",
+          drain: "table-lock",
+        }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_INVALID",
+          field: "drain",
+          mechanism: "engine-serialized",
+        }) as unknown,
+      }),
+    );
+    expect((caught as Error).message).toContain("applies only to");
+  });
+
+  it('refuses a "drain" key attached to mechanism: "caller-serialized" with WRITE_FENCE_DECLARATION_INVALID ("drain applies only to advisory")', () => {
+    let caught: unknown;
+    try {
+      resolveWriteFencePlan(
+        invalidWriteFenceTarget({
+          mechanism: "caller-serialized",
+          drain: "quiescent",
+        }),
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_INVALID",
+          field: "drain",
+          mechanism: "caller-serialized",
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("createSqliteBackend refuses the same JS-shaped invalid declaration at construction, through the real factory entrypoint", () => {
+    expect(() =>
+      createLoggedSqliteBackend({
+        writeFence: { mechanism: "row-lock", drain: "table-lock" },
+      } as unknown as Partial<BackendCapabilities>),
+    ).toThrow(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_INVALID",
+          field: "mechanism",
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("createPostgresBackend refuses the same JS-shaped invalid declaration at construction, through the real factory entrypoint", async () => {
+    await expect(
+      createLoggedPostgresBackend({
+        writeFence: { mechanism: "advisory", drain: "orbiting" },
+      } as unknown as Partial<BackendCapabilities>),
+    ).rejects.toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_INVALID",
+          field: "drain",
+        }) as unknown,
+      }),
     );
   });
 });

--- a/packages/typegraph/tests/lock-fence-plan.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan.test.ts
@@ -73,12 +73,21 @@ import {
   fts5Strategy,
 } from "../src";
 import {
+  requireWriteFence,
+  resolveWriteFencePlan,
+  writeFenceFromLegacyLocks,
+  type WriteFenceTarget,
+} from "../src/backend/capabilities/write-fence";
+import {
   type ContributionMaterializerDeps,
   createContributionMaterializer,
 } from "../src/backend/drizzle/contribution-materializations";
 import { postgresFenceSql } from "../src/backend/drizzle/postgres-fence-sql";
 import { lockPostgresTrustedImportTables } from "../src/backend/drizzle/trusted-import";
-import type { TransactionBackend } from "../src/backend/types";
+import type {
+  BackendCapabilities,
+  TransactionBackend,
+} from "../src/backend/types";
 import { openProvenanceStore } from "../src/graph-merge";
 import { ensureIdentitySchemaStorage } from "../src/identity/schema-transition";
 import { rebuildIdentityClosureForContext } from "../src/identity/service";
@@ -1273,5 +1282,216 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
       "table locks without advisory locks or serialized writers",
     );
     expect(statements).toHaveLength(0);
+  });
+});
+
+/**
+ * T15 — the `writeFence` declaration itself: `writeFenceFromLegacyLocks`'s
+ * mapping, the `WRITE_FENCE_DECLARATION_CONFLICT` refusal, and
+ * `requireWriteFence`'s `drain`-keyed table-lock refusal.
+ *
+ * Every target here is dialect `"postgres"` carrying `postgresFenceSql`, so
+ * an `advisory` mechanism can actually resolve a `lock` plan — the mechanism
+ * under test does not depend on which real dialect supplied the spelling.
+ */
+function writeFenceTestTarget(
+  capabilities: BackendCapabilities,
+): WriteFenceTarget {
+  return { dialect: "postgres", capabilities, fenceSql: postgresFenceSql };
+}
+
+const MINIMAL_EXECUTION_CAPABILITIES: BackendCapabilities = Object.freeze({
+  execution: Object.freeze({
+    interactiveTransactions: true,
+    atomicBatch: "none",
+  }),
+  windowFunctions: true,
+});
+
+/**
+ * A resolved `lock` plan's `sql` field is a fresh `FenceStatements` closure
+ * built by `resolveFenceStatements` on every call, so two plans resolved
+ * from equivalent declarations never carry referentially-equal (or
+ * `toEqual`-comparable — functions have no structural equality) `sql`
+ * objects even when every other field agrees. Comparing "the SAME plan
+ * through either declaration style" means every field but `sql`.
+ */
+function planShapeWithoutSql(plan: unknown): unknown {
+  if (typeof plan !== "object" || plan === null || !("sql" in plan)) {
+    return plan;
+  }
+  const { sql: _sql, ...rest } = plan as Record<string, unknown>;
+  return rest;
+}
+
+describe("T15 — the writeFence declaration", () => {
+  it("declaring both writeFence and pessimisticLocks refuses (WRITE_FENCE_DECLARATION_CONFLICT)", () => {
+    const target = writeFenceTestTarget({
+      ...MINIMAL_EXECUTION_CAPABILITIES,
+      writeFence: { mechanism: "advisory", drain: "table-lock" },
+      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+    });
+    expect(() => resolveWriteFencePlan(target)).toThrow(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_DECLARATION_CONFLICT",
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("advisory + tableLocks: true maps to {mechanism: advisory, drain: table-lock}, and resolves the SAME plan through either declaration style", () => {
+    const legacy = {
+      advisoryLocks: true,
+      tableLocks: true,
+      serializedWriters: false,
+    };
+    expect(writeFenceFromLegacyLocks(legacy)).toEqual({
+      mechanism: "advisory",
+      drain: "table-lock",
+    });
+    const viaLegacy = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        pessimisticLocks: legacy,
+      }),
+    );
+    const viaWriteFence = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "advisory", drain: "table-lock" },
+      }),
+    );
+    expect(planShapeWithoutSql(viaWriteFence)).toEqual(
+      planShapeWithoutSql(viaLegacy),
+    );
+    expect(viaLegacy).toEqual(
+      expect.objectContaining({
+        kind: "lock",
+        drain: "table-lock",
+        tableLocks: true,
+      }),
+    );
+  });
+
+  it("advisory + tableLocks: false (declared-advisory-only) maps to {mechanism: advisory, drain: none}, and resolves the SAME plan through either declaration style", () => {
+    expect(writeFenceFromLegacyLocks(ADVISORY_ONLY_CAPABILITIES)).toEqual({
+      mechanism: "advisory",
+      drain: "none",
+    });
+    const viaLegacy = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+      }),
+    );
+    const viaWriteFence = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "advisory", drain: "none" },
+      }),
+    );
+    expect(planShapeWithoutSql(viaWriteFence)).toEqual(
+      planShapeWithoutSql(viaLegacy),
+    );
+    expect(viaLegacy).toEqual(
+      expect.objectContaining({
+        kind: "lock",
+        drain: "none",
+        tableLocks: false,
+      }),
+    );
+  });
+
+  it("serializedWriters: true (SQLite-shaped) maps to {mechanism: engine-serialized, drain: table-lock}, and resolves the SAME plan through either declaration style", () => {
+    const legacy = {
+      advisoryLocks: false,
+      tableLocks: false,
+      serializedWriters: true,
+    };
+    expect(writeFenceFromLegacyLocks(legacy)).toEqual({
+      mechanism: "engine-serialized",
+      drain: "table-lock",
+    });
+    const viaLegacy = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        pessimisticLocks: legacy,
+      }),
+    );
+    const viaWriteFence = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+      }),
+    );
+    expect(planShapeWithoutSql(viaWriteFence)).toEqual(
+      planShapeWithoutSql(viaLegacy),
+    );
+    expect(viaLegacy).toEqual({ kind: "engine-serialized" });
+  });
+
+  it("all-false (declared-unfenced) maps to undefined; resolveWriteFencePlan falls back to unfenced/declared-none", () => {
+    expect(writeFenceFromLegacyLocks(UNFENCED_CAPABILITIES)).toBeUndefined();
+    expect(
+      resolveWriteFencePlan(
+        writeFenceTestTarget({
+          ...MINIMAL_EXECUTION_CAPABILITIES,
+          pessimisticLocks: UNFENCED_CAPABILITIES,
+        }),
+      ),
+    ).toEqual({ kind: "unfenced", reason: "declared-none" });
+  });
+
+  it('requireWriteFence under {advisory, quiescent} with "table-lock" returns the lock arm with drain quiescent, taking no statement itself', () => {
+    const plan = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "advisory", drain: "quiescent" },
+      }),
+    );
+    const fence = requireWriteFence(plan, "quiescent drain test", "table-lock");
+    expect(fence).toEqual(
+      expect.objectContaining({
+        kind: "lock",
+        drain: "quiescent",
+        tableLocks: false,
+      }),
+    );
+  });
+
+  it('requireWriteFence under {advisory, none} with "table-lock" refuses, naming the drain', () => {
+    const plan = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "advisory", drain: "none" },
+      }),
+    );
+    let caught: unknown;
+    try {
+      requireWriteFence(plan, "none drain test", "table-lock");
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_UNAVAILABLE",
+        }) as unknown,
+      }),
+    );
+    expect((caught as Error).message).toContain('drain: "none"');
+  });
+
+  it('requireWriteFence under {advisory, quiescent} with "advisory-lock" also returns the lock arm (advisory-lock never consults drain)', () => {
+    const plan = resolveWriteFencePlan(
+      writeFenceTestTarget({
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "advisory", drain: "quiescent" },
+      }),
+    );
+    expect(
+      requireWriteFence(plan, "quiescent advisory-lock test", "advisory-lock"),
+    ).toEqual(expect.objectContaining({ kind: "lock", drain: "quiescent" }));
   });
 });

--- a/packages/typegraph/tests/lock-fence-plan.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan.test.ts
@@ -301,6 +301,46 @@ describe("T15 — J1 lockRecordedGraphWrite", () => {
     }
   });
 
+  it("declared {advisory, quiescent}: advisory lock present, no throw (advisory-lock never consults drain)", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        lockRecordedGraphWrite(logged.backend, "graph-a"),
+      ).resolves.toBeDefined();
+      expect(
+        advisoryLockIndices(
+          logged.statements,
+          RECORDED_GRAPH_WRITE_ADVISORY_LOCK,
+        ),
+      ).toHaveLength(1);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {caller-serialized, quiescent}: no advisory lock, no throw", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        lockRecordedGraphWrite(logged.backend, "graph-a"),
+      ).resolves.toBeDefined();
+      expect(
+        advisoryLockIndices(
+          logged.statements,
+          RECORDED_GRAPH_WRITE_ADVISORY_LOCK,
+        ),
+      ).toHaveLength(0);
+    } finally {
+      await logged.close();
+    }
+  });
+
   it("ordinary graph-merge uniqueness refuses an unfenced store backend", async () => {
     const logged = await createLoggedPostgresBackend({
       pessimisticLocks: UNFENCED_CAPABILITIES,
@@ -410,6 +450,59 @@ describe("T15 — J2 lockRecordedClock (via allocateRecordedCommit)", () => {
     }
   });
 
+  it("declared {advisory, quiescent}: advisory lock present (advisory-lock never consults drain)", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        allocateRecordedCommit(logged.backend, schema, "graph-b", false),
+      ).resolves.toBeDefined();
+      expect(
+        advisoryLockIndices(logged.statements, RECORDED_CLOCK_ADVISORY_LOCK),
+      ).toHaveLength(1);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it.each([false, true] as const)(
+    "declared {caller-serialized, quiescent}: no advisory lock and no seed-UPSERT, regardless of ownsWriteLock (ownsWriteLock: %s)",
+    async (ownsWriteLock) => {
+      const logged = await createLoggedPostgresBackend({
+        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      });
+      try {
+        logged.reset();
+        await expect(
+          allocateRecordedCommit(
+            logged.backend,
+            schema,
+            "graph-b",
+            ownsWriteLock,
+          ),
+        ).resolves.toBeDefined();
+        expect(
+          advisoryLockIndices(logged.statements, RECORDED_CLOCK_ADVISORY_LOCK),
+        ).toHaveLength(0);
+        // Unlike `engine-serialized` (which skips the seed-UPSERT only when
+        // `ownsWriteLock` is true), the seed-UPSERT is never taken here for
+        // EITHER value — a `caller-serialized` promise is about the
+        // deployment, not about which transaction opened this frame.
+        expect(
+          logged.statements.some((statement) =>
+            statement.query.includes(
+              "ON CONFLICT (graph_id) DO UPDATE SET revision = revision",
+            ),
+          ),
+        ).toBe(false);
+      } finally {
+        await logged.close();
+      }
+    },
+  );
+
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
@@ -494,6 +587,40 @@ describe("T15 — J3 lockIdentityGraph", () => {
       expect(
         advisoryLockIndices(logged.statements, IDENTITY_ADVISORY_LOCK),
       ).toHaveLength(1);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {advisory, quiescent}: advisory lock present (advisory-lock never consults drain)", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        lockIdentityGraph(logged.backend, "graph-c"),
+      ).resolves.toBeUndefined();
+      expect(
+        advisoryLockIndices(logged.statements, IDENTITY_ADVISORY_LOCK),
+      ).toHaveLength(1);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {caller-serialized, quiescent}: no advisory lock, no throw", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        lockIdentityGraph(logged.backend, "graph-c"),
+      ).resolves.toBeUndefined();
+      expect(
+        advisoryLockIndices(logged.statements, IDENTITY_ADVISORY_LOCK),
+      ).toHaveLength(0);
     } finally {
       await logged.close();
     }
@@ -597,6 +724,36 @@ describe("T15 — J4 lockIdentityEnablementNodes", () => {
           }) as unknown,
         }),
       );
+      expect(tableLockIndices(logged.statements, "nodes")).toHaveLength(0);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {advisory, quiescent}: no throw, no LOCK TABLE (drain consulted before locking)", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        lockIdentityEnablementNodes(logged.backend, schema),
+      ).resolves.toBeUndefined();
+      expect(tableLockIndices(logged.statements, "nodes")).toHaveLength(0);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {caller-serialized, quiescent}: no throw, no LOCK TABLE", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        lockIdentityEnablementNodes(logged.backend, schema),
+      ).resolves.toBeUndefined();
       expect(tableLockIndices(logged.statements, "nodes")).toHaveLength(0);
     } finally {
       await logged.close();
@@ -768,6 +925,58 @@ describe("T15 — J5 lockIdentityDdl (via ensureIdentitySchemaStorage)", () => {
     }
   });
 
+  it("declared {advisory, quiescent}: advisory lock present (advisory-lock never consults drain)", async () => {
+    const logged = await createLoggedPostgresBackend();
+    try {
+      await seedIdentityUpgrade(logged);
+      const { pessimisticLocks: _pessimisticLocks, ...rest } =
+        logged.backend.capabilities;
+      const target = overlayCapabilities(logged.backend, {
+        ...rest,
+        writeFence: { mechanism: "advisory", drain: "quiescent" },
+      });
+      logged.reset();
+      await expect(
+        ensureIdentitySchemaStorage(
+          target,
+          schema,
+          identityProvisioningOptions(schema, registry),
+        ),
+      ).resolves.toBeDefined();
+      expect(
+        advisoryLockIndices(logged.statements, IDENTITY_DDL_ADVISORY_LOCK),
+      ).toHaveLength(1);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {caller-serialized, quiescent}: no advisory lock, no throw", async () => {
+    const logged = await createLoggedPostgresBackend();
+    try {
+      await seedIdentityUpgrade(logged);
+      const { pessimisticLocks: _pessimisticLocks, ...rest } =
+        logged.backend.capabilities;
+      const target = overlayCapabilities(logged.backend, {
+        ...rest,
+        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      });
+      logged.reset();
+      await expect(
+        ensureIdentitySchemaStorage(
+          target,
+          schema,
+          identityProvisioningOptions(schema, registry),
+        ),
+      ).resolves.toBeDefined();
+      expect(
+        advisoryLockIndices(logged.statements, IDENTITY_DDL_ADVISORY_LOCK),
+      ).toHaveLength(0);
+    } finally {
+      await logged.close();
+    }
+  });
+
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
@@ -869,6 +1078,36 @@ describe("T15 — J6 drainUnfencedRowWriters (via openProvenanceStore)", () => {
           }) as unknown,
         }),
       );
+      expect(tableLockIndices(logged.statements, "nodes")).toHaveLength(0);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {advisory, quiescent}: no throw, no LOCK TABLE (drain consulted before locking)", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        openProvenanceStore(logged.backend, freshGraphId()),
+      ).resolves.toBeDefined();
+      expect(tableLockIndices(logged.statements, "nodes")).toHaveLength(0);
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("declared {caller-serialized, quiescent}: no throw, no LOCK TABLE", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+    });
+    try {
+      logged.reset();
+      await expect(
+        openProvenanceStore(logged.backend, freshGraphId()),
+      ).resolves.toBeDefined();
       expect(tableLockIndices(logged.statements, "nodes")).toHaveLength(0);
     } finally {
       await logged.close();
@@ -1103,6 +1342,52 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
     expect(hasTableLock(statements)).toBe(false);
   });
 
+  it("declared {advisory, quiescent}: contribution lock present, no LOCK TABLE, no throw", async () => {
+    const statements: { query: string; params: readonly unknown[] }[] = [];
+    const deps = mockContributionDeps(
+      {
+        dialect: "postgres",
+        capabilities: {
+          execution: {
+            interactiveTransactions: true,
+            atomicBatch: "none",
+            unitOfWork: "interactive",
+          },
+          windowFunctions: true,
+          writeFence: { mechanism: "advisory", drain: "quiescent" },
+        },
+        fenceSql: postgresFenceSql,
+      },
+      statements,
+    );
+    await expect(rebuild(deps)).resolves.toBeDefined();
+    expect(hasContributionAdvisoryLock(statements)).toBe(true);
+    expect(hasTableLock(statements)).toBe(false);
+  });
+
+  it("declared {caller-serialized, quiescent}: no lock statements, no throw", async () => {
+    const statements: { query: string; params: readonly unknown[] }[] = [];
+    const deps = mockContributionDeps(
+      {
+        dialect: "postgres",
+        capabilities: {
+          execution: {
+            interactiveTransactions: true,
+            atomicBatch: "none",
+            unitOfWork: "interactive",
+          },
+          windowFunctions: true,
+          writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        },
+        fenceSql: postgresFenceSql,
+      },
+      statements,
+    );
+    await expect(rebuild(deps)).resolves.toBeDefined();
+    expect(hasContributionAdvisoryLock(statements)).toBe(false);
+    expect(hasTableLock(statements)).toBe(false);
+  });
+
   it("undeclared non-factory (postgres): refuses, no lock statement", async () => {
     const statements: { query: string; params: readonly unknown[] }[] = [];
     const deps = mockContributionDeps(
@@ -1189,6 +1474,44 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
           'LOCK TABLE "typegraph_nodes", "typegraph_edges" IN ACCESS EXCLUSIVE MODE',
       ),
     ).toBe(true);
+  });
+
+  it("declared {advisory, quiescent}: no throw, no LOCK TABLE (drain consulted before locking)", async () => {
+    const statements: { query: string; params: readonly unknown[] }[] = [];
+    const backend = mockTrustedImportBackend(
+      {
+        execution: {
+          interactiveTransactions: true,
+          atomicBatch: "none",
+          unitOfWork: "interactive",
+        },
+        windowFunctions: true,
+        writeFence: { mechanism: "advisory", drain: "quiescent" },
+      },
+      statements,
+    );
+    await lockPostgresTrustedImportTables(backend, TRUSTED_IMPORT_TABLE_NAMES);
+    expect(hasTableLock(statements)).toBe(false);
+    expect(statements).toHaveLength(0);
+  });
+
+  it("declared {caller-serialized, quiescent}: no throw, no LOCK TABLE", async () => {
+    const statements: { query: string; params: readonly unknown[] }[] = [];
+    const backend = mockTrustedImportBackend(
+      {
+        execution: {
+          interactiveTransactions: true,
+          atomicBatch: "none",
+          unitOfWork: "interactive",
+        },
+        windowFunctions: true,
+        writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      },
+      statements,
+    );
+    await lockPostgresTrustedImportTables(backend, TRUSTED_IMPORT_TABLE_NAMES);
+    expect(hasTableLock(statements)).toBe(false);
+    expect(statements).toHaveLength(0);
   });
 
   it("declared-advisory-only: refuses before any statement (WRITE_FENCE_UNAVAILABLE)", async () => {
@@ -1493,5 +1816,107 @@ describe("T15 — the writeFence declaration", () => {
     expect(
       requireWriteFence(plan, "quiescent advisory-lock test", "advisory-lock"),
     ).toEqual(expect.objectContaining({ kind: "lock", drain: "quiescent" }));
+  });
+
+  it("advisory + drain: table-lock with a fenceSql missing advisoryLockExpression refuses WRITE_FENCE_SQL_UNAVAILABLE naming that member", () => {
+    let caught: unknown;
+    try {
+      resolveWriteFencePlan({
+        dialect: "postgres",
+        capabilities: {
+          ...MINIMAL_EXECUTION_CAPABILITIES,
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
+        },
+        fenceSql: {
+          isolationFactExpression: postgresFenceSql.isolationFactExpression,
+          lockTables: postgresFenceSql.lockTables,
+        } as unknown as typeof postgresFenceSql,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_SQL_UNAVAILABLE",
+          member: "advisoryLockExpression",
+        }) as unknown,
+      }),
+    );
+    expect((caught as Error).message).toContain("advisoryLockExpression");
+  });
+
+  it("advisory + drain: table-lock with a fenceSql missing isolationFactExpression refuses WRITE_FENCE_SQL_UNAVAILABLE naming that member", () => {
+    let caught: unknown;
+    try {
+      resolveWriteFencePlan({
+        dialect: "postgres",
+        capabilities: {
+          ...MINIMAL_EXECUTION_CAPABILITIES,
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
+        },
+        fenceSql: {
+          advisoryLockExpression: postgresFenceSql.advisoryLockExpression,
+          lockTables: postgresFenceSql.lockTables,
+        } as unknown as typeof postgresFenceSql,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_SQL_UNAVAILABLE",
+          member: "isolationFactExpression",
+        }) as unknown,
+      }),
+    );
+    expect((caught as Error).message).toContain("isolationFactExpression");
+  });
+
+  it("advisory + drain: table-lock with a fenceSql missing lockTables refuses WRITE_FENCE_SQL_UNAVAILABLE naming that member and the drain", () => {
+    let caught: unknown;
+    try {
+      resolveWriteFencePlan({
+        dialect: "postgres",
+        capabilities: {
+          ...MINIMAL_EXECUTION_CAPABILITIES,
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
+        },
+        fenceSql: {
+          advisoryLockExpression: postgresFenceSql.advisoryLockExpression,
+          isolationFactExpression: postgresFenceSql.isolationFactExpression,
+        } as unknown as typeof postgresFenceSql,
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toEqual(
+      expect.objectContaining({
+        details: expect.objectContaining({
+          code: "WRITE_FENCE_SQL_UNAVAILABLE",
+          member: "lockTables",
+          drain: "table-lock",
+        }) as unknown,
+      }),
+    );
+    expect((caught as Error).message).toContain("lockTables");
+  });
+
+  it("advisory + drain: quiescent with the SAME fenceSql missing lockTables does NOT refuse (lockTables is only required by drain: table-lock)", () => {
+    const plan = resolveWriteFencePlan({
+      dialect: "postgres",
+      capabilities: {
+        ...MINIMAL_EXECUTION_CAPABILITIES,
+        writeFence: { mechanism: "advisory", drain: "quiescent" },
+      },
+      fenceSql: {
+        advisoryLockExpression: postgresFenceSql.advisoryLockExpression,
+        isolationFactExpression: postgresFenceSql.isolationFactExpression,
+      } as unknown as typeof postgresFenceSql,
+    });
+    expect(plan).toEqual(
+      expect.objectContaining({ kind: "lock", drain: "quiescent" }),
+    );
   });
 });

--- a/packages/typegraph/tests/lock-fence-plan.test.ts
+++ b/packages/typegraph/tests/lock-fence-plan.test.ts
@@ -1,27 +1,24 @@
 /**
- * T15 — the write-fence plan, at each of the 8 lock sites, across 5 postures.
+ * T15 — the write-fence plan, at each of the 8 lock sites, across 4 postures.
  *
  * Postures (the SQLite factory is exercised on a real better-sqlite3
- * connection; the other four are exercised on a real PGlite PostgreSQL
+ * connection; the other three are exercised on a real PGlite PostgreSQL
  * connection, since only a PostgreSQL-dialect connection can actually run
  * `pg_advisory_xact_lock` / `LOCK TABLE` SQL when the plan resolves to
  * `"lock"`):
  *
- *  1. SQLite factory — declared `{advisoryLocks:false, tableLocks:false,
- *     serializedWriters:true}` (A1). Every site resolves `engine-serialized`.
- *  2. PostgreSQL factory — declared `{advisoryLocks:true, tableLocks:true,
- *     serializedWriters:false}` (A2). Every site resolves `lock`.
- *  3. declared-unfenced — a PostgreSQL factory backend whose `capabilities`
- *     OVERRIDE (a real factory option, so it flows into every closure the
- *     factory builds at construction) declares `pessimisticLocks` all-false.
- *     Every site resolves `unfenced` and refuses.
- *  4. declared-advisory-only — `{advisoryLocks:true, tableLocks:false,
- *     serializedWriters:false}`. Advisory-lock sites (J1, J2, J3, J5, J7)
- *     succeed exactly as posture 2; table-lock sites (J4, J6, J8) refuse.
- *  5. undeclared non-factory (PostgreSQL dialect) — a real PostgreSQL
- *     connection wrapped so `capabilities.pessimisticLocks` is ABSENT and the
+ *  1. SQLite factory — declared `{mechanism: "engine-serialized", drain:
+ *     "table-lock"}` (A1). Every site resolves `engine-serialized`.
+ *  2. PostgreSQL factory — declared `{mechanism: "advisory", drain:
+ *     "table-lock"}` (A2). Every site resolves `lock`.
+ *  3. declared-advisory-only — `{mechanism: "advisory", drain: "none"}`.
+ *     Keyed sites (J1, J2, J3, J5, J7) succeed exactly as posture 2; drain
+ *     sites (J4, J6, J8) refuse.
+ *  4. undeclared non-factory (PostgreSQL dialect) — a real PostgreSQL
+ *     connection wrapped so `capabilities.writeFence` is ABSENT and the
  *     first-party mark is NOT carried (M-5's defect population). Every site
- *     resolves `unfenced`, identically to posture 3.
+ *     resolves `unfenced` and refuses — `writeFence` has no mechanism that
+ *     means "no fence", so this is the only way left to reach that plan.
  *
  * J1/J2 via `lockRecordedGraphWrite`/`allocateRecordedCommit` (both exported
  * directly, called with no Store at all — the full DDL bundled backends
@@ -43,19 +40,16 @@
  *
  * A ninth site, `lockPostgresTrustedImportTables` (J18 in the inventory —
  * see `tests/lock-fence-plan-inventory.test.ts`), is covered separately
- * below rather than folded into the 5-posture matrix above: it is a
- * PostgreSQL-only table lock with no advisory lock preceding it, so postures
- * 1 and 5 do not apply to it the way they do to J1-J8. Its own block covers
- * the postures that DO apply: PostgreSQL factory (lock taken, statement
- * pinned), declared-advisory-only (refuses — the `tableLocks: false` pin),
- * declared-unfenced (refuses), and declared-table-locks-only (refuses — the
- * plan model has no table-lock-alone arm, so `{advisoryLocks: false,
- * tableLocks: true, serializedWriters: false}` resolves `unfenced` same as
- * declared-unfenced does).
+ * below rather than folded into the 4-posture matrix above: it is a
+ * PostgreSQL-only table lock with no advisory lock preceding it, so posture
+ * 1 does not apply to it the way it does to J1-J8. Its own block covers the
+ * postures that DO apply: PostgreSQL factory (lock taken, statement
+ * pinned), declared-advisory-only (refuses — the `drain: "none"` pin), and
+ * undeclared non-factory (refuses).
  *
- * *Mutation A*: flip `serializedWriters` to `false` on `SQLITE_CAPABILITIES`
- * → the SQLite rows demand locks SQLite cannot take (J2-J8 refuse) — those
- * rows fail.
+ * *Mutation A*: flip `SQLITE_CAPABILITIES.writeFence.mechanism` away from
+ * `"engine-serialized"` → the SQLite rows demand locks SQLite cannot take
+ * (J2-J8 refuse) — those rows fail.
  * *Mutation B*: make the unmarked-absent arm derive from dialect → the
  * undeclared-non-factory rows emit advisory locks; that posture's rows fail.
  * *Mutation C*: make `requireWriteFence` ignore `requires` → the
@@ -75,7 +69,6 @@ import {
 import {
   requireWriteFence,
   resolveWriteFencePlan,
-  writeFenceFromLegacyLocks,
   type WriteFenceTarget,
 } from "../src/backend/capabilities/write-fence";
 import {
@@ -113,8 +106,7 @@ import {
   createLoggedSqliteBackend,
   type LoggedBackend,
   overlayCapabilities,
-  TABLE_LOCKS_ONLY_CAPABILITIES,
-  UNFENCED_CAPABILITIES,
+  unfencedLoggedBackend,
 } from "./lock-fence-test-utils";
 
 const IDENTITY_ADVISORY_LOCK = "typegraph:identity";
@@ -230,35 +222,9 @@ describe("T15 — J1 lockRecordedGraphWrite", () => {
     }
   });
 
-  it("declared-unfenced: refuses before any graph-write statement", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      logged.reset();
-      await expect(
-        lockRecordedGraphWrite(logged.backend, "graph-a"),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          details: expect.objectContaining({
-            code: "WRITE_FENCE_UNAVAILABLE",
-          }) as unknown,
-        }),
-      );
-      expect(
-        advisoryLockIndices(
-          logged.statements,
-          RECORDED_GRAPH_WRITE_ADVISORY_LOCK,
-        ),
-      ).toHaveLength(0);
-    } finally {
-      await logged.close();
-    }
-  });
-
   it("declared-advisory-only: advisory lock present, no throw", async () => {
     const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+      writeFence: ADVISORY_ONLY_CAPABILITIES,
     });
     try {
       logged.reset();
@@ -279,7 +245,7 @@ describe("T15 — J1 lockRecordedGraphWrite", () => {
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+      const { writeFence: _writeFence, ...undeclared } =
         logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, undeclared);
       logged.reset();
@@ -342,15 +308,14 @@ describe("T15 — J1 lockRecordedGraphWrite", () => {
   });
 
   it("ordinary graph-merge uniqueness refuses an unfenced store backend", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
+    const logged = await createLoggedPostgresBackend();
     try {
       const store = createStore(uniquenessGraph, logged.backend);
+      const unfencedTarget = unfencedLoggedBackend(logged).backend;
       logged.reset();
       await expect(
         store[STORE_RUNTIME].applyResolvedNodeUniqueness(
-          logged.backend,
+          unfencedTarget,
           {
             upserts: [
               {
@@ -410,32 +375,9 @@ describe("T15 — J2 lockRecordedClock (via allocateRecordedCommit)", () => {
     }
   });
 
-  it("declared-unfenced: refuses before any clock statement", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      logged.reset();
-      await expect(
-        allocateRecordedCommit(logged.backend, schema, "graph-b", false),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          details: expect.objectContaining({
-            code: "WRITE_FENCE_UNAVAILABLE",
-          }) as unknown,
-        }),
-      );
-      expect(
-        advisoryLockIndices(logged.statements, RECORDED_CLOCK_ADVISORY_LOCK),
-      ).toHaveLength(0);
-    } finally {
-      await logged.close();
-    }
-  });
-
   it("declared-advisory-only: advisory lock present", async () => {
     const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+      writeFence: ADVISORY_ONLY_CAPABILITIES,
     });
     try {
       logged.reset();
@@ -506,7 +448,7 @@ describe("T15 — J2 lockRecordedClock (via allocateRecordedCommit)", () => {
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+      const { writeFence: _writeFence, ...undeclared } =
         logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, undeclared);
       logged.reset();
@@ -556,28 +498,9 @@ describe("T15 — J3 lockIdentityGraph", () => {
     }
   });
 
-  it("declared-unfenced: refuses", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      await expect(
-        lockIdentityGraph(logged.backend, "graph-c"),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          details: expect.objectContaining({
-            code: "WRITE_FENCE_UNAVAILABLE",
-          }) as unknown,
-        }),
-      );
-    } finally {
-      await logged.close();
-    }
-  });
-
   it("declared-advisory-only: advisory lock present", async () => {
     const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+      writeFence: ADVISORY_ONLY_CAPABILITIES,
     });
     try {
       logged.reset();
@@ -629,7 +552,7 @@ describe("T15 — J3 lockIdentityGraph", () => {
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+      const { writeFence: _writeFence, ...undeclared } =
         logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, undeclared);
       await expect(lockIdentityGraph(target, "graph-c")).rejects.toThrow(
@@ -690,28 +613,9 @@ describe("T15 — J4 lockIdentityEnablementNodes", () => {
     }
   });
 
-  it("declared-unfenced: refuses", async () => {
+  it("declared-advisory-only: refuses (needs drain: 'table-lock'), no LOCK TABLE", async () => {
     const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      await expect(
-        lockIdentityEnablementNodes(logged.backend, schema),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          details: expect.objectContaining({
-            code: "WRITE_FENCE_UNAVAILABLE",
-          }) as unknown,
-        }),
-      );
-    } finally {
-      await logged.close();
-    }
-  });
-
-  it("declared-advisory-only: refuses (needs tableLocks), no LOCK TABLE", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+      writeFence: ADVISORY_ONLY_CAPABILITIES,
     });
     try {
       logged.reset();
@@ -763,7 +667,7 @@ describe("T15 — J4 lockIdentityEnablementNodes", () => {
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+      const { writeFence: _writeFence, ...undeclared } =
         logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, undeclared);
       await expect(lockIdentityEnablementNodes(target, schema)).rejects.toThrow(
@@ -871,43 +775,13 @@ describe("T15 — J5 lockIdentityDdl (via ensureIdentitySchemaStorage)", () => {
     }
   });
 
-  it("declared-unfenced: refuses", async () => {
-    const logged = await createLoggedPostgresBackend();
-    try {
-      await seedIdentityUpgrade(logged);
-      const target = overlayCapabilities(logged.backend, {
-        ...logged.backend.capabilities,
-        pessimisticLocks: UNFENCED_CAPABILITIES,
-      });
-      logged.reset();
-      await expect(
-        ensureIdentitySchemaStorage(
-          target,
-          schema,
-          identityProvisioningOptions(schema, registry),
-        ),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          details: expect.objectContaining({
-            code: "WRITE_FENCE_UNAVAILABLE",
-          }) as unknown,
-        }),
-      );
-      expect(
-        advisoryLockIndices(logged.statements, IDENTITY_DDL_ADVISORY_LOCK),
-      ).toHaveLength(0);
-    } finally {
-      await logged.close();
-    }
-  });
-
   it("declared-advisory-only: advisory lock present", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
       await seedIdentityUpgrade(logged);
       const target = overlayCapabilities(logged.backend, {
         ...logged.backend.capabilities,
-        pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+        writeFence: ADVISORY_ONLY_CAPABILITIES,
       });
       logged.reset();
       await expect(
@@ -929,8 +803,7 @@ describe("T15 — J5 lockIdentityDdl (via ensureIdentitySchemaStorage)", () => {
     const logged = await createLoggedPostgresBackend();
     try {
       await seedIdentityUpgrade(logged);
-      const { pessimisticLocks: _pessimisticLocks, ...rest } =
-        logged.backend.capabilities;
+      const { writeFence: _writeFence, ...rest } = logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, {
         ...rest,
         writeFence: { mechanism: "advisory", drain: "quiescent" },
@@ -955,8 +828,7 @@ describe("T15 — J5 lockIdentityDdl (via ensureIdentitySchemaStorage)", () => {
     const logged = await createLoggedPostgresBackend();
     try {
       await seedIdentityUpgrade(logged);
-      const { pessimisticLocks: _pessimisticLocks, ...rest } =
-        logged.backend.capabilities;
+      const { writeFence: _writeFence, ...rest } = logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, {
         ...rest,
         writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
@@ -981,7 +853,7 @@ describe("T15 — J5 lockIdentityDdl (via ensureIdentitySchemaStorage)", () => {
     const logged = await createLoggedPostgresBackend();
     try {
       await seedIdentityUpgrade(logged);
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+      const { writeFence: _writeFence, ...undeclared } =
         logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, undeclared);
       logged.reset();
@@ -1044,28 +916,9 @@ describe("T15 — J6 drainUnfencedRowWriters (via openProvenanceStore)", () => {
     }
   });
 
-  it("declared-unfenced: refuses", async () => {
+  it("declared-advisory-only: refuses (needs drain: 'table-lock'), no LOCK TABLE", async () => {
     const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      await expect(
-        openProvenanceStore(logged.backend, freshGraphId()),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          details: expect.objectContaining({
-            code: "WRITE_FENCE_UNAVAILABLE",
-          }) as unknown,
-        }),
-      );
-    } finally {
-      await logged.close();
-    }
-  });
-
-  it("declared-advisory-only: refuses (needs tableLocks), no LOCK TABLE", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+      writeFence: ADVISORY_ONLY_CAPABILITIES,
     });
     try {
       logged.reset();
@@ -1117,7 +970,7 @@ describe("T15 — J6 drainUnfencedRowWriters (via openProvenanceStore)", () => {
   it("undeclared non-factory (postgres): refuses", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+      const { writeFence: _writeFence, ...undeclared } =
         logged.backend.capabilities;
       const target = overlayCapabilities(logged.backend, undeclared);
       await expect(openProvenanceStore(target, freshGraphId())).rejects.toThrow(
@@ -1227,11 +1080,7 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          pessimisticLocks: {
-            advisoryLocks: false,
-            tableLocks: false,
-            serializedWriters: true,
-          },
+          writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
         },
       },
       statements,
@@ -1253,11 +1102,7 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          pessimisticLocks: {
-            advisoryLocks: true,
-            tableLocks: true,
-            serializedWriters: false,
-          },
+          writeFence: { mechanism: "advisory", drain: "table-lock" },
         },
         fenceSql: postgresFenceSql,
       },
@@ -1278,37 +1123,6 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
     ).toBe(true);
   });
 
-  it("declared-unfenced: refuses before any lock statement", async () => {
-    const statements: { query: string; params: readonly unknown[] }[] = [];
-    const deps = mockContributionDeps(
-      {
-        dialect: "postgres",
-        capabilities: {
-          execution: {
-            interactiveTransactions: true,
-            atomicBatch: "none",
-            unitOfWork: "interactive",
-          },
-          windowFunctions: true,
-          pessimisticLocks: {
-            advisoryLocks: false,
-            tableLocks: false,
-            serializedWriters: false,
-          },
-        },
-      },
-      statements,
-    );
-    await expect(rebuild(deps)).rejects.toThrow(
-      expect.objectContaining({
-        details: expect.objectContaining({
-          code: "WRITE_FENCE_UNAVAILABLE",
-        }) as unknown,
-      }),
-    );
-    expect(statements).toHaveLength(0);
-  });
-
   it("declared-advisory-only: contribution lock present, no LOCK TABLE, refuses", async () => {
     const statements: { query: string; params: readonly unknown[] }[] = [];
     const deps = mockContributionDeps(
@@ -1321,11 +1135,7 @@ describe("T15 — J7/J8 lockContributionDdl / lockSharedFulltextTable", () => {
             unitOfWork: "interactive",
           },
           windowFunctions: true,
-          pessimisticLocks: {
-            advisoryLocks: true,
-            tableLocks: false,
-            serializedWriters: false,
-          },
+          writeFence: { mechanism: "advisory", drain: "none" },
         },
         fenceSql: postgresFenceSql,
       },
@@ -1455,11 +1265,7 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        pessimisticLocks: {
-          advisoryLocks: true,
-          tableLocks: true,
-          serializedWriters: false,
-        },
+        writeFence: { mechanism: "advisory", drain: "table-lock" },
       },
       statements,
     );
@@ -1524,7 +1330,7 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
+        writeFence: ADVISORY_ONLY_CAPABILITIES,
       },
       statements,
     );
@@ -1540,7 +1346,7 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
     expect(statements).toHaveLength(0);
   });
 
-  it("declared-unfenced: refuses before any statement", async () => {
+  it("undeclared non-factory: refuses before any statement", async () => {
     const statements: { query: string; params: readonly unknown[] }[] = [];
     const backend = mockTrustedImportBackend(
       {
@@ -1550,7 +1356,6 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
           unitOfWork: "interactive",
         },
         windowFunctions: true,
-        pessimisticLocks: UNFENCED_CAPABILITIES,
       },
       statements,
     );
@@ -1562,56 +1367,15 @@ describe("T15 — J18 lockPostgresTrustedImportTables", () => {
           code: "WRITE_FENCE_UNAVAILABLE",
         }) as unknown,
       }),
-    );
-    expect(statements).toHaveLength(0);
-  });
-
-  it("declared-table-locks-only: refuses before any statement (no table-lock-alone arm), naming the posture", async () => {
-    const statements: { query: string; params: readonly unknown[] }[] = [];
-    const backend = mockTrustedImportBackend(
-      {
-        execution: {
-          interactiveTransactions: true,
-          atomicBatch: "none",
-          unitOfWork: "interactive",
-        },
-        windowFunctions: true,
-        pessimisticLocks: TABLE_LOCKS_ONLY_CAPABILITIES,
-      },
-      statements,
-    );
-    let caught: unknown;
-    try {
-      await lockPostgresTrustedImportTables(
-        backend,
-        TRUSTED_IMPORT_TABLE_NAMES,
-      );
-    } catch (error) {
-      caught = error;
-    }
-    expect(caught).toEqual(
-      expect.objectContaining({
-        details: expect.objectContaining({
-          code: "WRITE_FENCE_UNAVAILABLE",
-          reason: "table-locks-only",
-        }) as unknown,
-      }),
-    );
-    // requireWriteFence names the ACTUAL posture — table locks with no
-    // advisory lock or serialized-writer slot above them — rather than the
-    // generic "is absent, or declares neither..." message every other
-    // unfenced reason used to share with this one.
-    expect((caught as Error).message).toContain(
-      "table locks without advisory locks or serialized writers",
     );
     expect(statements).toHaveLength(0);
   });
 });
 
 /**
- * T15 — the `writeFence` declaration itself: `writeFenceFromLegacyLocks`'s
- * mapping, the `WRITE_FENCE_DECLARATION_CONFLICT` refusal, and
- * `requireWriteFence`'s `drain`-keyed table-lock refusal.
+ * T15 — the `writeFence` declaration itself: `requireWriteFence`'s
+ * `drain`-keyed refusal, and `resolveWriteFencePlan`'s per-member
+ * `WRITE_FENCE_SQL_UNAVAILABLE` refusals.
  *
  * Every target here is dialect `"postgres"` carrying `postgresFenceSql`, so
  * an `advisory` mechanism can actually resolve a `lock` plan — the mechanism
@@ -1631,159 +1395,24 @@ const MINIMAL_EXECUTION_CAPABILITIES: BackendCapabilities = Object.freeze({
   windowFunctions: true,
 });
 
-/**
- * A resolved `lock` plan's `sql` field is a fresh `FenceStatements` closure
- * built by `resolveFenceStatements` on every call, so two plans resolved
- * from equivalent declarations never carry referentially-equal (or
- * `toEqual`-comparable — functions have no structural equality) `sql`
- * objects even when every other field agrees. Comparing "the SAME plan
- * through either declaration style" means every field but `sql`.
- */
-function planShapeWithoutSql(plan: unknown): unknown {
-  if (typeof plan !== "object" || plan === null || !("sql" in plan)) {
-    return plan;
-  }
-  const { sql: _sql, ...rest } = plan as Record<string, unknown>;
-  return rest;
-}
-
 describe("T15 — the writeFence declaration", () => {
-  it("declaring both writeFence and pessimisticLocks refuses (WRITE_FENCE_DECLARATION_CONFLICT)", () => {
-    const target = writeFenceTestTarget({
-      ...MINIMAL_EXECUTION_CAPABILITIES,
-      writeFence: { mechanism: "advisory", drain: "table-lock" },
-      pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
-    });
-    expect(() => resolveWriteFencePlan(target)).toThrow(
-      expect.objectContaining({
-        details: expect.objectContaining({
-          code: "WRITE_FENCE_DECLARATION_CONFLICT",
-        }) as unknown,
-      }),
-    );
-  });
-
-  it("advisory + tableLocks: true maps to {mechanism: advisory, drain: table-lock}, and resolves the SAME plan through either declaration style", () => {
-    const legacy = {
-      advisoryLocks: true,
-      tableLocks: true,
-      serializedWriters: false,
-    };
-    expect(writeFenceFromLegacyLocks(legacy)).toEqual({
-      mechanism: "advisory",
-      drain: "table-lock",
-    });
-    const viaLegacy = resolveWriteFencePlan(
-      writeFenceTestTarget({
-        ...MINIMAL_EXECUTION_CAPABILITIES,
-        pessimisticLocks: legacy,
-      }),
-    );
-    const viaWriteFence = resolveWriteFencePlan(
-      writeFenceTestTarget({
-        ...MINIMAL_EXECUTION_CAPABILITIES,
-        writeFence: { mechanism: "advisory", drain: "table-lock" },
-      }),
-    );
-    expect(planShapeWithoutSql(viaWriteFence)).toEqual(
-      planShapeWithoutSql(viaLegacy),
-    );
-    expect(viaLegacy).toEqual(
-      expect.objectContaining({
-        kind: "lock",
-        drain: "table-lock",
-        tableLocks: true,
-      }),
-    );
-  });
-
-  it("advisory + tableLocks: false (declared-advisory-only) maps to {mechanism: advisory, drain: none}, and resolves the SAME plan through either declaration style", () => {
-    expect(writeFenceFromLegacyLocks(ADVISORY_ONLY_CAPABILITIES)).toEqual({
-      mechanism: "advisory",
-      drain: "none",
-    });
-    const viaLegacy = resolveWriteFencePlan(
-      writeFenceTestTarget({
-        ...MINIMAL_EXECUTION_CAPABILITIES,
-        pessimisticLocks: ADVISORY_ONLY_CAPABILITIES,
-      }),
-    );
-    const viaWriteFence = resolveWriteFencePlan(
-      writeFenceTestTarget({
-        ...MINIMAL_EXECUTION_CAPABILITIES,
-        writeFence: { mechanism: "advisory", drain: "none" },
-      }),
-    );
-    expect(planShapeWithoutSql(viaWriteFence)).toEqual(
-      planShapeWithoutSql(viaLegacy),
-    );
-    expect(viaLegacy).toEqual(
-      expect.objectContaining({
-        kind: "lock",
-        drain: "none",
-        tableLocks: false,
-      }),
-    );
-  });
-
-  it("serializedWriters: true (SQLite-shaped) maps to {mechanism: engine-serialized, drain: table-lock}, and resolves the SAME plan through either declaration style", () => {
-    const legacy = {
-      advisoryLocks: false,
-      tableLocks: false,
-      serializedWriters: true,
-    };
-    expect(writeFenceFromLegacyLocks(legacy)).toEqual({
-      mechanism: "engine-serialized",
-      drain: "table-lock",
-    });
-    const viaLegacy = resolveWriteFencePlan(
-      writeFenceTestTarget({
-        ...MINIMAL_EXECUTION_CAPABILITIES,
-        pessimisticLocks: legacy,
-      }),
-    );
-    const viaWriteFence = resolveWriteFencePlan(
-      writeFenceTestTarget({
-        ...MINIMAL_EXECUTION_CAPABILITIES,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
-      }),
-    );
-    expect(planShapeWithoutSql(viaWriteFence)).toEqual(
-      planShapeWithoutSql(viaLegacy),
-    );
-    expect(viaLegacy).toEqual({ kind: "engine-serialized" });
-  });
-
-  it("all-false (declared-unfenced) maps to undefined; resolveWriteFencePlan falls back to unfenced/declared-none", () => {
-    expect(writeFenceFromLegacyLocks(UNFENCED_CAPABILITIES)).toBeUndefined();
-    expect(
-      resolveWriteFencePlan(
-        writeFenceTestTarget({
-          ...MINIMAL_EXECUTION_CAPABILITIES,
-          pessimisticLocks: UNFENCED_CAPABILITIES,
-        }),
-      ),
-    ).toEqual({ kind: "unfenced", reason: "declared-none" });
-  });
-
-  it('requireWriteFence under {advisory, quiescent} with "table-lock" returns the lock arm with drain quiescent, taking no statement itself', () => {
+  it('requireWriteFence under {advisory, quiescent} with "drain" returns the lock arm with drain quiescent, taking no statement itself', () => {
     const plan = resolveWriteFencePlan(
       writeFenceTestTarget({
         ...MINIMAL_EXECUTION_CAPABILITIES,
         writeFence: { mechanism: "advisory", drain: "quiescent" },
       }),
     );
-    const fence = requireWriteFence(plan, "quiescent drain test", "table-lock");
+    const fence = requireWriteFence(plan, "quiescent drain test", "drain");
     expect(fence).toEqual(
       expect.objectContaining({
         kind: "lock",
         drain: "quiescent",
-        tableLocks: false,
       }),
     );
   });
 
-  it('requireWriteFence under {advisory, none} with "table-lock" refuses, naming the drain', () => {
+  it('requireWriteFence under {advisory, none} with "drain" refuses, naming the drain', () => {
     const plan = resolveWriteFencePlan(
       writeFenceTestTarget({
         ...MINIMAL_EXECUTION_CAPABILITIES,
@@ -1792,7 +1421,7 @@ describe("T15 — the writeFence declaration", () => {
     );
     let caught: unknown;
     try {
-      requireWriteFence(plan, "none drain test", "table-lock");
+      requireWriteFence(plan, "none drain test", "drain");
     } catch (error) {
       caught = error;
     }
@@ -1806,16 +1435,16 @@ describe("T15 — the writeFence declaration", () => {
     expect((caught as Error).message).toContain('drain: "none"');
   });
 
-  it('requireWriteFence under {advisory, quiescent} with "advisory-lock" also returns the lock arm (advisory-lock never consults drain)', () => {
+  it('requireWriteFence under {advisory, quiescent} with "keyed" also returns the lock arm (keyed never consults drain)', () => {
     const plan = resolveWriteFencePlan(
       writeFenceTestTarget({
         ...MINIMAL_EXECUTION_CAPABILITIES,
         writeFence: { mechanism: "advisory", drain: "quiescent" },
       }),
     );
-    expect(
-      requireWriteFence(plan, "quiescent advisory-lock test", "advisory-lock"),
-    ).toEqual(expect.objectContaining({ kind: "lock", drain: "quiescent" }));
+    expect(requireWriteFence(plan, "quiescent keyed test", "keyed")).toEqual(
+      expect.objectContaining({ kind: "lock", drain: "quiescent" }),
+    );
   });
 
   it("advisory + drain: table-lock with a fenceSql missing advisoryLockExpression refuses WRITE_FENCE_SQL_UNAVAILABLE naming that member", () => {

--- a/packages/typegraph/tests/lock-fence-refusal.test.ts
+++ b/packages/typegraph/tests/lock-fence-refusal.test.ts
@@ -177,6 +177,35 @@ describe("T16 — (d) undeclared non-factory refuses (a) and (b)", () => {
   });
 });
 
+describe("T16 — (h) the undeclared reason names both declaration styles, and both migration-guide lines are indented", () => {
+  it("history: true", async () => {
+    const logged = await createLoggedPostgresBackend();
+    try {
+      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
+        logged.backend.capabilities;
+      const target = overlayCapabilities(logged.backend, undeclared);
+      let caught: unknown;
+      try {
+        createStore(plainGraph, target, { history: true });
+      } catch (error) {
+        caught = error;
+      }
+      const message = (caught as Error).message;
+      expect(message).toContain(
+        "`capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) is absent",
+      );
+      // Both declaration lines the migration guide prints must be indented —
+      // not only the first (`writeFence`) line, which would leave
+      // "or, legacy:" and the `pessimisticLocks` line flush against the
+      // margin.
+      expect(message).toContain('\n  writeFence: { mechanism: "advisory"');
+      expect(message).toContain("\n  pessimisticLocks: { advisoryLocks: true");
+    } finally {
+      await logged.close();
+    }
+  });
+});
+
 describe("T16 — (e) the refusal message carries the literal declaration line", () => {
   it('names the exact string, not a substring like "pessimisticLocks"', () => {
     const logged = createLoggedSqliteBackend({

--- a/packages/typegraph/tests/lock-fence-refusal.test.ts
+++ b/packages/typegraph/tests/lock-fence-refusal.test.ts
@@ -303,3 +303,110 @@ describe("T16 — (f) revisionTracking: true alone on unfenced refuses, zero sta
     );
   });
 });
+
+/**
+ * T16 — the `writeFence`-declared twin of each row above.
+ *
+ * `writeFence`'s `mechanism` has no arm that means "no fence" the way the
+ * legacy boolean triple's all-false shape does, so a target that declares
+ * `writeFence` can never resolve `kind: "unfenced"` on its own — there is no
+ * "twin" of rows (a)/(b)/(f)/(g) that reaches the SAME `unfenced` reason
+ * through `writeFence` alone. What a declared `writeFence` DOES reach,
+ * exactly like the legacy shape, is `WRITE_FENCE_DECLARATION_CONFLICT` — and
+ * it reaches it even earlier than `createStore`'s two gates do: the backend
+ * factory itself resolves the write-fence plan once, at construction, for
+ * every backend it builds, so a target declaring both never survives to
+ * become a `GraphBackend` a graph could be stored on at all. Each row below
+ * is the SAME legacy declaration as its counterpart above, plus a
+ * `writeFence` declared alongside it.
+ */
+describe("T16 — writeFence-declared twin: declaring writeFence alongside a legacy declaration conflicts at backend construction", () => {
+  it("twin of (a): the SQLite unfenced declaration plus writeFence conflicts before createStore ever runs", () => {
+    expect(() =>
+      createLoggedSqliteBackend({
+        pessimisticLocks: UNFENCED_CAPABILITIES,
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+      }),
+    ).toThrow(writeFenceRefusal("WRITE_FENCE_DECLARATION_CONFLICT"));
+  });
+
+  it("twin of (g): the table-locks-only declaration plus writeFence conflicts too, not the table-locks-only reason", () => {
+    let thrown: unknown;
+    try {
+      createLoggedSqliteBackend({
+        pessimisticLocks: TABLE_LOCKS_ONLY_CAPABILITIES,
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toEqual(
+      writeFenceRefusal("WRITE_FENCE_DECLARATION_CONFLICT"),
+    );
+    // Neither IDENTITY_REQUIRES_WRITE_FENCE nor
+    // RECORDED_CLOCK_REQUIRES_WRITE_FENCE — nor a table-locks-only-flavored
+    // WRITE_FENCE_UNAVAILABLE — fires: the conflict is caught before a
+    // `GraphBackend` exists for `createStore` to inspect at all.
+    expect((thrown as { details: { code: string } }).details.code).toBe(
+      "WRITE_FENCE_DECLARATION_CONFLICT",
+    );
+  });
+});
+
+/**
+ * T16 — the two store gates recognize the new postures as fenced.
+ *
+ * Neither gate refuses under `kind !== "unfenced"`, so a `writeFence`
+ * declaration using either of the two postures this stage adds —
+ * `{advisory, quiescent}` and `{caller-serialized, quiescent}` — must
+ * construct successfully, exactly like an ordinary fenced declaration.
+ */
+describe("T16 — the quiescent drain and the caller-serialized mechanism construct successfully at both gates", () => {
+  it("identity graph: {advisory, quiescent}", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      expect(() => createStore(identityGraph, logged.backend)).not.toThrow();
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("identity graph: {caller-serialized, quiescent}", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+    });
+    try {
+      expect(() => createStore(identityGraph, logged.backend)).not.toThrow();
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("history: true: {advisory, quiescent}", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "advisory", drain: "quiescent" },
+    });
+    try {
+      expect(() =>
+        createStore(plainGraph, logged.backend, { history: true }),
+      ).not.toThrow();
+    } finally {
+      await logged.close();
+    }
+  });
+
+  it("history: true: {caller-serialized, quiescent}", async () => {
+    const logged = await createLoggedPostgresBackend({
+      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+    });
+    try {
+      expect(() =>
+        createStore(plainGraph, logged.backend, { history: true }),
+      ).not.toThrow();
+    } finally {
+      await logged.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/lock-fence-refusal.test.ts
+++ b/packages/typegraph/tests/lock-fence-refusal.test.ts
@@ -224,7 +224,7 @@ describe("T16 — (f) revisionTracking: true alone on unfenced refuses, zero sta
  *
  * Neither gate refuses under `kind !== "unfenced"`, so a `writeFence`
  * declaration using either of the two postures this stage adds —
- * `{advisory, quiescent}` and `{caller-serialized, quiescent}` — must
+ * `{advisory, quiescent}` and `{caller-serialized}` — must
  * construct successfully, exactly like an ordinary fenced declaration.
  */
 describe("T16 — (g) the quiescent drain and the caller-serialized mechanism construct successfully at both gates", () => {
@@ -239,9 +239,9 @@ describe("T16 — (g) the quiescent drain and the caller-serialized mechanism co
     }
   });
 
-  it("identity graph: {caller-serialized, quiescent}", async () => {
+  it("identity graph: {caller-serialized}", async () => {
     const logged = await createLoggedPostgresBackend({
-      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      writeFence: { mechanism: "caller-serialized" },
     });
     try {
       expect(() => createStore(identityGraph, logged.backend)).not.toThrow();
@@ -263,9 +263,9 @@ describe("T16 — (g) the quiescent drain and the caller-serialized mechanism co
     }
   });
 
-  it("history: true: {caller-serialized, quiescent}", async () => {
+  it("history: true: {caller-serialized}", async () => {
     const logged = await createLoggedPostgresBackend({
-      writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+      writeFence: { mechanism: "caller-serialized" },
     });
     try {
       expect(() =>

--- a/packages/typegraph/tests/lock-fence-refusal.test.ts
+++ b/packages/typegraph/tests/lock-fence-refusal.test.ts
@@ -2,7 +2,14 @@
  * T16 (I9) — the two construction gates refuse at `createStore`, never
  * mid-flush, and the refusal message is the migration guide (OQ-B).
  *
- * Six rows:
+ * `writeFence` has no mechanism that means "no fence" the way the deleted
+ * legacy `pessimisticLocks` all-false shape once did, so every row below
+ * that needs an `unfenced` backend reaches it by overlaying a normal
+ * backend's capabilities (`unfencedLoggedBackend`) rather than by a factory
+ * override — the same "undeclared, non-first-party target" M-5 always
+ * described, now the ONLY way to reach that plan.
+ *
+ * Rows:
  *
  *  (a) `history: true` on an `unfenced` backend refuses at `createStore`,
  *      zero statements.
@@ -18,26 +25,26 @@
  *  (d) an undeclared non-factory backend refuses (a) and (b) via M-5's
  *      `unfenced` default.
  *  (e) the refusal message contains the LITERAL declaration line for the
- *      backend's dialect, not a substring like "pessimisticLocks".
+ *      backend's dialect, not a substring like "writeFence".
  *  (f) `{ revisionTracking: true }` alone (no `history`) on an `unfenced`
  *      backend refuses, zero statements (ruling F3) — repeated through
  *      `cloneWorkingCopyStrategy`, which propagates the base store's
  *      `revisionTrackingEnabled` into a fresh store without the caller
  *      naming the option.
+ *  (g) the quiescent drain and the caller-serialized mechanism construct
+ *      successfully at both gates.
  */
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { createStore, defineGraph, defineNode } from "../src";
-import { pessimisticLockDeclarationLine } from "../src/backend/capabilities/write-fence";
+import { writeFenceDeclarationLine } from "../src/backend/capabilities/write-fence";
 import { TypeGraphError } from "../src/errors";
 import { cloneWorkingCopyStrategy } from "../src/graph-merge";
 import {
   createLoggedPostgresBackend,
   createLoggedSqliteBackend,
-  overlayCapabilities,
-  TABLE_LOCKS_ONLY_CAPABILITIES,
-  UNFENCED_CAPABILITIES,
+  unfencedLoggedBackend,
 } from "./lock-fence-test-utils";
 
 const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
@@ -61,9 +68,7 @@ function writeFenceRefusal(code: string): unknown {
 
 describe("T16 — (a) history: true on unfenced refuses, zero statements", () => {
   it("SQLite unfenced", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
+    const logged = unfencedLoggedBackend(createLoggedSqliteBackend());
     // Factory construction itself probes the driver (a `PRAGMA
     // compile_options` sync-detection read) — reset AFTER the backend
     // exists so only `createStore`'s own statements (there must be none)
@@ -78,9 +83,7 @@ describe("T16 — (a) history: true on unfenced refuses, zero statements", () =>
 
 describe("T16 — (b) identity graph on unfenced refuses, zero statements", () => {
   it("SQLite unfenced", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
+    const logged = unfencedLoggedBackend(createLoggedSqliteBackend());
     logged.reset();
     expect(() => createStore(identityGraph, logged.backend)).toThrow(
       writeFenceRefusal("IDENTITY_REQUIRES_WRITE_FENCE"),
@@ -91,10 +94,9 @@ describe("T16 — (b) identity graph on unfenced refuses, zero statements", () =
 
 describe("T16 — (c) engine-native interim refusal", () => {
   it("unfenced engine-native + history: refuses with the interim error, zero statements", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-      recordedTimeOwnership: "engine-native",
-    });
+    const logged = unfencedLoggedBackend(
+      createLoggedSqliteBackend({ recordedTimeOwnership: "engine-native" }),
+    );
     logged.reset();
     expect(() =>
       createStore(plainGraph, logged.backend, { history: true }),
@@ -118,18 +120,16 @@ describe("T16 — (c) engine-native interim refusal", () => {
   });
 
   it("R-2 exemption: unfenced engine-native WITHOUT history/revisionTracking constructs successfully", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-      recordedTimeOwnership: "engine-native",
-    });
+    const logged = unfencedLoggedBackend(
+      createLoggedSqliteBackend({ recordedTimeOwnership: "engine-native" }),
+    );
     expect(() => createStore(plainGraph, logged.backend)).not.toThrow();
   });
 
   it("the engine-native interim refusal names no release version", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-      recordedTimeOwnership: "engine-native",
-    });
+    const logged = unfencedLoggedBackend(
+      createLoggedSqliteBackend({ recordedTimeOwnership: "engine-native" }),
+    );
     let caught: unknown;
     try {
       createStore(plainGraph, logged.backend, { history: true });
@@ -151,9 +151,7 @@ describe("T16 — (d) undeclared non-factory refuses (a) and (b)", () => {
   it("history: true", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
-        logged.backend.capabilities;
-      const target = overlayCapabilities(logged.backend, undeclared);
+      const target = unfencedLoggedBackend(logged).backend;
       expect(() => createStore(plainGraph, target, { history: true })).toThrow(
         writeFenceRefusal("RECORDED_CLOCK_REQUIRES_WRITE_FENCE"),
       );
@@ -165,9 +163,7 @@ describe("T16 — (d) undeclared non-factory refuses (a) and (b)", () => {
   it("identity graph", async () => {
     const logged = await createLoggedPostgresBackend();
     try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
-        logged.backend.capabilities;
-      const target = overlayCapabilities(logged.backend, undeclared);
+      const target = unfencedLoggedBackend(logged).backend;
       expect(() => createStore(identityGraph, target)).toThrow(
         writeFenceRefusal("IDENTITY_REQUIRES_WRITE_FENCE"),
       );
@@ -177,40 +173,9 @@ describe("T16 — (d) undeclared non-factory refuses (a) and (b)", () => {
   });
 });
 
-describe("T16 — (h) the undeclared reason names both declaration styles, and both migration-guide lines are indented", () => {
-  it("history: true", async () => {
-    const logged = await createLoggedPostgresBackend();
-    try {
-      const { pessimisticLocks: _pessimisticLocks, ...undeclared } =
-        logged.backend.capabilities;
-      const target = overlayCapabilities(logged.backend, undeclared);
-      let caught: unknown;
-      try {
-        createStore(plainGraph, target, { history: true });
-      } catch (error) {
-        caught = error;
-      }
-      const message = (caught as Error).message;
-      expect(message).toContain(
-        "`capabilities.writeFence` (or the deprecated `capabilities.pessimisticLocks`) is absent",
-      );
-      // Both declaration lines the migration guide prints must be indented —
-      // not only the first (`writeFence`) line, which would leave
-      // "or, legacy:" and the `pessimisticLocks` line flush against the
-      // margin.
-      expect(message).toContain('\n  writeFence: { mechanism: "advisory"');
-      expect(message).toContain("\n  pessimisticLocks: { advisoryLocks: true");
-    } finally {
-      await logged.close();
-    }
-  });
-});
-
 describe("T16 — (e) the refusal message carries the literal declaration line", () => {
-  it('names the exact string, not a substring like "pessimisticLocks"', () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
+  it('names the exact string, and indents it, not a bare mention of "writeFence"', () => {
+    const logged = unfencedLoggedBackend(createLoggedSqliteBackend());
     let caught: unknown;
     try {
       createStore(identityGraph, logged.backend);
@@ -219,65 +184,17 @@ describe("T16 — (e) the refusal message carries the literal declaration line",
     }
     expect(caught).toBeInstanceOf(Error);
     const message = (caught as Error).message;
-    expect(message).toContain(pessimisticLockDeclarationLine("sqlite"));
-    // The exact string, not merely the word "pessimisticLocks" in isolation:
-    // a pointer like "declare pessimisticLocks on this backend" would still
-    // contain the bare word without carrying the migration guide's line.
-    expect(message).not.toBe("pessimisticLocks");
-  });
-});
-
-describe("T16 — (g) a table-locks-only declaration refuses, naming that posture specifically", () => {
-  it("refuseUnfencedClockAllocation names the table-locks-only posture, not the generic absent/all-false message", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: TABLE_LOCKS_ONLY_CAPABILITIES,
-    });
-    logged.reset();
-    let caught: unknown;
-    try {
-      createStore(plainGraph, logged.backend, { history: true });
-    } catch (error) {
-      caught = error;
-    }
-    expect(caught).toEqual(
-      writeFenceRefusal("RECORDED_CLOCK_REQUIRES_WRITE_FENCE"),
-    );
-    expect((caught as Error).message).toContain(
-      "table locks without advisory locks or serialized writers",
-    );
-    expect((caught as Error).message).not.toContain(
-      "declares neither advisory/table locks nor serialized writers",
-    );
-    expect(logged.statements).toHaveLength(0);
-  });
-
-  it("refuseUnfencedOperationalIdentity names the table-locks-only posture, not the generic absent/all-false message", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: TABLE_LOCKS_ONLY_CAPABILITIES,
-    });
-    logged.reset();
-    let caught: unknown;
-    try {
-      createStore(identityGraph, logged.backend);
-    } catch (error) {
-      caught = error;
-    }
-    expect(caught).toEqual(writeFenceRefusal("IDENTITY_REQUIRES_WRITE_FENCE"));
-    expect((caught as Error).message).toContain(
-      "table locks without advisory locks or serialized writers",
-    );
-    expect((caught as Error).message).not.toContain(
-      "declares neither advisory/table locks nor serialized writers",
-    );
-    expect(logged.statements).toHaveLength(0);
+    expect(message).toContain(`  ${writeFenceDeclarationLine("sqlite")}`);
+    // The exact string, not merely the word "writeFence" in isolation: a
+    // pointer like "declare writeFence on this backend" would still contain
+    // the bare word without carrying the migration guide's line.
+    expect(message).not.toBe("writeFence");
   });
 });
 
 describe("T16 — (f) revisionTracking: true alone on unfenced refuses, zero statements", () => {
   it("direct construction", () => {
-    const logged = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
+    const logged = unfencedLoggedBackend(createLoggedSqliteBackend());
     logged.reset();
     expect(() =>
       createStore(plainGraph, logged.backend, { revisionTracking: true }),
@@ -292,63 +209,12 @@ describe("T16 — (f) revisionTracking: true alone on unfenced refuses, zero sta
     });
     expect(baseStore.revisionTrackingEnabled).toBe(true);
 
-    const fresh = createLoggedSqliteBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
+    const fresh = unfencedLoggedBackend(createLoggedSqliteBackend());
     const strategy = cloneWorkingCopyStrategy<typeof plainGraph>(() =>
       Promise.resolve(fresh.backend),
     );
     await expect(strategy.create(baseStore)).rejects.toThrow(
       writeFenceRefusal("RECORDED_CLOCK_REQUIRES_WRITE_FENCE"),
-    );
-  });
-});
-
-/**
- * T16 — the `writeFence`-declared twin of each row above.
- *
- * `writeFence`'s `mechanism` has no arm that means "no fence" the way the
- * legacy boolean triple's all-false shape does, so a target that declares
- * `writeFence` can never resolve `kind: "unfenced"` on its own — there is no
- * "twin" of rows (a)/(b)/(f)/(g) that reaches the SAME `unfenced` reason
- * through `writeFence` alone. What a declared `writeFence` DOES reach,
- * exactly like the legacy shape, is `WRITE_FENCE_DECLARATION_CONFLICT` — and
- * it reaches it even earlier than `createStore`'s two gates do: the backend
- * factory itself resolves the write-fence plan once, at construction, for
- * every backend it builds, so a target declaring both never survives to
- * become a `GraphBackend` a graph could be stored on at all. Each row below
- * is the SAME legacy declaration as its counterpart above, plus a
- * `writeFence` declared alongside it.
- */
-describe("T16 — writeFence-declared twin: declaring writeFence alongside a legacy declaration conflicts at backend construction", () => {
-  it("twin of (a): the SQLite unfenced declaration plus writeFence conflicts before createStore ever runs", () => {
-    expect(() =>
-      createLoggedSqliteBackend({
-        pessimisticLocks: UNFENCED_CAPABILITIES,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
-      }),
-    ).toThrow(writeFenceRefusal("WRITE_FENCE_DECLARATION_CONFLICT"));
-  });
-
-  it("twin of (g): the table-locks-only declaration plus writeFence conflicts too, not the table-locks-only reason", () => {
-    let thrown: unknown;
-    try {
-      createLoggedSqliteBackend({
-        pessimisticLocks: TABLE_LOCKS_ONLY_CAPABILITIES,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
-      });
-    } catch (error) {
-      thrown = error;
-    }
-    expect(thrown).toEqual(
-      writeFenceRefusal("WRITE_FENCE_DECLARATION_CONFLICT"),
-    );
-    // Neither IDENTITY_REQUIRES_WRITE_FENCE nor
-    // RECORDED_CLOCK_REQUIRES_WRITE_FENCE — nor a table-locks-only-flavored
-    // WRITE_FENCE_UNAVAILABLE — fires: the conflict is caught before a
-    // `GraphBackend` exists for `createStore` to inspect at all.
-    expect((thrown as { details: { code: string } }).details.code).toBe(
-      "WRITE_FENCE_DECLARATION_CONFLICT",
     );
   });
 });
@@ -361,7 +227,7 @@ describe("T16 — writeFence-declared twin: declaring writeFence alongside a leg
  * `{advisory, quiescent}` and `{caller-serialized, quiescent}` — must
  * construct successfully, exactly like an ordinary fenced declaration.
  */
-describe("T16 — the quiescent drain and the caller-serialized mechanism construct successfully at both gates", () => {
+describe("T16 — (g) the quiescent drain and the caller-serialized mechanism construct successfully at both gates", () => {
   it("identity graph: {advisory, quiescent}", async () => {
     const logged = await createLoggedPostgresBackend({
       writeFence: { mechanism: "advisory", drain: "quiescent" },

--- a/packages/typegraph/tests/lock-fence-test-utils.ts
+++ b/packages/typegraph/tests/lock-fence-test-utils.ts
@@ -22,11 +22,18 @@
  * factory cannot construct directly (a present-but-all-false declaration, a
  * declared-advisory-only declaration).
  */
-import { PGlite, type QueryOptions } from "@electric-sql/pglite";
+import {
+  type Extensions,
+  PGlite,
+  type QueryOptions,
+} from "@electric-sql/pglite";
 import { vector as pgvectorExtension } from "@electric-sql/pglite-pgvector";
 import Database from "better-sqlite3";
 import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
-import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+import {
+  drizzle as drizzlePglite,
+  type PgliteDatabase,
+} from "drizzle-orm/pglite";
 
 import {
   generatePostgresMigrationSQL,
@@ -53,52 +60,78 @@ export type LoggedBackend = Readonly<{
   execRaw: (statement: string) => Promise<void>;
 }>;
 
+export type LoggedPgliteClient = Readonly<{
+  client: PGlite;
+  db: PgliteDatabase;
+  statements: LoggedStatement[];
+  close: () => Promise<void>;
+}>;
+
 /**
- * A real PostgreSQL backend (PGlite, in-process, no Docker). Every statement
- * the wrapped client actually sends is captured by patching `client.query`
- * itself — the layer `backend.execute`/`executeStatement` calls into on the
- * fast path — so a lock site's SQL is observed regardless of whether it runs
- * inside a top-level call or inside `schemaWriteTransaction`'s callback.
- * `capabilities` — when supplied — is passed as the factory's own override
- * option, so it flows into every closure the factory builds at construction
- * time (the contribution materializer's `fenceTarget` included), not just
- * the returned backend's own property.
+ * The one PGlite-client-plus-capture primitive: a real, in-process
+ * PostgreSQL-dialect connection (no Docker) with every statement the client
+ * actually sends captured at both layers {@link createLoggedPostgresBackend}'s
+ * own doc comment describes — a driver-level patch of `client.query` plus
+ * drizzle's own `logger`, since a lock site reached inside a transaction
+ * callback bypasses the top-level one.
+ *
+ * `extensions` and `ddl` are the caller's own choice so a vector-enabled
+ * backend fixture and a vector-disabled profile fixture can each seed the
+ * schema that matches their own declared capability, from this one capture
+ * primitive, rather than two independent re-implementations drifting apart.
  */
-export async function createLoggedPostgresBackend(
-  capabilities?: Partial<BackendCapabilities>,
-): Promise<LoggedBackend> {
-  const client = await PGlite.create({
-    extensions: { vector: pgvectorExtension },
-  });
-  await client.exec(generatePostgresMigrationSQL());
+export async function createLoggedPgliteClient(
+  options: Readonly<{ extensions?: Extensions; ddl: string }>,
+): Promise<LoggedPgliteClient> {
+  const client = await PGlite.create(
+    options.extensions === undefined ? {} : { extensions: options.extensions },
+  );
+  await client.exec(options.ddl);
   const statements: LoggedStatement[] = [];
   const originalQuery = client.query.bind(client);
   client.query = (<T>(
     query: string,
     params?: unknown[],
-    options?: QueryOptions,
+    queryOptions?: QueryOptions,
   ) => {
     statements.push({ query, params: params ?? [] });
-    return originalQuery<T>(query, params, options);
+    return originalQuery<T>(query, params, queryOptions);
   }) as typeof client.query;
-  const backend = createPostgresBackend(
-    drizzlePglite(client, {
-      logger: {
-        logQuery(query: string, params: unknown[]): void {
-          statements.push({ query, params });
-        },
+  const db = drizzlePglite(client, {
+    logger: {
+      logQuery(query: string, params: unknown[]): void {
+        statements.push({ query, params });
       },
-    }),
-    {
-      vector: false,
-      ...(capabilities === undefined ? {} : { capabilities }),
     },
-  );
+  });
+  return { client, db, statements, close: () => client.close() };
+}
+
+/**
+ * A real PostgreSQL backend (PGlite, in-process, no Docker), built from
+ * {@link createLoggedPgliteClient} with the pgvector extension installed and
+ * the complete bundled-factory migration SQL applied. `capabilities` — when
+ * supplied — is passed as the factory's own override option, so it flows
+ * into every closure the factory builds at construction time (the
+ * contribution materializer's `fenceTarget` included), not just the
+ * returned backend's own property.
+ */
+export async function createLoggedPostgresBackend(
+  capabilities?: Partial<BackendCapabilities>,
+): Promise<LoggedBackend> {
+  const { client, db, statements, close } = await createLoggedPgliteClient({
+    extensions: { vector: pgvectorExtension },
+    ddl: generatePostgresMigrationSQL(),
+  });
+  const backend = createPostgresBackend(db, {
+    vector: false,
+    ...(capabilities === undefined ? {} : { capabilities }),
+  });
   return {
     backend,
     statements,
     reset: () => statements.splice(0),
-    close: () => client.close(),
+    close,
     execRaw: async (statement: string) => {
       await client.exec(statement);
     },

--- a/packages/typegraph/tests/lock-fence-test-utils.ts
+++ b/packages/typegraph/tests/lock-fence-test-utils.ts
@@ -18,9 +18,9 @@
  * Neither mechanism double-counts the other's statements, since each fires
  * on a disjoint execution path.
  *
- * Also exports a capabilities-overlay Proxy for postures a first-party
- * factory cannot construct directly (a present-but-all-false declaration, a
- * declared-advisory-only declaration).
+ * Also exports a capabilities-overlay Proxy for the one posture a
+ * first-party factory cannot construct directly: an undeclared
+ * (`capabilities.writeFence` absent) target.
  */
 import {
   type Extensions,
@@ -194,15 +194,16 @@ export function createLoggedSqliteBackend(
  * A capabilities-overlay `Proxy`: forwards every member of `base` unchanged
  * except `capabilities`.
  *
- * A lock site nested inside `schemaWriteTransaction`'s callback (J5, J6)
- * receives a TRANSACTION-SCOPED object the factory builds from its OWN
- * closed-over `capabilities` constant, not from whatever property this
- * wrapper exposes — so `schemaWriteTransaction` itself is intercepted too,
- * recursively overlaying the `tx` argument the real implementation hands to
- * its callback. A lock site reached through a per-construction closure
- * outside `schemaWriteTransaction` entirely (J7/J8's contribution
- * materializer `fenceTarget`) is NOT reachable through this overlay at
- * all — those two sites test the "undeclared non-factory" posture through
+ * A lock site nested inside `schemaWriteTransaction`'s or `transaction`'s
+ * callback (J5, J6, and any managed write reached through a plain
+ * `backend.transaction(...)`) receives a TRANSACTION-SCOPED object the
+ * factory builds from its OWN closed-over `capabilities` constant, not from
+ * whatever property this wrapper exposes — so both openers are intercepted
+ * too, recursively overlaying the `tx` argument the real implementation
+ * hands to its callback. A lock site reached through a per-construction
+ * closure outside either opener entirely (J7/J8's contribution materializer
+ * `fenceTarget`) is NOT reachable through this overlay at all — those two
+ * sites test the "undeclared non-factory" posture through
  * `createContributionMaterializer` directly instead (see
  * `tests/lock-fence-plan.test.ts`).
  *
@@ -235,37 +236,46 @@ export function overlayCapabilities<T extends object>(
             fn(overlayCapabilities(tx, capabilities)),
           );
       }
+      if (property === "transaction" && typeof value === "function") {
+        const real = value as (
+          fn: (tx: object) => Promise<unknown>,
+          options?: unknown,
+        ) => Promise<unknown>;
+        return (fn: (tx: object) => Promise<unknown>, options?: unknown) =>
+          real(
+            (tx: object) => fn(overlayCapabilities(tx, capabilities)),
+            options,
+          );
+      }
       return value;
     },
   });
 }
 
-export const UNFENCED_CAPABILITIES: NonNullable<
-  BackendCapabilities["pessimisticLocks"]
-> = Object.freeze({
-  advisoryLocks: false,
-  tableLocks: false,
-  serializedWriters: false,
-});
-
+/**
+ * The declared-advisory-only posture: an advisory-lock mechanism with no
+ * drain, so every keyed site (J1, J2, J3, J5, J7) succeeds while every drain
+ * site (J4, J6, J8, J18) refuses naming `drain: "none"`.
+ */
 export const ADVISORY_ONLY_CAPABILITIES: NonNullable<
-  BackendCapabilities["pessimisticLocks"]
+  BackendCapabilities["writeFence"]
 > = Object.freeze({
-  advisoryLocks: true,
-  tableLocks: false,
-  serializedWriters: false,
+  mechanism: "advisory",
+  drain: "none",
 });
 
 /**
- * The declaration the plan model has no arm for: a table lock with neither
- * an advisory lock above it nor a serialized-writer slot beneath it.
- * `resolveWriteFencePlan` resolves this to `unfenced` — see the note next to
- * `planFromLockCapabilities` in `write-fence.ts`.
+ * Overlays `logged`'s backend so `capabilities.writeFence` is absent.
+ * `writeFence` has no mechanism that means "no fence" the way the deleted
+ * legacy `pessimisticLocks` all-false shape once did, so this — an
+ * undeclared, non-first-party target — is the only way left to reach an
+ * `unfenced` plan on an otherwise-real backend.
  */
-export const TABLE_LOCKS_ONLY_CAPABILITIES: NonNullable<
-  BackendCapabilities["pessimisticLocks"]
-> = Object.freeze({
-  advisoryLocks: false,
-  tableLocks: true,
-  serializedWriters: false,
-});
+export function unfencedLoggedBackend(logged: LoggedBackend): LoggedBackend {
+  const { writeFence: _writeFence, ...undeclared } =
+    logged.backend.capabilities;
+  return {
+    ...logged,
+    backend: overlayCapabilities(logged.backend, undeclared),
+  };
+}

--- a/packages/typegraph/tests/postgres-trigram-extension-lock.test.ts
+++ b/packages/typegraph/tests/postgres-trigram-extension-lock.test.ts
@@ -352,11 +352,7 @@ describe("Postgres pg_trgm extension prerequisite", () => {
       fenceSql: undefined,
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        pessimisticLocks: {
-          advisoryLocks: false,
-          tableLocks: false,
-          serializedWriters: true,
-        },
+        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
       },
     });
     const backend = createSqlBackend(derivedProfile);

--- a/packages/typegraph/tests/postgres-trigram-extension-lock.test.ts
+++ b/packages/typegraph/tests/postgres-trigram-extension-lock.test.ts
@@ -352,7 +352,7 @@ describe("Postgres pg_trgm extension prerequisite", () => {
       fenceSql: undefined,
       declaredCapabilities: {
         ...baseProfile.declaredCapabilities,
-        writeFence: { mechanism: "engine-serialized", drain: "table-lock" },
+        writeFence: { mechanism: "engine-serialized" },
       },
     });
     const backend = createSqlBackend(derivedProfile);

--- a/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
+++ b/packages/typegraph/tests/property/graph-merge/merge-laws.test.ts
@@ -1,7 +1,7 @@
 /**
  * Three-way merge LAW properties (complements the T12 determinism gate).
  *
- * `merge()` claims Dolt-class deterministic THREE-WAY merge semantics — NOT
+ * `merge()` claims deterministic three-way merge semantics — NOT
  * CRDT semilattice (ACI) convergence. Entity-resolution merge is not
  * associative or idempotent in general (similarity is not transitive), so the
  * honest, checkable law set for an LCA-anchored merge `m(base, branches…)` is:

--- a/packages/typegraph/tests/schema-fence-plan.test.ts
+++ b/packages/typegraph/tests/schema-fence-plan.test.ts
@@ -16,19 +16,20 @@
  * cannot race itself, so an empty clause is correct at any isolation level —
  * which is the posture SQLite has always run in.
  *
- * `unfenced` is what a Postgres-wire engine with no locking primitive
- * declares (DoltgreSQL, `dolthub/doltgresql#2600`). What it buys is a refusal
- * that names the missing capability, at construction, instead of a silent
- * race.
+ * There is no `unfenced` row here: both consumers read a `fenceTarget`
+ * `createSqlBackend` closes over once at construction, from the SAME
+ * finalized capabilities its own construction-time gate already required to
+ * carry a `writeFence` declaration — so, unlike the call-time-parameter lock
+ * sites `tests/lock-fence-plan.test.ts` covers, no backend this factory
+ * builds can ever reach these two consumers in an unfenced state, and no
+ * overlay applied to the returned backend can change that closure after the
+ * fact. `requireWriteFence`'s own `unfenced` refusal is covered directly
+ * where it IS reachable — the "undeclared non-factory" rows in
+ * `tests/lock-fence-plan.test.ts` — rather than restated here.
  *
  * Asserted on the SQL each site actually emits, never on a boolean, so the
  * test fails for the reason a caller would hit.
  *
- * *Mutation*: make `acquireSchemaWriteFence` ignore the plan and always take
- * the lock → the fenced rows still pass but the refusal row fails (the store
- * builds instead of refusing). *Mutation*: swap either `requireWriteFence`
- * call back to a bare `resolveWriteFencePlan` + `plan.kind === "lock"`
- * ternary → the refusal row fails, naming the fence that silently degraded.
  * *Mutation*: make `schemaFenceInsertLockClause` emit `FOR SHARE`
  * unconditionally → the SQLite degrade row fails. *Mutation*: make any site
  * always skip its lock → the corresponding fenced row fails.
@@ -47,7 +48,6 @@ import {
   createLoggedPostgresBackend,
   createLoggedSqliteBackend,
   type LoggedBackend,
-  UNFENCED_CAPABILITIES,
 } from "./lock-fence-test-utils";
 
 const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
@@ -90,8 +90,8 @@ async function measure(
 describe("schema fence — a fenced PostgreSQL backend takes every lock", () => {
   it("emits the advisory lock and FOR UPDATE on commit, FOR SHARE on write", async () => {
     // No capabilities override: POSTGRES_CAPABILITIES declares
-    // `{ advisoryLocks: true, tableLocks: true, serializedWriters: false }`,
-    // which resolves `lock`.
+    // `writeFence: { mechanism: "advisory", drain: "table-lock" }`, which
+    // resolves `lock`.
     const logged = await createLoggedPostgresBackend();
     try {
       const { commit, write } = await measure(logged, "j14-fenced");
@@ -104,66 +104,6 @@ describe("schema fence — a fenced PostgreSQL backend takes every lock", () => 
       );
       expect(fusedInsert.length).toBeGreaterThan(0);
       expect(fusedInsert.every((query) => FOR_SHARE.test(query))).toBe(true);
-    } finally {
-      await logged.close();
-    }
-  });
-});
-
-describe("schema fence — an unfenced PostgreSQL backend is refused, not degraded", () => {
-  it("refuses the schema commit rather than running it without the lock", async () => {
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      logged.reset();
-      const error = await createStoreWithSchema(
-        graphFor("j14-unfenced"),
-        logged.backend,
-      ).catch((error_: unknown) => error_);
-
-      // The refusal names the missing capability rather than surfacing as a
-      // SQL error, and it arrives before any lock statement was attempted.
-      expect(error).toBeInstanceOf(Error);
-      expect((error as { details?: { code?: string } }).details?.code).toBe(
-        "WRITE_FENCE_UNAVAILABLE",
-      );
-      const attempted = logged.statements.map((statement) => statement.query);
-      expect(attempted.filter((query) => ADVISORY_LOCK.test(query))).toEqual(
-        [],
-      );
-      expect(attempted.filter((query) => FOR_UPDATE.test(query))).toEqual([]);
-      expect(attempted.filter((query) => FOR_SHARE.test(query))).toEqual([]);
-    } finally {
-      await logged.close();
-    }
-  });
-
-  it("refuses the managed write fence for the same reason", async () => {
-    // Reached directly, because the store that would call it cannot be built
-    // above. This is the half whose lock the transaction HOLDS across its
-    // writes, so a degraded version would assert a version and then let the
-    // flip it was checking for land before the write.
-    const logged = await createLoggedPostgresBackend({
-      pessimisticLocks: UNFENCED_CAPABILITIES,
-    });
-    try {
-      const error = await requireDefined(logged.backend.transaction)(
-        async (tx) =>
-          requireDefined(tx.lockSchemaVersionForWrite)({
-            graphId: "j15-unfenced",
-            expectedVersion: 1,
-          }),
-      ).catch((error_: unknown) => error_);
-
-      expect(error).toBeInstanceOf(Error);
-      expect((error as { details?: { code?: string } }).details?.code).toBe(
-        "WRITE_FENCE_UNAVAILABLE",
-      );
-      // Emphatically NOT a StaleVersionError: refusing for the missing
-      // capability is the point, and reporting a stale version instead would
-      // be the degraded behavior this test exists to forbid.
-      expect(error).not.toBeInstanceOf(StaleVersionError);
     } finally {
       await logged.close();
     }

--- a/packages/typegraph/tests/schema-graph-write-fence.test.ts
+++ b/packages/typegraph/tests/schema-graph-write-fence.test.ts
@@ -151,6 +151,76 @@ describe("schema + graph write fence", () => {
     }
   });
 
+  // Regression for the fused lock building off `fenceSql`'s mere presence
+  // rather than the resolved plan: this factory's `fenceTarget` carries
+  // `postgresFenceSql` unconditionally (harmless under every OTHER
+  // mechanism, since every portable lock site already reads
+  // `caller-serialized` as no statement), so gating fusion on that presence
+  // alone fused the schema+graph advisory lock back in even though the
+  // declaration says no lock is needed or wanted.
+  it("does not fuse the schema+graph lock when the declared write fence is caller-serialized/quiescent", async () => {
+    const client = await PGlite.create();
+    try {
+      await client.exec(generatePostgresDDL().join("\n\n"));
+      const backend = createPostgresBackend(drizzlePglite(client), {
+        vector: false,
+        capabilities: {
+          writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+        },
+      });
+
+      await backend.transaction((tx) => {
+        expect(tx.lockSchemaVersionAndGraphWrite).toBeUndefined();
+        return Promise.resolve();
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("takes no advisory lock and no FOR SHARE for a schema-managed write under caller-serialized/quiescent", async () => {
+    const statements: string[] = [];
+    const client = await PGlite.create();
+    try {
+      await client.exec(generatePostgresDDL().join("\n\n"));
+      const backend = createPostgresBackend(
+        drizzlePglite(client, {
+          logger: {
+            logQuery(query: string): void {
+              statements.push(query);
+            },
+          },
+        }),
+        {
+          vector: false,
+          capabilities: {
+            writeFence: {
+              mechanism: "caller-serialized",
+              drain: "quiescent",
+            },
+          },
+        },
+      );
+      const [store] = await createStoreWithSchema(leaseGraph, backend, {
+        history: true,
+      });
+      statements.splice(0);
+
+      await store.nodes.Person.create({ name: "Quiescent" });
+
+      expect(
+        statements.some((statement) =>
+          /pg_advisory_xact_lock/iu.test(statement),
+        ),
+      ).toBe(false);
+      expect(
+        statements.some((statement) => /for share/iu.test(statement)),
+      ).toBe(false);
+    } finally {
+      await client.close();
+    }
+  });
+
   it.each(["node conflict", "missing edge endpoint"] as const)(
     "does not lease an unproven fused fence after a %s",
     async (zeroRowCause) => {

--- a/packages/typegraph/tests/schema-graph-write-fence.test.ts
+++ b/packages/typegraph/tests/schema-graph-write-fence.test.ts
@@ -158,14 +158,14 @@ describe("schema + graph write fence", () => {
   // `caller-serialized` as no statement), so gating fusion on that presence
   // alone fused the schema+graph advisory lock back in even though the
   // declaration says no lock is needed or wanted.
-  it("does not fuse the schema+graph lock when the declared write fence is caller-serialized/quiescent", async () => {
+  it("does not fuse the schema+graph lock when the declared write fence is caller-serialized", async () => {
     const client = await PGlite.create();
     try {
       await client.exec(generatePostgresDDL().join("\n\n"));
       const backend = createPostgresBackend(drizzlePglite(client), {
         vector: false,
         capabilities: {
-          writeFence: { mechanism: "caller-serialized", drain: "quiescent" },
+          writeFence: { mechanism: "caller-serialized" },
         },
       });
 
@@ -178,7 +178,7 @@ describe("schema + graph write fence", () => {
     }
   });
 
-  it("takes no advisory lock and no FOR SHARE for a schema-managed write under caller-serialized/quiescent", async () => {
+  it("takes no advisory lock and no FOR SHARE for a schema-managed write under caller-serialized", async () => {
     const statements: string[] = [];
     const client = await PGlite.create();
     try {
@@ -196,7 +196,6 @@ describe("schema + graph write fence", () => {
           capabilities: {
             writeFence: {
               mechanism: "caller-serialized",
-              drain: "quiescent",
             },
           },
         },

--- a/packages/typegraph/vitest.pglite-project.ts
+++ b/packages/typegraph/vitest.pglite-project.ts
@@ -12,6 +12,7 @@ export const PGLITE_TEST_FILES = [
   "tests/atomic-resolved-update-batch-pglite.test.ts",
   "tests/atomic-transport-conformance.test.ts",
   "tests/base-schema-adoption.test.ts",
+  "tests/caller-serialized-queue.test.ts",
   "tests/capability-bundle-dialect-honesty.test.ts",
   "tests/capability-declaration-validation.test.ts",
   "tests/constraint-claim-inventory.test.ts",


### PR DESCRIPTION
Replaces the three-boolean `pessimisticLocks` declaration with one declared write-fence mechanism plus a separate drain fact, adds a `caller-serialized` arm that TypeGraph half-enforces in process, and makes `requireWriteFence` ask for what a site actually needs. Emitted SQL for both bundled backends is unchanged; the parity capability snapshots move only by the declaration line.

## One declaration

`capabilities.writeFence` is a discriminated union: `{ mechanism: "advisory"; drain: "table-lock" | "quiescent" | "none" }`, `{ mechanism: "engine-serialized" }`, or `{ mechanism: "caller-serialized" }`. The mechanism is the exclusion primitive; the drain, which only `advisory` carries because the serialized mechanisms drain by construction, is whether a site that must exclude every other writer of a relation can take a relation-wide lock, promise there is none, or neither. Both bundled constants declare it directly, and the resolver validates both fields against exact allowlists at runtime, failing closed on a JavaScript-shaped or stale declaration. `resolveWriteFencePlan` stays the one reader; the first-party dialect derivation returns the same shape.

## The plan and the requirement vocabulary

`WriteFencePlan` is `lock { drain, sql } | engine-serialized | caller-serialized | unfenced`. `requireWriteFence(plan, operation, requires: "keyed" | "drain")`: `keyed` is satisfied by every non-unfenced arm; `drain` refuses only a `lock` plan whose `drain` is `none`, naming the drain. The four drain sites (identity enablement, merge provenance, shared fulltext drop, trusted import) read the plan's `drain` and take their relation lock only under `table-lock`; the nine keyed sites and the extension-install lock take no statement under `engine-serialized` or `caller-serialized`. The recorded graph-write lock returns the uncoordinated token under both non-lock arms, since neither is a session-bound acquisition. The posture matrix in `lock-fence-plan.test.ts` gains the `{advisory, quiescent}` and `{caller-serialized, quiescent}` postures across every site; the refusal matrix keeps only shapes the new declaration can produce.

## `caller-serialized`

A deployment promise, distinct from the engine claim the PostgreSQL factory still refuses. TypeGraph enforces the in-process half: when the plan resolves `caller-serialized`, `createSqlBackend` derives the root with every mutation-capable member the taxonomy names (entity, sidecar and bulk writes, maintenance, schema commits and their opener, DDL and provisioning, the raw executors, `clearGraph`) plus both transaction openers routed through one per-backend serialized queue; typed reads and transaction handles are untouched. A totality ratchet partitions all 130 root members into queued and unqueued with a reason per class. `adoptTransaction` is refused under this mechanism, since an externally owned transaction's lifetime cannot be held by the queue. A root write issued from inside a transaction callback is refused with a named reentrancy error, and the queue requires async-context detection in this mode: it awaits its loader before the first task and refuses submissions where detection is unavailable rather than risking a silent deadlock. The queue is SQLite's own `serialized-execution-queue`, moved to `src/backend` verbatim, and moving it surfaced a real nested-queue deadlock in the reentrancy detection, fixed here. The cross-process half stays the caller's: the docs state both halves in that order.

## Conformance

`tests/backends/integration/write-fence-conformance.ts` runs on every lane: a read after a keyed acquisition sees the previous holder's commit (server lane, two connections, a concurrent holder); a drain site under `table-lock` blocks a concurrent row writer until commit, under `quiescent` takes no lock, under `none` refuses naming the drain; the isolation fact reaches the coordination token, and a target with no `isolationFactExpression` refuses recorded capture and convergence. Derived PostgreSQL profiles declaring `{advisory, quiescent}`, `{caller-serialized, quiescent}` and `{advisory, none}` cover the postures the bundled backends do not.

## Breaking

Listed in the changeset with replacements: `pessimisticLocks` and `PessimisticLockCapabilities` removed; `drain` removed from the serialized mechanisms; `requireWriteFence`'s `requires` values renamed; the `lock` arm's `tableLocks` and `advisoryLocks` removed in favor of `drain`; the `unfenced` arm's `reason` removed; `WriteFencePlan` gained `caller-serialized`, so an external exhaustive switch must add the case; `WRITE_FENCE_DECLARATION_CONFLICT` removed. The bundled backends' behavior does not change.

## Follow-ups

The graph-template instantiation statement still composes the single-argument schema lock unconditionally; under `caller-serialized` it is a harmless extra lock, and folding it under the plan is deferred. The `row` mechanism and the optimistic tier are the next stage.
