### PR TITLE
feat(store): the batch tier's contract, made total and tested against real engines

### DIFF
--- a/.changeset/guarded-batch.md
+++ b/.changeset/guarded-batch.md
@@ -1,0 +1,33 @@
+---
+"@nicia-ai/typegraph": minor
+---
+
+A backend whose `capabilities.execution.unitOfWork` is `"batch"` (Cloudflare D1's `batch()`, Neon
+HTTP's `transaction(queries)`) fixes every statement before the first one runs and commits them
+together with no session in between. `resolveBatchWriteVerdict` in
+`src/backend/capabilities/batch-write-verdict.ts` is the one place that classifies a schema-managed
+write's fitness for that tier: given a write's already-proven need (an interactive callback, a
+probe-then-write constraint check, Operational Identity, history, or a schema commit), it either
+defers (any other tier) or returns a refusal carrying a stable `BATCH_WRITE_UNSUPPORTED` code, the
+reason, and a canonical explanation. Every enforcing gate that used to word its own batch-engine
+limitation independently — the constrained-write fence, `store.transaction`, Operational Identity's
+atomic-backend checks, recorded-time capture's transactionability guards, and each dialect's
+schema-commit refusal — now asks this one verdict for its phrasing and nests
+`{ code: "BATCH_WRITE_UNSUPPORTED", reason }` under `details.batchRefusal`, so every refusal on a
+batch-tier backend names the same reason in the same words. The portable schema-version fence keeps
+its plain, reasonless `SCHEMA_WRITE_FENCE_UNSUPPORTED` limitation for everything it reaches that
+isn't one of those five proven needs — an ineligible write kind, a derived backend, a provenance
+mismatch — rather than guessing which reason, if any, applies.
+
+A singleton node `create` with a caller-supplied id now fuses its schema fence on a batch-tier
+backend exactly as a generated id already did, provided the kind carries no declared unique
+constraint: the id-generation gate that existed for an interactive root's autocommit durability no
+longer excludes a batch program, which commits its one statement as a unit regardless of which id it
+carries. The tombstone-resurrection write a supplied id can fall through to is fenced immediately
+before it runs, so it refuses on a batch-tier target rather than writing the row unfenced.
+
+`tests/batch-engine-harness.ts` adds a fake D1 client and a fake Neon HTTP client, each backed by a
+real engine (better-sqlite3, PGlite) wrapped in a real transaction, so batch atomicity — a rollback
+on a failing statement, a stale schema version writing nothing, every refusal reason reaching its
+gate — is now proven against real engine behavior instead of a mocked response. Bundled interactive
+behavior, emitted SQL, and the engine-profile-parity snapshot are unchanged.

--- a/.changeset/guarded-batch.md
+++ b/.changeset/guarded-batch.md
@@ -23,8 +23,12 @@ A singleton node `create` with a caller-supplied id now fuses its schema fence o
 backend exactly as a generated id already did, provided the kind carries no declared unique
 constraint: the id-generation gate that existed for an interactive root's autocommit durability no
 longer excludes a batch program, which commits its one statement as a unit regardless of which id it
-carries. The tombstone-resurrection write a supplied id can fall through to is fenced immediately
-before it runs, so it refuses on a batch-tier target rather than writing the row unfenced.
+carries. `isAutocommitSingleStatementWrite` — the separate, stricter classifier for a bundled root's
+transaction-free write — is deliberately not relaxed the same way: the fused supplied-id create
+instead proves `insertNodeIfAbsentWithSchemaFence` through the ordinary hooked write plan, which
+already selects the correct fenced statement per id. The tombstone-resurrection write a supplied id
+can fall through to is fenced immediately before it runs, so it refuses on a batch-tier target rather
+than writing the row unfenced.
 
 `tests/batch-engine-harness.ts` adds a fake D1 client and a fake Neon HTTP client, each backed by a
 real engine (better-sqlite3, PGlite) wrapped in a real transaction, so batch atomicity — a rollback

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -288,15 +288,16 @@ Both Neon drivers work with TypeGraph. They have different tradeoffs:
   are unavailable — TypeGraph auto-detects this driver and sets `capabilities.execution.interactiveTransactions = false`,
   so `store.transaction(...)` refuses rather than pretending to provide rollback. Eligible
   atomic-batch operations remain available when the transport is certified for them.
-  A schema-managed Store may attach for reads, but its first write fails closed because the driver
-  cannot hold the schema-version fence.
+  A schema-managed Store's write fuses its schema fence into the write's own statement when the
+  write fuses, and fails closed otherwise — see
+  [The guard every fused write shares](/limitations#the-guard-every-fused-write-shares) for which
+  writes fuse and the reasons a write that cannot refuses with.
 - **`drizzle-orm/neon-serverless`** uses a WebSocket Pool. Holds a session, supports full transactional
   semantics, but the WebSocket connection lifecycle needs care in serverless / per-request contexts
   (you typically want a fresh Pool per request).
 
-Pick HTTP for stateless reads and explicitly raw, unfenced single writes after a
-transactional migrator has initialized the database. Pick WebSockets for schema
-migrations, schema-managed Store writes, or any atomic multi-statement write.
+Pick HTTP for stateless reads and for the fused schema-managed writes. Pick WebSockets for schema
+migrations, and for any write outside that fused envelope.
 :::
 
 ### node-postgres (pg)
@@ -410,10 +411,14 @@ to manage. TypeGraph auto-detects this driver and sets
 sequential execution.
 
 A schema-managed or verified Store's first write does not universally fail
-closed here — it depends on whether the write fuses. On a kind with no
-declared unique constraint, a singleton node or edge create, update,
-`upsertById`, or delete fuses (a create takes a generated or a
-caller-supplied id), and so do `cardinality: "many"` edge creates,
+closed here — it depends on whether the write fuses. A singleton node
+create, update, `upsertById`, or delete fuses on a kind with no declared
+unique constraint (a create takes a generated or a caller-supplied id) —
+except a node delete, which fuses even when the kind DOES carry a declared
+unique constraint, because the atomic delete program releases that claim in
+the same statement. A singleton edge create fuses when the kind's
+cardinality is `"many"`, and edge update and delete fuse the same way
+(`EdgeCollection` has no `upsertById`). So do
 `bulkInsert`/`bulkCreate`/`bulkDelete`/`bulkReplaceById`/`bulkUpsertById`,
 and a constrained write inside an atomic program's claim envelope. Each of
 these asserts the active schema version inside the statements neon-http
@@ -1278,10 +1283,14 @@ Cloudflare D1 has no interactive transaction primitive, so it cannot commit
 TypeGraph schema versions: `commitSchemaVersion` / `setActiveVersion` need to
 hold one transaction across their compare-and-swap read and activating
 write, and D1 has no session to hold it on. Apply the base DDL with Wrangler
-/ drizzle-kit. `capabilities.execution.unitOfWork` reports `"batch"`. On a
-kind with no declared unique constraint, a singleton node or edge create,
-update, `upsertById`, or delete fuses (a create takes a generated or a
-caller-supplied id), and so do `cardinality: "many"` edge creates,
+/ drizzle-kit. `capabilities.execution.unitOfWork` reports `"batch"`. A
+singleton node create, update, `upsertById`, or delete fuses on a kind with
+no declared unique constraint (a create takes a generated or a
+caller-supplied id) — except a node delete, which fuses even when the kind
+DOES carry a declared unique constraint, because the atomic delete program
+releases that claim in the same statement. A singleton edge create fuses
+when the kind's cardinality is `"many"`, and edge update and delete fuse the
+same way (`EdgeCollection` has no `upsertById`). So do
 `bulkInsert`/`bulkCreate`/`bulkDelete`/`bulkReplaceById`/`bulkUpsertById`,
 and a constrained write inside an atomic program's claim envelope. Each of
 these asserts the active schema version inside the statements
@@ -2194,9 +2203,12 @@ Both backends report `execution.interactiveTransactions: true` by default. The e
 specific drivers:
 Cloudflare D1 (SQLite) and `drizzle-orm/neon-http` (Postgres) are non-transactional, so they downgrade to
 `execution.interactiveTransactions: false`. Operations that require atomicity (`commitSchemaVersion`,
-`setActiveVersion`, Operational Identity) throw on those drivers regardless of backend. Schema-managed Store writes also
-fail closed because they
-cannot hold the transaction-scoped schema fence; `store.transaction()` refuses on those roots. Eligible operations
+`setActiveVersion`, Operational Identity) throw on those drivers regardless of backend. A
+schema-managed Store's write that cannot fuse its schema fence into its own statement fails closed
+the same way, because it has no other way to hold the transaction-scoped fence; `store.transaction()`
+refuses on those roots regardless. See
+[The guard every fused write shares](/limitations#the-guard-every-fused-write-shares) for which
+writes fuse. Eligible operations
 with a certified atomic SQL program remain available independently of this interactive transaction capability.
 :::
 

--- a/apps/docs/src/content/docs/backend-setup.md
+++ b/apps/docs/src/content/docs/backend-setup.md
@@ -403,23 +403,41 @@ Edge runtimes expose `WebSocket` globally and need no extra setup.
 
 For stateless edge workloads where you don't need transactional writes. The HTTP
 driver issues one request per query — lowest cold-start cost, no session lifecycle
-to manage. TypeGraph auto-detects this driver and sets `capabilities.execution.interactiveTransactions`
-to `false`. On a raw Store, `store.transaction(...)` refuses rather than silently
-falling through to sequential execution. Eligible plain node batches and
-`cardinality: "many"` edge creates use the authoritative one-statement command
-even on a schema-managed Store; other managed writes fail closed when they
-need an interactive schema or constraint fence.
+to manage. TypeGraph auto-detects this driver and sets
+`capabilities.execution.interactiveTransactions` to `false` and
+`capabilities.execution.unitOfWork` to `"batch"`. On a raw Store,
+`store.transaction(...)` refuses rather than silently falling through to
+sequential execution.
 
-Schema commits are the one exception: `commitSchemaVersion` and
-`setActiveVersion` require atomicity to eliminate the orphan-row crash window
-they exist to fix, so they refuse with a typed `ConfigurationError` on
+A schema-managed or verified Store's first write does not universally fail
+closed here — it depends on whether the write fuses. On a kind with no
+declared unique constraint, a singleton node or edge create, update,
+`upsertById`, or delete fuses (a create takes a generated or a
+caller-supplied id), and so do `cardinality: "many"` edge creates,
+`bulkInsert`/`bulkCreate`/`bulkDelete`/`bulkReplaceById`/`bulkUpsertById`,
+and a constrained write inside an atomic program's claim envelope. Each of
+these asserts the active schema version inside the statements neon-http
+submits together, and `transaction(queries)` commits or rejects that
+submission as a whole. A write that cannot fuse either fails closed with
+`BATCH_WRITE_UNSUPPORTED` naming a proven reason (an interactive callback, a
+probe-then-write constraint check, Operational Identity, history, or a
+schema commit), or — for a write that simply doesn't fit the fused shape,
+such as a singleton create, update, or `upsertById` on a uniquely-constrained
+kind, or a supplied-id tombstone resurrection — fails closed with the plain
+`SCHEMA_WRITE_FENCE_UNSUPPORTED` limitation and no named reason. See
+[The guard every fused write shares](/limitations#the-guard-every-fused-write-shares)
+for the shared guard and the full reason table.
+
+Schema commits stay refused regardless: `commitSchemaVersion` and
+`setActiveVersion` require holding one transaction across their
+compare-and-swap read and activating write to eliminate the orphan-row crash
+window they exist to fix, so they refuse with a typed `ConfigurationError` on
 non-transactional backends. Run schema migrations from a process with a
 transactional driver (`drizzle-orm/neon-serverless`, regular `pg`, etc.); the
-edge worker can keep using neon-http for reads. It can also use a raw
-`createStore()` for single writes when the application explicitly accepts that
-those writes are not fenced against schema changes. A managed or verified Store
-can attach for reads, but its first write fails closed because neon-http cannot
-hold the schema fence.
+edge worker can keep using neon-http for reads and for the fused writes
+above. A raw `createStore()` remains available for writes outside that
+envelope when the application explicitly accepts they are not fenced against
+schema changes.
 
 ```bash
 npm install @neondatabase/serverless drizzle-orm
@@ -438,9 +456,9 @@ const store = createStore(graph, backend);
 // backend.capabilities.execution.interactiveTransactions === false (auto-detected)
 ```
 
-Use `neon-http` for reads and explicitly raw, unfenced single upserts. Run
-migrations and schema-managed Store writes through `neon-serverless`, regular
-`pg`, or another transactional driver.
+Use `neon-http` for reads and for the fused schema-managed writes listed
+above. Run schema migrations, and any write outside that envelope, through
+`neon-serverless`, regular `pg`, or another transactional driver.
 
 ### PGlite (Postgres-in-WASM)
 
@@ -1257,12 +1275,27 @@ in directly, and a custom profile has no way to replace it.
 TypeGraph supports Cloudflare D1 for edge deployments, with some limitations.
 
 Cloudflare D1 has no interactive transaction primitive, so it cannot commit
-TypeGraph schema versions or run multi-statement schema-managed Store writes.
-Apply the base DDL with Wrangler / drizzle-kit. Eligible plain node batches
-and `cardinality: "many"` edge creates can still use the bundled
-authoritative one-statement command; other schema-managed writes require a
-transactional backend. Use a raw `createStore()` only when the application
-accepts unfenced writes for the remaining paths:
+TypeGraph schema versions: `commitSchemaVersion` / `setActiveVersion` need to
+hold one transaction across their compare-and-swap read and activating
+write, and D1 has no session to hold it on. Apply the base DDL with Wrangler
+/ drizzle-kit. `capabilities.execution.unitOfWork` reports `"batch"`. On a
+kind with no declared unique constraint, a singleton node or edge create,
+update, `upsertById`, or delete fuses (a create takes a generated or a
+caller-supplied id), and so do `cardinality: "many"` edge creates,
+`bulkInsert`/`bulkCreate`/`bulkDelete`/`bulkReplaceById`/`bulkUpsertById`,
+and a constrained write inside an atomic program's claim envelope. Each of
+these asserts the active schema version inside the statements
+`D1Database.batch()` runs together, so these succeed on a schema-managed
+Store. A write that cannot fuse either fails closed with
+`BATCH_WRITE_UNSUPPORTED` naming a proven reason (a probe-then-write
+constraint check, an interactive callback, Operational Identity, history, or
+a schema commit), or — for a write that simply doesn't fit the fused shape,
+such as a singleton create, update, or `upsertById` on a uniquely-constrained
+kind, or a supplied-id tombstone resurrection — fails closed with the plain
+`SCHEMA_WRITE_FENCE_UNSUPPORTED` limitation and no named reason; see
+[The guard every fused write shares](/limitations#the-guard-every-fused-write-shares)
+for the full reason table. Use a raw `createStore()` only when the
+application accepts unfenced writes for the remaining paths:
 
 ```typescript
 import { drizzle } from "drizzle-orm/d1";
@@ -1408,9 +1441,14 @@ never inherited by an ordinary derived backend.
 `"interactive"` when `interactiveTransactions` is `true`, else `"batch"` when
 `atomicBatch` is not `"none"` (an HTTP-only driver such as `drizzle-orm/neon-http`,
 which cannot hold an open session but does support a native atomic program),
-else `"none"`. Nothing in the store consumes it yet — it exists so a caller can
-tell the three execution shapes apart without re-deriving the same distinction
-from `interactiveTransactions` and `atomicBatch` separately.
+else `"none"`. Two internal readers key off the `"batch"` value: the
+batch-tier write verdict (`resolveBatchWriteVerdict`) that produces
+`BATCH_WRITE_UNSUPPORTED` refusals, and the autocommit single-statement
+eligibility gate that decides whether a supplied-id singleton create can
+fuse its schema fence into one statement. It also exists so any other
+caller can tell the three execution shapes apart without re-deriving the
+same distinction from `interactiveTransactions` and `atomicBatch`
+separately.
 
 `graphAnalytics.supported` describes the backend shape, not mutable PostgreSQL
 session state. A hot standby or a role without the database `TEMP` privilege can

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -735,6 +735,41 @@ and retry it with `BEGIN IMMEDIATE`; TypeGraph-owned transactions already use
 that mode. The refusal happens before the constraint probe, so the write is
 fenced or refused rather than allowed to rely on a stale decision.
 
+#### `BATCH_WRITE_UNSUPPORTED`
+
+A backend whose `capabilities.execution.unitOfWork` is `"batch"` (Cloudflare
+D1's `batch()`, Neon HTTP's `transaction(queries)`) fixes every statement
+before the first one runs and commits them together with no session in
+between. Every fused write on such a backend — a static batch and a
+certified atomic program alike — asserts the active schema version inside
+the very statement that writes, so a stale version writes nothing and the
+store reports `StaleVersionError`. See
+[The guard every fused write shares](/limitations#the-guard-every-fused-write-shares).
+
+A write that needs more than that one guarded statement refuses, but
+`BATCH_WRITE_UNSUPPORTED` is not itself a top-level error code: the
+enforcing gate keeps its own class and code
+(`CONSTRAINT_WRITE_FENCE_UNSUPPORTED`, `UNSUPPORTED_BACKEND_CAPABILITY`,
+`IDENTITY_REQUIRES_ATOMIC_BACKEND`, or a plain `ConfigurationError` for
+`history` / `revisionTracking` / a schema commit) and nests
+`{ code: "BATCH_WRITE_UNSUPPORTED", reason }` under `details.batchRefusal`,
+naming what a closed batch cannot supply:
+
+| `details.batchRefusal.reason` | What it needs | Raised by |
+| --- | --- | --- |
+| `interactive-callback` | Hold an interactive callback transaction open across several round trips. | `store.transaction(fn)` / `store.transactionWithReceipt(fn)` |
+| `constraint-needs-probe` | Read a value it wrote earlier in the same write before deciding what to write next. | A declared constraint's probe-then-write (`CONSTRAINT_WRITE_FENCE_UNSUPPORTED`, above) |
+| `identity` | Read and write Operational Identity's closure across several round trips inside one held transaction. | `Store` construction, or `requireAtomicIdentityBackend`, when `graph.identity` is declared |
+| `history` | Hold the per-graph write lock and clock open across a whole write cascade. | `history: true` or `revisionTracking: true` |
+| `schema-commit` | Hold one transaction across its compare-and-swap read and its activating write. | `commitSchemaVersion` / `setActiveVersion` |
+
+`SCHEMA_WRITE_FENCE_UNSUPPORTED` — the portable schema-version fence an
+ineligible write falls back to (see [Schema Migrations](/schema-management))
+— does not carry `batchRefusal`. It is reached from many fuse failures that
+are not specific to a batch-tier backend (an ineligible write kind, a
+derived backend, a provenance mismatch), so it states its plain limitation
+without guessing which of the reasons above, if any, applies.
+
 #### Write-fence declaration codes
 
 `capabilities.writeFence` resolves one of four write-fence plans a lock site

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -767,8 +767,9 @@ naming what a closed batch cannot supply:
 ineligible write falls back to (see [Schema Migrations](/schema-management))
 — does not carry `batchRefusal`. It is reached from many fuse failures that
 are not specific to a batch-tier backend (an ineligible write kind, a
-derived backend, a provenance mismatch), so it states its plain limitation
-without guessing which of the reasons above, if any, applies.
+tombstone-resurrection write a supplied id falls through to, a derived
+backend, a provenance mismatch), so it states its plain limitation without
+guessing which of the reasons above, if any, applies.
 
 #### Write-fence declaration codes
 

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -101,6 +101,51 @@ root `getOrCreateByEndpoints` calls can therefore use the authoritative
 one-statement command. The durable identity does not make unrelated Store
 operations, claims, or history/revision side effects transactionless.
 
+### The guard every fused write shares
+
+Every static batch and every certified atomic program asserts the active
+schema version inside the very statement that writes, never as a preceding
+check — the fused create's `WHERE … is_active` predicate, or the program's
+leading `schema_fence` CTE. A stale version makes that statement match zero
+rows, so the write commits nothing, and the store re-reads and reports
+`StaleVersionError` instead of writing against a version that already moved
+on. This is what lets a `"batch"`-tier backend (`capabilities.execution.unitOfWork === "batch"`
+— Cloudflare D1's `batch()`, Neon HTTP's `transaction(queries)`, which fix
+every statement before the first one runs and commit them together with no
+session in between) run schema-managed creates, updates and deletes, and
+bulk writes at all: the fence travels inside the one exchange it can hold,
+instead of needing a session to hold it separately. A singleton node or edge
+update, `upsertById`, or delete fuses the same way as a create, through a
+one-entry certified atomic program, whenever its kind carries no declared
+unique constraint (and, for a node delete, no disjointness or uniqueness
+claim the backend has not proven it can release in that same statement).
+
+A write that needs more than that one guarded statement — because it must
+read a value it wrote earlier in the same write, hold an interactive
+callback open across round trips, maintain Operational Identity's closure,
+hold history's per-graph lock across a whole write cascade, or hold one
+transaction across a schema commit's compare-and-swap — refuses on a
+`"batch"`-tier backend with `BATCH_WRITE_UNSUPPORTED`, naming which of those
+it needed:
+
+| `reason` | What it needs |
+| --- | --- |
+| `interactive-callback` | Hold an interactive callback transaction open across several round trips (`store.transaction(fn)`). |
+| `constraint-needs-probe` | Read a value it wrote earlier in the same write before deciding what to write next (a declared constraint's probe-then-write). |
+| `identity` | Read and write Operational Identity's closure across several round trips inside one held transaction. |
+| `history` | Hold the per-graph write lock and clock open across a whole write cascade (`history: true` / `revisionTracking: true`). |
+| `schema-commit` | Hold one transaction across its compare-and-swap read and its activating write (`commitSchemaVersion` / `setActiveVersion`). |
+
+A write that simply cannot fuse — an ineligible write kind, a singleton
+create/update/`upsertById` on a kind with a declared unique constraint, a
+tombstone-resurrection write a supplied id falls through to, or a derived
+backend — refuses with `SCHEMA_WRITE_FENCE_UNSUPPORTED` instead and carries
+no `batchRefusal` reason: that gate has no proven need to name, only its own
+plain limitation.
+
+See [`BATCH_WRITE_UNSUPPORTED`](/errors#batch_write_unsupported) for where
+each reason surfaces in an error's `details`.
+
 ## libsql Single-Connection Transactions
 
 For local `@libsql/client` connections (`file:` paths and `file::memory:`),

--- a/apps/docs/src/content/docs/limitations.md
+++ b/apps/docs/src/content/docs/limitations.md
@@ -31,9 +31,11 @@ kind: on PostgreSQL, `batch()`'s implicit transaction runs at the default
 read-committed isolation, so queries there can also observe interleaved commits.
 
 Write behavior depends on how the Store was constructed. A schema-managed Store
+fuses its schema fence into a write's own statement when the write fuses, and
 fails closed for writes that need the transaction-scoped schema or constraint
-fence, but eligible plain node batches and `cardinality: "many"` edges can use
-the authoritative one-statement command. A raw `createStore()` /
+fence otherwise — see
+[The guard every fused write shares](#the-guard-every-fused-write-shares)
+below for which writes fuse and which refuse. A raw `createStore()` /
 `createAdapterStore()` without a reconciled snapshot still has no interactive
 transaction boundary. `store.transaction(fn)` refuses with a typed capability
 error rather than pretending to provide rollback; direct backend writes remain
@@ -114,11 +116,13 @@ on. This is what lets a `"batch"`-tier backend (`capabilities.execution.unitOfWo
 every statement before the first one runs and commit them together with no
 session in between) run schema-managed creates, updates and deletes, and
 bulk writes at all: the fence travels inside the one exchange it can hold,
-instead of needing a session to hold it separately. A singleton node or edge
-update, `upsertById`, or delete fuses the same way as a create, through a
-one-entry certified atomic program, whenever its kind carries no declared
-unique constraint (and, for a node delete, no disjointness or uniqueness
-claim the backend has not proven it can release in that same statement).
+instead of needing a session to hold it separately. A singleton node update,
+`upsertById`, or delete fuses the same way as a create, through a one-entry
+certified atomic program, whenever its kind carries no declared unique
+constraint — except a node delete, which fuses even when the kind DOES
+carry one, because the atomic delete program releases that claim in the
+same statement. A singleton edge update or delete fuses the same way
+(`EdgeCollection` has no `upsertById`).
 
 A write that needs more than that one guarded statement — because it must
 read a value it wrote earlier in the same write, hold an interactive

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -190,8 +190,10 @@ preserve that state:
 Managed writes acquire a transaction-scoped fence and revalidate that version
 before changing graph data. On the official SQLite and PostgreSQL backends this
 prevents a stale Store write from landing across a schema commit. A custom or
-non-transactional backend that cannot provide the fence fails closed on its
-first managed write.
+non-transactional backend fails closed on the first managed write that cannot
+fuse the fence into its own statement — see
+[The guard every fused write shares](/limitations#the-guard-every-fused-write-shares)
+for which writes fuse and which refuse.
 
 `createStore()` and `createAdapterStore()` without `{ reconciled }` are raw,
 unversioned attaches. Their writes—and calls made directly through a backend—do

--- a/apps/docs/src/content/docs/schema-management.md
+++ b/apps/docs/src/content/docs/schema-management.md
@@ -144,10 +144,17 @@ It throws:
 - `StoreNotInitializedError` if the schema is current but the
   runtime-contribution markers (e.g. fulltext) are missing/stale.
 
-The attach itself can succeed on a non-transactional or custom backend, but the
-first managed write throws `ConfigurationError` with
-`details.code === "SCHEMA_WRITE_FENCE_UNSUPPORTED"` unless the backend can run
-transactions and provides the schema-write fence. Reads remain available.
+The attach itself can succeed on a non-transactional or custom backend. On a
+backend whose `capabilities.execution.unitOfWork` is `"batch"` (Cloudflare
+D1, Neon HTTP), a fused write commonly succeeds — see
+[The guard every fused write shares](/limitations#the-guard-every-fused-write-shares)
+for which writes fuse — and a write that cannot fuse throws
+`ConfigurationError` with `details.code === "SCHEMA_WRITE_FENCE_UNSUPPORTED"`,
+or, for a proven need such as an interactive callback or a schema commit, a
+typed error naming `BATCH_WRITE_UNSUPPORTED` under `details.batchRefusal`.
+On any other backend that provides neither an interactive transaction nor
+the schema-write fence, every managed write throws `ConfigurationError` with
+`details.code === "SCHEMA_WRITE_FENCE_UNSUPPORTED"`. Reads remain available.
 
 If you only need the check without building a Store (e.g. a readiness
 probe), call `assertSchemaCurrent(backend, graph)` directly — it returns

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -7887,7 +7887,7 @@ type UnsafeHistoryStoreBackendMember = "clearGraph" | "commitSchemaVersionWithPr
 
 // @public
 export class UnsupportedBackendCapabilityError extends TypeGraphError {
-    constructor(operation: string, capability: string, details?: Readonly<Record<string, unknown>>, suggestion?: string);
+    constructor(operation: string, capability: string, details?: Readonly<Record<string, unknown>>, suggestion?: string, messageSuffix?: string);
 }
 
 // @public

--- a/packages/typegraph/src/backend/capabilities/batch-write-verdict.ts
+++ b/packages/typegraph/src/backend/capabilities/batch-write-verdict.ts
@@ -1,0 +1,121 @@
+/**
+ * The one classification of a schema-managed write's fitness for a
+ * `"batch"` engine (Cloudflare D1's `batch()`, Neon HTTP's
+ * `transaction(queries)`) — a backend whose `capabilities.execution.unitOfWork`
+ * is `"batch"` fixes every statement before the first one runs and commits
+ * them together with no interactive session in between.
+ *
+ * A leaf module so both halves of the write path can reach it without a
+ * cycle: `store/operations/write-transaction.ts` re-exports it beside
+ * `constraintFenceRefusal`, and `store/recorded-capture/guards.ts` (which
+ * `write-transaction.ts` itself imports through the `recorded-capture`
+ * barrel) imports it directly instead of reaching back through that barrel.
+ */
+import { type BackendCapabilities } from "../types";
+
+/**
+ * What a schema-managed write needs that a closed batch program cannot
+ * supply. Each reason names the one thing, of the five kinds this module's
+ * callers already refuse, that requires a session instead.
+ */
+export type BatchWriteRefusalReason =
+  | "interactive-callback"
+  | "constraint-needs-probe"
+  | "identity"
+  | "history"
+  | "schema-commit";
+
+/**
+ * Either an atomic program or a fused statement carries the write
+ * (`program`), or it needs something a closed batch cannot supply, named by
+ * `reason` with the `explanation` every enforcing gate embeds.
+ */
+export type BatchWriteVerdict =
+  | Readonly<{ kind: "program" }>
+  | Readonly<{
+      kind: "refused";
+      code: "BATCH_WRITE_UNSUPPORTED";
+      reason: BatchWriteRefusalReason;
+      explanation: string;
+    }>;
+
+/**
+ * The one canonical explanation per {@link BatchWriteRefusalReason}, so the
+ * enforcing gates (the constrained-write probe, `store.transaction`,
+ * Operational Identity, recorded-time capture, and a schema commit) describe
+ * the same limitation in the same words instead of independently-worded
+ * sentences.
+ */
+const BATCH_WRITE_REFUSAL_EXPLANATIONS: Readonly<
+  Record<BatchWriteRefusalReason, string>
+> = {
+  "interactive-callback":
+    "hold an interactive callback transaction open across several round trips",
+  "constraint-needs-probe":
+    "read a value it wrote earlier in the same write before deciding what to write next",
+  identity:
+    "read and write Operational Identity's closure across several round trips inside one held transaction",
+  history:
+    "hold the per-graph write lock and clock open across a whole write cascade",
+  "schema-commit":
+    "hold one transaction across its compare-and-swap read and its activating write",
+};
+
+/**
+ * Classifies a schema-managed write's fitness for the backend's declared
+ * `unitOfWork`, for a caller that has ALREADY decided — from its own
+ * existing predicate (identity enabled, history enabled, a probe-needing
+ * constraint, an interactive `store.transaction` call, a schema commit) —
+ * that `write.needs` names what this write requires. This function does
+ * not re-derive that classification; it only decides whether the backend's
+ * declared tier is the reason the need goes unmet, so that a backend which
+ * is non-transactional AND has no atomic batch either — a custom
+ * `GraphBackend` with neither primitive — keeps its own plain wording
+ * (`kind: "program"` here, meaning "not a batch-tier limitation") instead
+ * of being misdescribed as a batch-engine limitation it does not have.
+ *
+ * `needs` is required: a caller with no proven need has nothing to classify
+ * and must not call this function at all, rather than pass an absent value
+ * through it and silently receive the same "not a batch limitation" answer.
+ */
+export function resolveBatchWriteVerdict(
+  backend: Readonly<{ capabilities: Pick<BackendCapabilities, "execution"> }>,
+  write: Readonly<{ needs: BatchWriteRefusalReason }>,
+): BatchWriteVerdict {
+  if (backend.capabilities.execution.unitOfWork !== "batch") {
+    return { kind: "program" };
+  }
+  return {
+    kind: "refused",
+    code: "BATCH_WRITE_UNSUPPORTED",
+    reason: write.needs,
+    explanation: BATCH_WRITE_REFUSAL_EXPLANATIONS[write.needs],
+  };
+}
+
+/**
+ * The one composed sentence fragment every enforcing gate appends to its own
+ * base message — empty when `verdict.kind` is `"program"`, so a gate can
+ * always write `baseSentence + batchRefusalSuffix(verdict)` with no
+ * conditional of its own.
+ */
+export function batchRefusalSuffix(verdict: BatchWriteVerdict): string {
+  return verdict.kind === "refused" ?
+      ` Specifically, this needs to ${verdict.explanation}, which a closed batch program cannot do.`
+    : "";
+}
+
+/**
+ * The one `details` fragment every enforcing gate spreads into its error's
+ * `details` object, nested under `batchRefusal` so it never collides with a
+ * gate's own `code` (`SCHEMA_WRITE_FENCE_UNSUPPORTED`,
+ * `CONSTRAINT_WRITE_FENCE_UNSUPPORTED`, `IDENTITY_REQUIRES_ATOMIC_BACKEND`,
+ * …) — empty when `verdict.kind` is `"program"`.
+ */
+export function batchRefusalDetails(
+  verdict: BatchWriteVerdict,
+): Readonly<Record<string, unknown>> {
+  return verdict.kind === "refused" ?
+      { batchRefusal: { code: verdict.code, reason: verdict.reason } }
+    : {};
+}

--- a/packages/typegraph/src/backend/capabilities/execution.ts
+++ b/packages/typegraph/src/backend/capabilities/execution.ts
@@ -1,8 +1,31 @@
-import type { BackendCapabilities } from "../types";
+import type {
+  BackendCapabilities,
+  BackendExecutionCapabilities,
+} from "../types";
+
+/**
+ * THE one derivation of `execution.unitOfWork` from the other two execution
+ * facts. An engine that can hold an open callback transaction groups a write
+ * that way regardless of whether it also exposes an atomic batch primitive;
+ * otherwise a closed atomic program is the unit when one exists, and there is
+ * none at all when neither does. Every place that changes `atomicBatch` —
+ * the capability tail and the two boundaries below — re-derives through this
+ * function, so the two facts can never disagree on one object.
+ */
+export function deriveUnitOfWork(
+  execution: Pick<
+    BackendExecutionCapabilities,
+    "interactiveTransactions" | "atomicBatch"
+  >,
+): NonNullable<BackendExecutionCapabilities["unitOfWork"]> {
+  if (execution.interactiveTransactions) return "interactive";
+  return execution.atomicBatch === "none" ? "none" : "batch";
+}
 
 /**
  * Removes exact atomic execution evidence at a backend derivation or session
- * boundary.
+ * boundary, and re-derives `unitOfWork` with it: a derived object with no
+ * atomic batch is not a batch-tier backend, whatever its source was.
  *
  * Derived/projection constructors and transaction factories share this owner
  * so a new backend construction seam cannot accidentally retain execution
@@ -13,11 +36,17 @@ export function downgradeAtomicBatch(
 ): BackendCapabilities {
   return {
     ...capabilities,
-    execution: {
+    execution: withUnitOfWork({
       ...capabilities.execution,
       atomicBatch: "none",
-    },
+    }),
   };
+}
+
+function withUnitOfWork(
+  execution: BackendExecutionCapabilities,
+): BackendExecutionCapabilities {
+  return { ...execution, unitOfWork: deriveUnitOfWork(execution) };
 }
 
 /**
@@ -35,9 +64,9 @@ export function scopeAtomicBatchToSession(
 ): BackendCapabilities {
   return {
     ...capabilities,
-    execution: {
+    execution: withUnitOfWork({
       ...capabilities.execution,
       atomicBatch: available ? "session" : "none",
-    },
+    }),
   };
 }

--- a/packages/typegraph/src/backend/drizzle/engine/capabilities.ts
+++ b/packages/typegraph/src/backend/drizzle/engine/capabilities.ts
@@ -40,6 +40,7 @@ import type { VectorStrategy } from "../../../query/dialect/vector-strategy";
 import { buildVectorCapabilities } from "../../../query/dialect/vector-strategy";
 import { createAtomicSqlProgramExecutor } from "../../capabilities/atomic-sql-program";
 import { assertBundledCapabilityDeclarations } from "../../capabilities/declarations";
+import { deriveUnitOfWork } from "../../capabilities/execution";
 import type { BackendCapabilities } from "../../types";
 import { contributionRebuildSupported } from "../contribution-materializations";
 import type { SqlExecutionAdapter } from "../execution/types";
@@ -111,10 +112,10 @@ export function finalizeEngineCapabilities(
       // engine that can hold an open callback transaction groups a write
       // that way regardless of whether it also happens to expose an atomic
       // batch primitive.
-      unitOfWork:
-        declared.execution.interactiveTransactions ? "interactive"
-        : atomicBatch === "none" ? "none"
-        : "batch",
+      unitOfWork: deriveUnitOfWork({
+        interactiveTransactions: declared.execution.interactiveTransactions,
+        atomicBatch,
+      }),
     },
     // Absent strategy: omit outright, regardless of what `declared` carried
     // — a value left over from a builder that (wrongly) baked one in, or a

--- a/packages/typegraph/src/backend/drizzle/postgres.ts
+++ b/packages/typegraph/src/backend/drizzle/postgres.ts
@@ -107,6 +107,11 @@ import {
   registerAtomicSqlProgram,
 } from "../capabilities/atomic-sql-program";
 import {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
+} from "../capabilities/batch-write-verdict";
+import {
   assertNoLegacyTransactionCapability,
   sealCapabilityDeclaration,
 } from "../capabilities/declarations";
@@ -1634,15 +1639,20 @@ export function buildPostgresEngineProfile(
       fn: (tx: InternalOperationBackend) => Promise<T>,
     ): Promise<T> {
       if (!capabilities.execution.interactiveTransactions) {
+        const verdict = resolveBatchWriteVerdict(ctx.self(), {
+          needs: "schema-commit",
+        });
         throw new ConfigurationError(
           "Schema writes and removal cleanup require atomic transactions, " +
             "but this Postgres backend does not provide them. The drizzle-orm/neon-http " +
             "driver communicates over HTTP and cannot hold a session across statements; " +
-            "use drizzle-orm/neon-serverless (websocket) for transactional writes.",
+            "use drizzle-orm/neon-serverless (websocket) for transactional writes." +
+            batchRefusalSuffix(verdict),
           {
             backend: "postgres",
             capability: "execution.interactiveTransactions",
             supportsInteractiveTransactions: false,
+            ...batchRefusalDetails(verdict),
           },
         );
       }

--- a/packages/typegraph/src/backend/drizzle/sqlite.ts
+++ b/packages/typegraph/src/backend/drizzle/sqlite.ts
@@ -76,6 +76,11 @@ import {
   createAtomicSqlProgramExecutor,
 } from "../capabilities/atomic-sql-program";
 import {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
+} from "../capabilities/batch-write-verdict";
+import {
   assertNoLegacyTransactionCapability,
   sealCapabilityDeclaration,
 } from "../capabilities/declarations";
@@ -428,11 +433,15 @@ const toSchemaVersionRow = createSchemaVersionRowMapper(
 );
 
 /** Every SQLite "atomic transactions unavailable" refusal shares this shape. */
-function throwSqliteTransactionsDisabled(message: string): never {
+function throwSqliteTransactionsDisabled(
+  message: string,
+  details?: Readonly<Record<string, unknown>>,
+): never {
   throw new ConfigurationError(message, {
     backend: "sqlite",
     capability: "execution.interactiveTransactions",
     supportsInteractiveTransactions: false,
+    ...details,
   });
 }
 
@@ -1720,11 +1729,16 @@ export function buildSqliteEngineProfile(
       fn: (tx: InternalOperationBackend) => Promise<T>,
     ): Promise<T> {
       if (transactionMode === "none") {
+        const verdict = resolveBatchWriteVerdict(ctx.self(), {
+          needs: "schema-commit",
+        });
         throwSqliteTransactionsDisabled(
           "Schema writes and removal cleanup require atomic transactions, " +
             "but this SQLite backend has transactions disabled. Configure a " +
             "driver that supports transactions (better-sqlite3, libsql, " +
-            "bun:sqlite) to use schema commits.",
+            "bun:sqlite) to use schema commits." +
+            batchRefusalSuffix(verdict),
+          batchRefusalDetails(verdict),
         );
       }
 

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -332,7 +332,12 @@ export type BackendCapabilities = Readonly<{
      * the batch-tier write verdict (`resolveBatchWriteVerdict` in
      * `backend/capabilities/batch-write-verdict.ts`) and the autocommit
      * single-statement eligibility gate
-     * (`canFuseSchemaFenceInFirstWrite`).
+     * (`canFuseSchemaFenceInFirstWrite`). Absent is treated as anything but
+     * `"batch"`: `resolveBatchWriteVerdict` answers `program` (its "not a
+     * batch-tier limitation" verdict) for it, so a backend that declares
+     * neither an interactive transaction nor an atomic batch still fails
+     * closed on a write that needs one — through that write's own capability
+     * check, not through a batch-tier refusal it never earned.
      */
     unitOfWork?: "interactive" | "batch" | "none";
   }>;

--- a/packages/typegraph/src/backend/types.ts
+++ b/packages/typegraph/src/backend/types.ts
@@ -328,7 +328,11 @@ export type BackendCapabilities = Readonly<{
      * when `atomicBatch` is not `"none"`, else `"none"` — overwriting
      * whatever a profile's own `declaredCapabilities` set. Optional so a
      * custom `GraphBackend` implementation, which nothing derives this for,
-     * is not forced to declare it; no consumer reads it yet.
+     * is not forced to declare it. Two readers key off the `"batch"` value:
+     * the batch-tier write verdict (`resolveBatchWriteVerdict` in
+     * `backend/capabilities/batch-write-verdict.ts`) and the autocommit
+     * single-statement eligibility gate
+     * (`canFuseSchemaFenceInFirstWrite`).
      */
     unitOfWork?: "interactive" | "batch" | "none";
   }>;

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -1668,9 +1668,15 @@ export class UnsupportedBackendCapabilityError extends TypeGraphError {
     capability: string,
     details: Readonly<Record<string, unknown>> = {},
     suggestion?: string,
+    // Appended to the generated message, never to `suggestion`: every other
+    // capability-refusal gate places its batch-engine explanation
+    // (`batchRefusalSuffix`) in the message, and this constructor's message
+    // is otherwise fixed shape, so a caller with that explanation needs a
+    // seam to reach it rather than smuggling it into the advice sentence.
+    messageSuffix?: string,
   ) {
     super(
-      `${operation} requires backend capability '${capability}'.`,
+      `${operation} requires backend capability '${capability}'.${messageSuffix ?? ""}`,
       "UNSUPPORTED_BACKEND_CAPABILITY",
       {
         details: { operation, capability, ...details },

--- a/packages/typegraph/src/identity/service-maintenance.ts
+++ b/packages/typegraph/src/identity/service-maintenance.ts
@@ -8,6 +8,11 @@ import {
 import { type SqlSchema } from "../query/compiler/schema";
 import { sql } from "../query/sql-fragment";
 import { asCompiledRowsSql } from "../query/sql-intent";
+import {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
+} from "../store/operations/write-transaction";
 import { withRecordedIdentityMutationTarget } from "../store/recorded-capture";
 import { chunk } from "../utils/array";
 import { nowIso } from "../utils/date";
@@ -67,11 +72,27 @@ export type IdentityRebuildContext<G extends GraphDef> = Pick<
   "backend" | "graphId" | "registry" | "schema" | "sameIdAcrossKinds"
 >;
 
+/**
+ * Defense-in-depth: `Store`'s constructor (`store.ts`) already refuses
+ * Operational Identity at construction whenever
+ * `!capabilities.execution.interactiveTransactions`, so no public path
+ * reaches this gate against a batch-tier backend today — identity
+ * maintenance never runs once construction has refused it. It stays here,
+ * re-checked, because {@link rebuildIdentityClosureForContext} and
+ * {@link validateIdentityForContext} are also called by lower-level
+ * preflights that do not go through `Store`'s constructor.
+ */
 function requireAtomicIdentityBackend(backend: Backend, graphId: string): void {
   if (!backend.capabilities.execution.interactiveTransactions) {
+    const verdict = resolveBatchWriteVerdict(backend, { needs: "identity" });
     throw new ConfigurationError(
-      "Operational Identity requires atomic transaction support.",
-      { code: "IDENTITY_REQUIRES_ATOMIC_BACKEND", graphId },
+      "Operational Identity requires atomic transaction support." +
+        batchRefusalSuffix(verdict),
+      {
+        code: "IDENTITY_REQUIRES_ATOMIC_BACKEND",
+        graphId,
+        ...batchRefusalDetails(verdict),
+      },
     );
   }
 }

--- a/packages/typegraph/src/store/operations/autocommit-single-statement.ts
+++ b/packages/typegraph/src/store/operations/autocommit-single-statement.ts
@@ -91,7 +91,14 @@ export function canFuseSchemaFenceInFirstWrite(
         candidate.schemaVersion !== undefined &&
         canUseSchemaFenceAtExecutionBoundary(
           candidate.backend,
-          candidate.idGenerated,
+          // The id-generation gate on root autocommit exists for an
+          // INTERACTIVE root's durability (a caller-supplied id retried
+          // after an ambiguous failure could duplicate-conflict); an atomic
+          // batch program commits its one fused statement as a unit
+          // regardless of which id it carries, so a batch-tier target
+          // clears this gate for a supplied id too.
+          candidate.idGenerated ||
+            candidate.backend.capabilities.execution.unitOfWork === "batch",
         ) &&
         isSchemaFencedInsertEligible(candidate.backend) &&
         !candidate.historyEnabled &&
@@ -142,6 +149,15 @@ export function isAutocommitSingleStatementWrite(
         !candidate.historyEnabled &&
         !candidate.revisionTrackingEnabled &&
         !candidate.identityEnabled &&
+        // Unlike `canFuseSchemaFenceInFirstWrite`'s root-autocommit test,
+        // this `idGenerated` stays strict for every target, batch-tier
+        // included: the eligibility check below proves only
+        // `insertNodeWithSchemaFence` (the fresh-id INSERT, no duplicate
+        // check), never `insertNodeIfAbsentWithSchemaFence`. A supplied id
+        // needs the if-absent statement's duplicate handling regardless of
+        // unitOfWork, so it takes `runHookedWritePlan`'s route instead,
+        // where `canFuseSchemaFenceInFirstWrite` already selects the
+        // correct statement per id.
         candidate.idGenerated &&
         candidate.kindRegistered &&
         candidate.uniqueConstraintCount === 0 &&

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -2574,7 +2574,16 @@ async function executeNodeCreateInternal<G extends GraphDef>(
           { operation: "insert", entity: "node" },
         );
       }
-      await lockSchemaVersionForStoreWrite(ctx, targetBackend);
+      // A supplied id's fused statement returned no row because the id is
+      // already occupied (the stale-version case already threw above) — the
+      // occupancy check below re-reads to report the duplicate. On a
+      // transaction this re-fences before that read, matching the
+      // fresh-id branch above; a `"none"`-mode target (a batch engine's
+      // fused statement already carried its own fence) has no ordinary
+      // lock to take here.
+      if (transactionMode !== "none") {
+        await lockSchemaVersionForStoreWrite(ctx, targetBackend);
+      }
     }
 
     if (fuseProjections && !fuseSchemaFenceProjections) {
@@ -2620,6 +2629,14 @@ async function executeNodeCreateInternal<G extends GraphDef>(
       }
       if (occupied.deleted_at === undefined) {
         throw createAlreadyExistsError("node", prepared.kind, prepared.id);
+      }
+      // The tombstone-slot classification above is a read; resurrecting it is
+      // a genuine write (`session.reviseNode`) outside the fused INSERT's
+      // atomicity. When that INSERT's own no-row diagnosis left the schema
+      // fence untaken for a `"none"`-mode target (see above), fail closed
+      // here before the write, matching edge create's identical point.
+      if (fuseSchemaFenceInFirstWrite && transactionMode === "none") {
+        await lockSchemaVersionForStoreWrite(ctx, targetBackend);
       }
       const resurrected = await resurrectPreparedNode(
         ctx,

--- a/packages/typegraph/src/store/operations/node-operations.ts
+++ b/packages/typegraph/src/store/operations/node-operations.ts
@@ -2635,6 +2635,15 @@ async function executeNodeCreateInternal<G extends GraphDef>(
       // atomicity. When that INSERT's own no-row diagnosis left the schema
       // fence untaken for a `"none"`-mode target (see above), fail closed
       // here before the write, matching edge create's identical point.
+      // `lockSchemaVersionForStoreWrite` throws the plain
+      // `SCHEMA_WRITE_FENCE_UNSUPPORTED` limitation here, not
+      // `BATCH_WRITE_UNSUPPORTED`: a tombstone resurrection needs a second
+      // write outside the fused INSERT regardless of `unitOfWork`, which is
+      // not one of `BatchWriteRefusalReason`'s five proven needs (an
+      // interactive callback, a constraint probe, identity, history, or a
+      // schema commit) — it is simply a write shape that cannot fuse, the
+      // same plain limitation an ineligible write kind or a derived backend
+      // reaches through this same call.
       if (fuseSchemaFenceInFirstWrite && transactionMode === "none") {
         await lockSchemaVersionForStoreWrite(ctx, targetBackend);
       }

--- a/packages/typegraph/src/store/operations/write-transaction.ts
+++ b/packages/typegraph/src/store/operations/write-transaction.ts
@@ -59,6 +59,11 @@
  * would make the claim above false wherever it matters most. Unconstrained
  * writes assert nothing and keep working on those backends.
  */
+import {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
+} from "../../backend/capabilities/batch-write-verdict";
 import { statementExecutionMembers } from "../../backend/capabilities/bind";
 import { type STATEMENT_EXECUTION } from "../../backend/capabilities/bundle-registry";
 import { type BundleVerdictOf } from "../../backend/capabilities/resolve";
@@ -357,6 +362,15 @@ async function lockSchemaVersionForStoreWriteUncached(
     "transaction" in backend &&
     !backend.capabilities.execution.interactiveTransactions
   ) {
+    // Reached from every call site above through many different fuse
+    // failures (an ineligible kind, a derived backend an execution-boundary
+    // proof does not cover, a provenance mismatch at the actual write
+    // receiver) — this gate's own inputs (graph id, schema version) name
+    // none of them. It states the plain limitation with no guessed cause;
+    // a caller that HAS proven a specific `BatchWriteRefusalReason` (a
+    // declared constraint, `store.transaction`, identity, history, a schema
+    // commit) reports it through that reason's own enforcing gate instead of
+    // this one.
     throw new ConfigurationError(
       "Schema-managed Store writes require a transactional backend so schema " +
         "changes and entity writes can share one fence.",
@@ -459,6 +473,23 @@ function resolveWriteTransactionMode(
     : "none";
 }
 
+/**
+ * Re-exported beside {@link constraintFenceRefusal} — the two live together
+ * conceptually even though {@link resolveBatchWriteVerdict}'s implementation
+ * sits in a leaf module (`backend/capabilities/batch-write-verdict.ts`) so
+ * that `recorded-capture/guards.ts`, which this module itself imports
+ * through the `recorded-capture` barrel, can import it without a cycle.
+ * `BatchWriteRefusalReason` / `BatchWriteVerdict` are not re-exported here:
+ * every current caller consumes them structurally through
+ * `resolveBatchWriteVerdict`'s return type, with no call site importing
+ * either type by name.
+ */
+export {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
+} from "../../backend/capabilities/batch-write-verdict";
+
 /** What a caller must change to make each refused constraint class writable. */
 const CONSTRAINT_FENCE_ADVICE = {
   edgeCardinality:
@@ -517,15 +548,21 @@ export function constraintFenceRefusal(
     return undefined;
   }
 
+  const verdict = resolveBatchWriteVerdict(backend, {
+    needs: "constraint-needs-probe",
+  });
+
   return new ConfigurationError(
     "This backend cannot fence a constrained write: enforcing a declared " +
       "constraint requires a transaction — to scope the per-graph write lock " +
       "to, and to commit a reservation row together with the row it gates — " +
-      "and this backend has no transactions.",
+      "and this backend has no transactions." +
+      batchRefusalSuffix(verdict),
     {
       code: "CONSTRAINT_WRITE_FENCE_UNSUPPORTED",
       graphId: ctx.graphId,
       constraint: reason,
+      ...batchRefusalDetails(verdict),
     },
     {
       suggestion:

--- a/packages/typegraph/src/store/recorded-capture/guards.ts
+++ b/packages/typegraph/src/store/recorded-capture/guards.ts
@@ -1,4 +1,9 @@
 import {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
+} from "../../backend/capabilities/batch-write-verdict";
+import {
   recordedRevisionOriginsVerdict,
   statementExecutionVerdict,
 } from "../../backend/capabilities/resolve";
@@ -251,11 +256,25 @@ export function rawWriteGuards(
   };
 }
 
+/**
+ * Defense-in-depth on the non-interactive branch: `Store`'s constructor
+ * already routes `history: true` through `#revisionTrackingEnabled` and
+ * calls {@link assertRevisionTrackableBackend} — which refuses a batch-tier
+ * backend first — before it ever reaches {@link createRecordedBackend} (and
+ * so this gate). It stays here, re-checked with the same verdict, for any
+ * caller of `createRecordedBackend` that does not go through that
+ * constructor path.
+ */
 export function assertCapturableBackend(backend: GraphBackend): void {
   if (!backend.capabilities.execution.interactiveTransactions) {
+    const verdict = resolveBatchWriteVerdict(backend, { needs: "history" });
     throw new ConfigurationError(
-      "history: true requires a backend with transaction support.",
-      { dialect: backend.dialect },
+      "history: true requires a backend with transaction support." +
+        batchRefusalSuffix(verdict),
+      {
+        dialect: backend.dialect,
+        ...batchRefusalDetails(verdict),
+      },
       {
         suggestion:
           "Use a transactional SQLite/PostgreSQL backend or disable recorded-time capture for this store.",
@@ -301,9 +320,14 @@ export function assertCapturableBackend(backend: GraphBackend): void {
  */
 export function assertRevisionTrackableBackend(backend: GraphBackend): void {
   if (!backend.capabilities.execution.interactiveTransactions) {
+    const verdict = resolveBatchWriteVerdict(backend, { needs: "history" });
     throw new ConfigurationError(
-      "revisionTracking: true requires a backend with transaction support.",
-      { dialect: backend.dialect },
+      "revisionTracking: true requires a backend with transaction support." +
+        batchRefusalSuffix(verdict),
+      {
+        dialect: backend.dialect,
+        ...batchRefusalDetails(verdict),
+      },
       {
         suggestion:
           "Use a transactional SQLite/PostgreSQL backend or leave revision tracking disabled.",

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -297,6 +297,9 @@ import {
   prepareNodeReplacement,
 } from "./operations";
 import {
+  batchRefusalDetails,
+  batchRefusalSuffix,
+  resolveBatchWriteVerdict,
   type RetriedUnitAttempt,
   runInWriteTransaction,
   runRetriedUnit,
@@ -1110,13 +1113,18 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       (!backend.capabilities.execution.interactiveTransactions ||
         !statementExecution.supported)
     ) {
+      const identityVerdict = resolveBatchWriteVerdict(backend, {
+        needs: "identity",
+      });
       throw new ConfigurationError(
-        "Operational Identity requires an atomic transactional backend with statement execution support.",
+        "Operational Identity requires an atomic transactional backend with statement execution support." +
+          batchRefusalSuffix(identityVerdict),
         {
           code: "IDENTITY_REQUIRES_ATOMIC_BACKEND",
           interactiveTransactions:
             backend.capabilities.execution.interactiveTransactions,
           statementExecution: statementExecution.supported,
+          ...batchRefusalDetails(identityVerdict),
         },
         {
           suggestion:
@@ -3310,11 +3318,20 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     operation: "store.transaction()" | "store.transactionWithReceipt()",
   ): Promise<TransactionRunResult<T>> {
     if (!this.#backend.capabilities.execution.interactiveTransactions) {
+      const transactionVerdict = resolveBatchWriteVerdict(this.#backend, {
+        needs: "interactive-callback",
+      });
       throw new UnsupportedBackendCapabilityError(
         operation,
         "execution.interactiveTransactions",
-        { graphId: this.graphId, dialect: this.#backend.dialect },
-        "Use a backend with transaction support, or call ordinary Store write methods when non-atomic work is intentional.",
+        {
+          graphId: this.graphId,
+          dialect: this.#backend.dialect,
+          ...batchRefusalDetails(transactionVerdict),
+        },
+        "Use a backend with transaction support, or call ordinary Store " +
+          "write methods when non-atomic work is intentional.",
+        batchRefusalSuffix(transactionVerdict),
       );
     }
 

--- a/packages/typegraph/tests/backend-derivation.test.ts
+++ b/packages/typegraph/tests/backend-derivation.test.ts
@@ -159,6 +159,7 @@ describe("deriveBackend over frozen inputs", () => {
     expect(derived.capabilities.execution).toEqual({
       interactiveTransactions: true,
       atomicBatch: "none",
+      unitOfWork: "interactive",
     });
     expect(Reflect.ownKeys(derived)).toEqual(["capabilities", "run"]);
     expect(Object.getOwnPropertyDescriptor(derived, "run")).toMatchObject({

--- a/packages/typegraph/tests/batch-engine-harness.ts
+++ b/packages/typegraph/tests/batch-engine-harness.ts
@@ -176,6 +176,7 @@ function createD1HarnessClient(sqlite: Database.Database) {
 
 export type D1BatchHarnessOptions = Readonly<{
   tables?: SqliteTables;
+  /** Applies to the batch-shaped `backend` only — `interactiveBackend` exists solely for schema commits and version bumps. */
   capabilities?: SqliteBackendOptions["capabilities"];
 }>;
 
@@ -368,6 +369,7 @@ function createNeonHarnessClient(client: PGlite) {
 
 export type NeonHttpBatchHarnessOptions = Readonly<{
   tables?: PostgresTables;
+  /** Applies to the batch-shaped `backend` only — `interactiveBackend` exists solely for schema commits and version bumps. */
   capabilities?: PostgresBackendOptions["capabilities"];
 }>;
 

--- a/packages/typegraph/tests/batch-engine-harness.ts
+++ b/packages/typegraph/tests/batch-engine-harness.ts
@@ -28,13 +28,11 @@ import { drizzle as drizzleD1 } from "drizzle-orm/d1";
 import { drizzle as drizzleNeonHttp } from "drizzle-orm/neon-http";
 import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
 
-import { markBundledRootAutocommitEligible } from "../src/backend/capabilities/autocommit-single-statement";
+import { isBundledRootAutocommitEligible } from "../src/backend/capabilities/autocommit-single-statement";
 import {
   generateSqliteMigrationSQL,
   generateVectorlessPostgresMigrationSQL,
 } from "../src/backend/drizzle/ddl";
-import { type AnyPgDatabase } from "../src/backend/drizzle/execution/postgres-execution";
-import { type AnySqliteDatabase } from "../src/backend/drizzle/execution/sqlite-execution";
 import {
   createPostgresBackend,
   type PostgresBackendOptions,
@@ -210,15 +208,23 @@ export function createD1BatchEngineHarness(
   const d1Db = drizzleD1(
     d1Client as unknown as Parameters<typeof drizzleD1>[0],
   );
-  const backend = markBundledRootAutocommitEligible(
-    createSqliteBackend(d1Db as unknown as AnySqliteDatabase, {
-      tables,
-      fulltext: false,
-      ...(options.capabilities === undefined ?
-        {}
-      : { capabilities: options.capabilities }),
-    }),
-  );
+  const backend = createSqliteBackend(d1Db, {
+    tables,
+    fulltext: false,
+    ...(options.capabilities === undefined ?
+      {}
+    : { capabilities: options.capabilities }),
+  });
+  // `createSqliteBackend` already applies this mark itself (its profile
+  // declares `autocommit.singleStatementDurable: true`). Asserting it here,
+  // instead of marking it again, keeps this harness sensitive to a factory-
+  // mark regression rather than papering over one — the mark is exactly what
+  // the fused supplied-id create path under test depends on.
+  if (!isBundledRootAutocommitEligible(backend)) {
+    throw new Error(
+      "createSqliteBackend did not mark its root backend autocommit-eligible",
+    );
+  }
 
   return {
     backend,
@@ -394,16 +400,24 @@ export async function createNeonHttpBatchEngineHarness(
   const neonDb = drizzleNeonHttp({
     client: neonClient as unknown as NeonQueryFunction<false, false>,
   });
-  const backend = markBundledRootAutocommitEligible(
-    createPostgresBackend(neonDb as unknown as AnyPgDatabase, {
-      tables,
-      vector: false,
-      fulltext: false,
-      ...(options.capabilities === undefined ?
-        {}
-      : { capabilities: options.capabilities }),
-    }),
-  );
+  const backend = createPostgresBackend(neonDb, {
+    tables,
+    vector: false,
+    fulltext: false,
+    ...(options.capabilities === undefined ?
+      {}
+    : { capabilities: options.capabilities }),
+  });
+  // `createPostgresBackend` already applies this mark itself (its profile
+  // declares `autocommit.singleStatementDurable: true`). Asserting it here,
+  // instead of marking it again, keeps this harness sensitive to a factory-
+  // mark regression rather than papering over one — the mark is exactly what
+  // the fused supplied-id create path under test depends on.
+  if (!isBundledRootAutocommitEligible(backend)) {
+    throw new Error(
+      "createPostgresBackend did not mark its root backend autocommit-eligible",
+    );
+  }
 
   return {
     backend,

--- a/packages/typegraph/tests/batch-engine-harness.ts
+++ b/packages/typegraph/tests/batch-engine-harness.ts
@@ -1,0 +1,413 @@
+/**
+ * Real-engine harnesses for the two bundled "closed batch" transports: D1
+ * (`D1Database.batch`) and Neon HTTP (`NeonQueryFunction.transaction`).
+ *
+ * Every existing D1/Neon test fixture in this package is a hand-scripted
+ * mock: `batch()`/`transaction()` return canned rows chosen by matching
+ * substrings of the SQL text. That proves the SQL a program emits, never
+ * that the transport actually behaves the way the design relies on — in
+ * particular, that a failing statement rolls back every statement that ran
+ * earlier in the same batch. These harnesses back the driver-level surface
+ * each transport exposes with a REAL engine (better-sqlite3 for D1, PGlite
+ * for Neon HTTP), wrapped by the bundled factories exactly as a production
+ * D1 or Neon HTTP deployment would be, so the atomicity, error shapes, and
+ * row contents under test are the engine's own.
+ *
+ * Each harness also hands back a second, genuinely INTERACTIVE backend over
+ * the SAME physical database — real `drizzle-orm/better-sqlite3` /
+ * `drizzle-orm/pglite`, not the batch-shaped client — because schema commits
+ * and version bumps refuse on a backend with no interactive transactions.
+ * Tests that need to move the active schema version out from under the
+ * batch-shaped backend do it through this second handle.
+ */
+import { PGlite } from "@electric-sql/pglite";
+import type { NeonQueryFunction } from "@neondatabase/serverless";
+import Database from "better-sqlite3";
+import { drizzle as drizzleBetterSqlite3 } from "drizzle-orm/better-sqlite3";
+import { drizzle as drizzleD1 } from "drizzle-orm/d1";
+import { drizzle as drizzleNeonHttp } from "drizzle-orm/neon-http";
+import { drizzle as drizzlePglite } from "drizzle-orm/pglite";
+
+import { markBundledRootAutocommitEligible } from "../src/backend/capabilities/autocommit-single-statement";
+import {
+  generateSqliteMigrationSQL,
+  generateVectorlessPostgresMigrationSQL,
+} from "../src/backend/drizzle/ddl";
+import { type AnyPgDatabase } from "../src/backend/drizzle/execution/postgres-execution";
+import { type AnySqliteDatabase } from "../src/backend/drizzle/execution/sqlite-execution";
+import {
+  createPostgresBackend,
+  type PostgresBackendOptions,
+  type PostgresTables,
+  tables as defaultPostgresTables,
+} from "../src/backend/drizzle/postgres";
+import {
+  createSqliteBackend,
+  type SqliteBackendOptions,
+  type SqliteTables,
+  tables as defaultSqliteTables,
+} from "../src/backend/drizzle/sqlite";
+import { type GraphBackend } from "../src/backend/types";
+
+/** A backend under test, paired with an interactive handle over the same engine. */
+export type BatchEngineHarness = Readonly<{
+  /** The bundled backend over the batch-shaped driver: no interactive transactions. */
+  backend: GraphBackend;
+  /**
+   * A real interactive backend over the SAME physical database. Schema
+   * commits and version bumps run through this handle — `backend` above
+   * refuses them, exactly as a production D1/Neon HTTP deployment would.
+   */
+  interactiveBackend: GraphBackend;
+  close: () => Promise<void>;
+}>;
+
+// ============================================================
+// D1: prepare(sql).bind(...params) / batch(statements)
+// ============================================================
+
+/**
+ * The bound-statement shape Cloudflare's `D1PreparedStatement.bind(...)`
+ * returns: an object usable both as an independent statement (`.all()` /
+ * `.run()` / `.raw()`) and, unexecuted, as one member of a
+ * `D1Database.batch()` array. `raw()` is D1's column-array result mode —
+ * `drizzle-orm/d1`'s session uses it for a typed `.select()` query (as
+ * `adoptBaseSchemaStorage`'s base-schema-marker read does), never for
+ * TypeGraph's own raw-SQL `db.execute()` path.
+ */
+type D1HarnessBoundStatement = Readonly<{
+  sql: string;
+  params: readonly unknown[];
+  all: () => Promise<D1HarnessResult>;
+  run: () => Promise<D1HarnessResult>;
+  raw: () => Promise<readonly (readonly unknown[])[]>;
+}>;
+
+type D1HarnessResult = Readonly<{
+  results: readonly unknown[];
+  success: true;
+}>;
+
+/**
+ * Runs one statement against a real better-sqlite3 connection. Mirrors the
+ * reader/non-reader choice `sqlite-execution.ts`'s `executeCompiledRun` makes
+ * for the bundled synchronous backend: better-sqlite3 rejects `.all()` on a
+ * statement with no result columns and `.run()` on one that has them.
+ */
+function runD1HarnessStatement(
+  sqlite: Database.Database,
+  sqlText: string,
+  params: readonly unknown[],
+): readonly unknown[] {
+  const statement = sqlite.prepare(sqlText);
+  if (statement.reader) {
+    return statement.all(...params);
+  }
+  statement.run(...params);
+  return [];
+}
+
+function bindD1HarnessStatement(
+  sqlite: Database.Database,
+  sqlText: string,
+  params: readonly unknown[],
+): D1HarnessBoundStatement {
+  function execute(): Promise<D1HarnessResult> {
+    return Promise.resolve({
+      results: runD1HarnessStatement(sqlite, sqlText, params),
+      success: true,
+    });
+  }
+  function raw(): Promise<readonly (readonly unknown[])[]> {
+    const rows = sqlite
+      .prepare(sqlText)
+      .raw()
+      .all(...params) as readonly (readonly unknown[])[];
+    return Promise.resolve(rows);
+  }
+  return { sql: sqlText, params, all: execute, run: execute, raw };
+}
+
+/**
+ * Cloudflare's documented `D1Database.batch()` contract: every statement runs
+ * in order; if any statement fails, the whole batch is aborted and none of
+ * its writes are applied. Modeled here as one `BEGIN` / `COMMIT` /
+ * `ROLLBACK` around the real connection driving every other statement this
+ * harness runs, so a failing statement rolls back its own chunk AND every
+ * chunk that ran earlier in the SAME `batch()` call — not a canned
+ * per-statement result standing in for that guarantee.
+ */
+function runD1HarnessBatch(
+  sqlite: Database.Database,
+  statements: readonly D1HarnessBoundStatement[],
+): Promise<readonly D1HarnessResult[]> {
+  sqlite.exec("BEGIN");
+  try {
+    const results = statements.map((statement) => ({
+      results: runD1HarnessStatement(sqlite, statement.sql, statement.params),
+      success: true as const,
+    }));
+    sqlite.exec("COMMIT");
+    return Promise.resolve(results);
+  } catch (error) {
+    sqlite.exec("ROLLBACK");
+    throw error;
+  }
+}
+
+/**
+ * A fake `D1Database`, backed by a real better-sqlite3 connection instead of
+ * a canned response. `prepare` mirrors D1's two-step prepare-then-bind API;
+ * `batch` mirrors D1's documented all-or-nothing transport (see
+ * {@link runD1HarnessBatch}).
+ */
+function createD1HarnessClient(sqlite: Database.Database) {
+  return {
+    prepare(sqlText: string) {
+      return {
+        bind(...params: readonly unknown[]): D1HarnessBoundStatement {
+          return bindD1HarnessStatement(sqlite, sqlText, params);
+        },
+      };
+    },
+    batch(statements: readonly D1HarnessBoundStatement[]) {
+      return runD1HarnessBatch(sqlite, statements);
+    },
+  };
+}
+
+export type D1BatchHarnessOptions = Readonly<{
+  tables?: SqliteTables;
+  capabilities?: SqliteBackendOptions["capabilities"];
+}>;
+
+/**
+ * Builds a D1-shaped batch backend and a real interactive SQLite backend
+ * over the SAME in-memory better-sqlite3 connection.
+ *
+ * `createSqliteBackend` detects the harness client as D1 through
+ * `drizzle-orm/d1`'s OWN session — its class is genuinely named
+ * `SQLiteD1Session`, not a spoofed marker — so `hostedPlatform`,
+ * `transactionMode: "none"`, and `capabilities.execution.unitOfWork:
+ * "batch"` are the library's real detection running against a real driver
+ * shape, exactly as it would against Cloudflare's own D1Database.
+ */
+export function createD1BatchEngineHarness(
+  options: D1BatchHarnessOptions = {},
+): BatchEngineHarness {
+  const tables = options.tables ?? defaultSqliteTables;
+  const sqlite = new Database(":memory:");
+  sqlite.exec(generateSqliteMigrationSQL(tables, false));
+
+  const interactiveDb = drizzleBetterSqlite3(sqlite);
+  const interactiveBackend = createSqliteBackend(interactiveDb, {
+    tables,
+    fulltext: false,
+    executionProfile: { isSync: true },
+  });
+
+  const d1Client = createD1HarnessClient(sqlite);
+  const d1Db = drizzleD1(
+    d1Client as unknown as Parameters<typeof drizzleD1>[0],
+  );
+  const backend = markBundledRootAutocommitEligible(
+    createSqliteBackend(d1Db as unknown as AnySqliteDatabase, {
+      tables,
+      fulltext: false,
+      ...(options.capabilities === undefined ?
+        {}
+      : { capabilities: options.capabilities }),
+    }),
+  );
+
+  return {
+    backend,
+    interactiveBackend,
+    close: () => {
+      sqlite.close();
+      return Promise.resolve();
+    },
+  };
+}
+
+// ============================================================
+// Neon HTTP: query(sql, params) / transaction(queries)
+// ============================================================
+
+type NeonHarnessQuerySpec = Readonly<{
+  sqlText: string;
+  params: readonly unknown[];
+  /**
+   * Mirrors the real driver's `arrayMode` query option: `drizzle-orm/neon-http`
+   * passes it whenever it drives a typed `.select()` (fields are known and
+   * zipped against column-array rows) and leaves it off for TypeGraph's own
+   * raw-SQL `db.execute()` path, which reads named columns off object rows.
+   */
+  arrayMode: boolean;
+}>;
+
+type NeonHarnessRows = Readonly<{ rows: readonly unknown[] }>;
+
+/**
+ * The lazy handle `@neondatabase/serverless`'s tagged-template driver
+ * returns from `.query(sql, params)`: calling it does not execute yet.
+ * Awaiting it directly runs the statement autocommit (one round trip);
+ * passing an array of these to `.transaction()` instead runs every one of
+ * them, in order, inside ONE server-side transaction without ever resolving
+ * this promise on its own — Neon's documented all-or-nothing primitive.
+ * `then` is the only member either consumer needs: ordinary Drizzle reads
+ * `await` it directly, and `.transaction()` below reads `__harnessQuerySpec`
+ * without ever calling `.then()`, so a query passed to `.transaction()` runs
+ * exactly once.
+ */
+type NeonHarnessQuery = PromiseLike<NeonHarnessRows> &
+  Readonly<{ __harnessQuerySpec: NeonHarnessQuerySpec }>;
+
+/** The narrow slice of PGlite's `query`/transaction-`query` this harness drives. */
+type NeonHarnessSqlTarget = Readonly<{
+  query: (
+    sqlText: string,
+    params: unknown[],
+    options?: Readonly<{ rowMode?: "array" | "object" }>,
+  ) => Promise<NeonHarnessRows>;
+}>;
+
+async function runNeonHarnessStatement(
+  target: NeonHarnessSqlTarget,
+  spec: NeonHarnessQuerySpec,
+): Promise<NeonHarnessRows> {
+  const result = await target.query(spec.sqlText, [...spec.params], {
+    rowMode: spec.arrayMode ? "array" : "object",
+  });
+  return { rows: result.rows };
+}
+
+function makeNeonHarnessQuery(
+  client: PGlite,
+  sqlText: string,
+  params: readonly unknown[],
+  arrayMode: boolean,
+): NeonHarnessQuery {
+  const spec: NeonHarnessQuerySpec = { sqlText, params, arrayMode };
+  let autocommit: Promise<NeonHarnessRows> | undefined;
+  return {
+    __harnessQuerySpec: spec,
+    // Deliberately modeling @neondatabase/serverless's own lazy query
+    // handle: awaiting it directly runs the statement autocommit, and
+    // `runNeonHarnessTransaction` below never calls `.then()` on it, reading
+    // `__harnessQuerySpec` instead — so a query passed to `.transaction()`
+    // still runs exactly once.
+    // eslint-disable-next-line unicorn/no-thenable
+    then(onFulfilled, onRejected) {
+      autocommit ??= runNeonHarnessStatement(client, spec);
+      return autocommit.then(onFulfilled, onRejected);
+    },
+  };
+}
+
+/**
+ * Neon's documented `transaction(queries)`: every query runs, in order,
+ * inside one server-side transaction; if any fails, none of the writes are
+ * applied. Modeled here as PGlite's own `transaction(callback)` — a real
+ * `BEGIN`/`COMMIT`/`ROLLBACK` — driving the SAME statements the caller built
+ * via {@link makeNeonHarnessQuery}, rather than a canned per-query result.
+ */
+async function runNeonHarnessTransaction(
+  client: PGlite,
+  queries: readonly NeonHarnessQuery[],
+): Promise<readonly NeonHarnessRows[]> {
+  return client.transaction(async (tx) => {
+    const results: NeonHarnessRows[] = [];
+    for (const query of queries) {
+      results.push(await runNeonHarnessStatement(tx, query.__harnessQuerySpec));
+    }
+    return results;
+  });
+}
+
+/**
+ * A fake Neon HTTP client, backed by a real PGlite engine instead of a
+ * canned response. Callable + `.transaction()` + no `.begin()` is exactly
+ * what `isNeonHttpClient` (`postgres-execution.ts`) detects; the callable
+ * form itself is a fragment-builder in the real driver and TypeGraph never
+ * invokes it, so it is left unmodeled here.
+ */
+function createNeonHarnessClient(client: PGlite) {
+  function query(
+    sqlText: string,
+    params: readonly unknown[] = [],
+    options?: Readonly<{ arrayMode?: boolean }>,
+  ): NeonHarnessQuery {
+    return makeNeonHarnessQuery(
+      client,
+      sqlText,
+      params,
+      options?.arrayMode ?? false,
+    );
+  }
+  function transaction(
+    queries: readonly NeonHarnessQuery[],
+  ): Promise<readonly NeonHarnessRows[]> {
+    return runNeonHarnessTransaction(client, queries);
+  }
+  return Object.assign(
+    () => {
+      throw new Error(
+        "This harness models @neondatabase/serverless's query()/transaction() surface only; the tagged-template call form is unused by TypeGraph.",
+      );
+    },
+    { query, transaction },
+  );
+}
+
+export type NeonHttpBatchHarnessOptions = Readonly<{
+  tables?: PostgresTables;
+  capabilities?: PostgresBackendOptions["capabilities"];
+}>;
+
+/**
+ * Builds a Neon-HTTP-shaped batch backend and a real interactive PostgreSQL
+ * backend over the SAME in-process PGlite engine.
+ *
+ * `createPostgresBackend` detects the harness client via `isNeonHttpClient`
+ * (callable, `.transaction`, no `.begin`) exactly as it would a real
+ * `neon(url)` client, so `interactiveTransactions: false`,
+ * `capabilities.execution.atomicBatch: "root"`, and
+ * `capabilities.execution.unitOfWork: "batch"` are the library's real
+ * detection, not an asserted fixture value.
+ */
+export async function createNeonHttpBatchEngineHarness(
+  options: NeonHttpBatchHarnessOptions = {},
+): Promise<BatchEngineHarness> {
+  const tables = options.tables ?? defaultPostgresTables;
+  const client = await PGlite.create();
+  await client.exec(generateVectorlessPostgresMigrationSQL(tables, false));
+
+  const interactiveDb = drizzlePglite(client);
+  const interactiveBackend = createPostgresBackend(interactiveDb, {
+    tables,
+    vector: false,
+    fulltext: false,
+  });
+
+  const neonClient = createNeonHarnessClient(client);
+  const neonDb = drizzleNeonHttp({
+    client: neonClient as unknown as NeonQueryFunction<false, false>,
+  });
+  const backend = markBundledRootAutocommitEligible(
+    createPostgresBackend(neonDb as unknown as AnyPgDatabase, {
+      tables,
+      vector: false,
+      fulltext: false,
+      ...(options.capabilities === undefined ?
+        {}
+      : { capabilities: options.capabilities }),
+    }),
+  );
+
+  return {
+    backend,
+    interactiveBackend,
+    close: () => client.close(),
+  };
+}

--- a/packages/typegraph/tests/batch-engine-semantics.test.ts
+++ b/packages/typegraph/tests/batch-engine-semantics.test.ts
@@ -13,7 +13,13 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
-import { EndpointNotFoundError, StaleVersionError } from "../src";
+import {
+  ConfigurationError,
+  EndpointNotFoundError,
+  StaleVersionError,
+  UniquenessError,
+  ValidationError,
+} from "../src";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
 import { migrateSchema } from "../src/schema";
 import { createStoreWithSchema } from "../src/store";
@@ -22,6 +28,7 @@ import {
   createD1BatchEngineHarness,
   createNeonHttpBatchEngineHarness,
 } from "./batch-engine-harness";
+import { matchingObject } from "./test-utils";
 
 const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
 const Company = defineNode("Company", {
@@ -64,6 +71,39 @@ const evolvedGraph = defineGraph({
       cardinality: "many",
     },
   },
+});
+
+// A node with a claimed unique field, for the constrained-write-inside-the-
+// claim-envelope scenario: the claim/reservation row and the node row commit
+// or roll back together inside one atomic program.
+const ClaimedPerson = defineNode("ClaimedPerson", {
+  schema: z.object({ email: z.string() }),
+});
+const claimGraph = defineGraph({
+  id: "batch-engine-semantics-claim",
+  nodes: {
+    ClaimedPerson: {
+      type: ClaimedPerson,
+      unique: [
+        {
+          name: "claimed_person_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+  },
+  edges: {},
+});
+
+// A graph whose identity is on, purely to exercise the Store-construction
+// refusal a batch-tier backend hits before any row is read or written.
+const identityGraph = defineGraph({
+  id: "batch-engine-semantics-identity",
+  nodes: { Person: { type: Person } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "fold" },
 });
 
 type HarnessKind = "d1" | "neon-http";
@@ -176,6 +216,181 @@ describe.each([
         ]),
       ).rejects.toBeInstanceOf(StaleVersionError);
       await expect(store.edges.worksAt.count()).resolves.toBe(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("conflicts on the claim row for a constrained write inside the claim envelope, leaving no row", async () => {
+    const harness = await createHarness(kind);
+    try {
+      await createStoreWithSchema(claimGraph, harness.interactiveBackend);
+      const [store] = await createStoreWithSchema(claimGraph, harness.backend);
+      // A single `create()` on an own-kind unique constraint takes no lock
+      // fence (the uniques primary key is the whole fence) but also does not
+      // fuse (`uniqueConstraintCount` must be zero to fuse), so it still
+      // needs the portable schema fence a batch engine has no session to
+      // hold. `bulkCreate` runs through the claim envelope's atomic program
+      // instead, which is what this scenario is about.
+      await store.nodes.ClaimedPerson.bulkCreate([
+        { props: { email: "alice@example.com" } },
+      ]);
+
+      // The second item's claim conflicts with the row the earlier
+      // `bulkCreate` already committed, not with the first item of this same
+      // batch. The typed uniqueness error surfaces, and `count()` staying at
+      // 1 (not 2) proves the first item of THIS batch rolled back with it.
+      await expect(
+        store.nodes.ClaimedPerson.bulkInsert([
+          { props: { email: "bob@example.com" } },
+          { props: { email: "alice@example.com" } },
+        ]),
+      ).rejects.toBeInstanceOf(UniquenessError);
+      await expect(store.nodes.ClaimedPerson.count()).resolves.toBe(1);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("fuses a supplied-id singleton create, fences it, and reports a duplicate id", async () => {
+    const harness = await createHarness(kind);
+    try {
+      const store = await bootHarnessStore(harness);
+
+      const created = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "explicit-person-id" },
+      );
+      expect(created.id).toBe("explicit-person-id");
+      await expect(store.nodes.Person.count()).resolves.toBe(1);
+
+      // Same id again: the fused if-absent statement writes nothing, and the
+      // duplicate is reported through the ordinary typed error.
+      await expect(
+        store.nodes.Person.create(
+          { name: "Bob" },
+          { id: "explicit-person-id" },
+        ),
+      ).rejects.toBeInstanceOf(ValidationError);
+      await expect(store.nodes.Person.count()).resolves.toBe(1);
+
+      // A stale schema version: the fenced statement writes nothing and the
+      // store re-diagnoses it as StaleVersionError.
+      await migrateSchema(harness.interactiveBackend, evolvedGraph, 1);
+      await expect(
+        store.nodes.Person.create(
+          { name: "Cara" },
+          { id: "another-explicit-id" },
+        ),
+      ).rejects.toBeInstanceOf(StaleVersionError);
+      await expect(store.nodes.Person.count()).resolves.toBe(1);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("refuses to resurrect a supplied-id create over a tombstoned row", async () => {
+    const harness = await createHarness(kind);
+    try {
+      const store = await bootHarnessStore(harness);
+
+      const created = await store.nodes.Person.create(
+        { name: "Alice" },
+        { id: "resurrection-candidate" },
+      );
+      await store.nodes.Person.bulkDelete([created.id]);
+
+      // The fused if-absent INSERT finds the id occupied by a tombstone.
+      // Resurrecting it is a real UPDATE outside the fused statement's
+      // atomicity, so the batch engine — with no session to hold a fence
+      // across it — refuses instead of writing the row unfenced.
+      await expect(
+        store.nodes.Person.create(
+          { name: "Bob" },
+          { id: "resurrection-candidate" },
+        ),
+      ).rejects.toMatchObject({
+        details: matchingObject({ code: "SCHEMA_WRITE_FENCE_UNSUPPORTED" }),
+      });
+      await expect(store.nodes.Person.count()).resolves.toBe(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("reaches every batch-write refusal reason with a reported reason", async () => {
+    const harness = await createHarness(kind);
+    try {
+      const store = await bootHarnessStore(harness);
+
+      // interactive-callback: store.transaction() needs an open callback
+      // session a closed batch program cannot hold.
+      await expect(
+        store.transaction(() => Promise.resolve(undefined)),
+      ).rejects.toMatchObject({
+        details: matchingObject({
+          batchRefusal: {
+            code: "BATCH_WRITE_UNSUPPORTED",
+            reason: "interactive-callback",
+          },
+        }),
+      });
+
+      // constraint-needs-probe: a dynamic match-key convergence write needs a
+      // read that steers what it writes.
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+      await expect(
+        store.edges.worksAt.getOrCreateByEndpoints(alice, acme, {
+          role: "Engineer",
+        }),
+      ).rejects.toMatchObject({
+        details: matchingObject({
+          batchRefusal: {
+            code: "BATCH_WRITE_UNSUPPORTED",
+            reason: "constraint-needs-probe",
+          },
+        }),
+      });
+
+      // identity: Operational Identity's closure maintenance needs several
+      // round trips inside one held transaction.
+      await createStoreWithSchema(identityGraph, harness.interactiveBackend);
+      await expect(
+        createStoreWithSchema(identityGraph, harness.backend),
+      ).rejects.toMatchObject({
+        details: matchingObject({
+          batchRefusal: { code: "BATCH_WRITE_UNSUPPORTED", reason: "identity" },
+        }),
+      });
+
+      // history: recorded-time capture needs the per-graph write lock and
+      // clock held across a whole write cascade.
+      await expect(
+        createStoreWithSchema(graph, harness.backend, { history: true }),
+      ).rejects.toMatchObject({
+        details: matchingObject({
+          batchRefusal: { code: "BATCH_WRITE_UNSUPPORTED", reason: "history" },
+        }),
+      });
+
+      // schema-commit: committing a schema version needs one held
+      // transaction across its compare-and-swap read and its activating
+      // write.
+      const schemaCommitRejection = await migrateSchema(
+        harness.backend,
+        evolvedGraph,
+        1,
+      ).catch((error: unknown) => error);
+      expect(schemaCommitRejection).toBeInstanceOf(ConfigurationError);
+      expect(schemaCommitRejection).toMatchObject({
+        details: matchingObject({
+          batchRefusal: {
+            code: "BATCH_WRITE_UNSUPPORTED",
+            reason: "schema-commit",
+          },
+        }),
+      });
     } finally {
       await harness.close();
     }

--- a/packages/typegraph/tests/batch-engine-semantics.test.ts
+++ b/packages/typegraph/tests/batch-engine-semantics.test.ts
@@ -20,6 +20,8 @@ import {
   UniquenessError,
   ValidationError,
 } from "../src";
+import { resolveBatchWriteVerdict } from "../src/backend/capabilities/batch-write-verdict";
+import { deriveBackend, projectBackend } from "../src/backend/derive-backend";
 import { defineEdge, defineGraph, defineNode } from "../src/core";
 import { migrateSchema } from "../src/schema";
 import { createStoreWithSchema } from "../src/store";
@@ -157,6 +159,29 @@ describe.each([
           .interactiveTransactions,
       ).toBe(true);
       expect(harness.interactiveBackend.capabilities.execution.unitOfWork).toBe(
+        "interactive",
+      );
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("re-derives unitOfWork when derivation strips the atomic batch, so no derived object is a batch-tier backend without a batch", async () => {
+    const harness = await createHarness(kind);
+    try {
+      const derived = deriveBackend(harness.backend, {});
+      expect(derived.capabilities.execution.atomicBatch).toBe("none");
+      expect(derived.capabilities.execution.unitOfWork).toBe("none");
+      expect(
+        resolveBatchWriteVerdict(derived, { needs: "interactive-callback" }),
+      ).toEqual({ kind: "program" });
+
+      const projected = projectBackend(harness.backend, ["capabilities"]);
+      expect(projected.capabilities.execution.atomicBatch).toBe("none");
+      expect(projected.capabilities.execution.unitOfWork).toBe("none");
+
+      const derivedInteractive = deriveBackend(harness.interactiveBackend, {});
+      expect(derivedInteractive.capabilities.execution.unitOfWork).toBe(
         "interactive",
       );
     } finally {

--- a/packages/typegraph/tests/batch-engine-semantics.test.ts
+++ b/packages/typegraph/tests/batch-engine-semantics.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Batch-tier atomicity and eligibility, pinned against real engines through
+ * the D1- and Neon-shaped harnesses in `batch-engine-harness.ts`.
+ *
+ * These are the tests the harness exists for: every prior D1/Neon fixture in
+ * this package fabricates its `batch()`/`transaction()` rows by matching
+ * substrings of the emitted SQL, so no test has ever exercised what a
+ * failing statement inside a real closed batch actually does to the
+ * statements that ran before it. Here the transport is real (better-sqlite3
+ * for D1, PGlite for Neon HTTP), so a rollback is the engine's own, not an
+ * asserted fixture value.
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { EndpointNotFoundError, StaleVersionError } from "../src";
+import { defineEdge, defineGraph, defineNode } from "../src/core";
+import { migrateSchema } from "../src/schema";
+import { createStoreWithSchema } from "../src/store";
+import {
+  type BatchEngineHarness,
+  createD1BatchEngineHarness,
+  createNeonHttpBatchEngineHarness,
+} from "./batch-engine-harness";
+
+const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
+const Company = defineNode("Company", {
+  schema: z.object({ name: z.string() }),
+});
+const worksAt = defineEdge("worksAt", {
+  schema: z.object({ role: z.string() }),
+});
+const graph = defineGraph({
+  id: "batch-engine-semantics",
+  nodes: { Person: { type: Person }, Company: { type: Company } },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "many",
+    },
+  },
+});
+
+// A backward-compatible evolution of `graph` (same id, additive optional
+// field) — enough for `migrateSchema` to commit a new active version without
+// touching anything this suite writes.
+const evolvedGraph = defineGraph({
+  id: graph.id,
+  nodes: {
+    Person: {
+      type: defineNode("Person", {
+        schema: z.object({ name: z.string(), nickname: z.string().optional() }),
+      }),
+    },
+    Company: { type: Company },
+  },
+  edges: {
+    worksAt: {
+      type: worksAt,
+      from: [Person],
+      to: [Company],
+      cardinality: "many",
+    },
+  },
+});
+
+type HarnessKind = "d1" | "neon-http";
+
+// Small enough that two edges fill the first chunk and a third starts a
+// second one, on both dialects: `floor((30 - schemaFenceParams) / edgeInsertParams)`
+// is 2 for both the SQLite and PostgreSQL fenced-edge-insert builders.
+const CHUNKING_MAX_BIND_PARAMETERS = 30;
+
+async function createHarness(
+  kind: HarnessKind,
+  maxBindParameters?: number,
+): Promise<BatchEngineHarness> {
+  const capabilities =
+    maxBindParameters === undefined ? undefined : { maxBindParameters };
+  if (kind === "d1") {
+    return createD1BatchEngineHarness(
+      capabilities === undefined ? {} : { capabilities },
+    );
+  }
+  return createNeonHttpBatchEngineHarness(
+    capabilities === undefined ? {} : { capabilities },
+  );
+}
+
+/**
+ * Commits the schema through the harness's interactive handle (schema
+ * commits refuse on the batch-shaped backend, by design), then boots a Store
+ * on the batch-shaped backend — a pure read-only reconciliation, since the
+ * hash already matches what the interactive handle just committed.
+ */
+async function bootHarnessStore(harness: BatchEngineHarness) {
+  await createStoreWithSchema(graph, harness.interactiveBackend);
+  const [store] = await createStoreWithSchema(graph, harness.backend);
+  return store;
+}
+
+describe.each([
+  { label: "D1", kind: "d1" as const },
+  { label: "Neon HTTP", kind: "neon-http" as const },
+])("batch engine semantics ($label)", ({ kind }) => {
+  it("declares unitOfWork batch on the harness backend and interactive on its bundled peer", async () => {
+    const harness = await createHarness(kind);
+    try {
+      expect(
+        harness.backend.capabilities.execution.interactiveTransactions,
+      ).toBe(false);
+      expect(harness.backend.capabilities.execution.unitOfWork).toBe("batch");
+      expect(
+        harness.interactiveBackend.capabilities.execution
+          .interactiveTransactions,
+      ).toBe(true);
+      expect(harness.interactiveBackend.capabilities.execution.unitOfWork).toBe(
+        "interactive",
+      );
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("leaves no row from an earlier chunk when a later chunk's endpoint is missing", async () => {
+    const harness = await createHarness(kind, CHUNKING_MAX_BIND_PARAMETERS);
+    try {
+      const store = await bootHarnessStore(harness);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const bob = await store.nodes.Person.create({ name: "Bob" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+
+      // Two valid edges fill the first chunk; the third — a missing
+      // endpoint — starts a second chunk on its own (CHUNKING_MAX_BIND_PARAMETERS
+      // makes the chunk size exactly 2 on both dialects). The native SQL
+      // turns a missing endpoint into a NOT NULL violation on the edge's
+      // primary key, so this statement errors instead of silently returning
+      // zero rows — the property the whole batch's atomicity depends on.
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from: alice, to: acme, props: { role: "Engineer" } },
+          { from: bob, to: acme, props: { role: "Designer" } },
+          {
+            from: alice,
+            to: { kind: "Company", id: "missing-company" },
+            props: { role: "Ghost" },
+          },
+        ]),
+      ).rejects.toBeInstanceOf(EndpointNotFoundError);
+
+      // The whole batch() / transaction() call rolled back: the first
+      // chunk's two otherwise-valid edges are gone too.
+      await expect(store.edges.worksAt.count()).resolves.toBe(0);
+    } finally {
+      await harness.close();
+    }
+  });
+
+  it("writes nothing and raises StaleVersionError after its re-diagnosis read", async () => {
+    const harness = await createHarness(kind);
+    try {
+      const store = await bootHarnessStore(harness);
+      const alice = await store.nodes.Person.create({ name: "Alice" });
+      const acme = await store.nodes.Company.create({ name: "Acme" });
+
+      // Bumps the active schema version through the interactive handle —
+      // "another handle" committing concurrently. `store` above still
+      // carries the schema version it read at boot, which is now stale.
+      await migrateSchema(harness.interactiveBackend, evolvedGraph, 1);
+
+      await expect(
+        store.edges.worksAt.bulkInsert([
+          { from: alice, to: acme, props: { role: "Engineer" } },
+        ]),
+      ).rejects.toBeInstanceOf(StaleVersionError);
+      await expect(store.edges.worksAt.count()).resolves.toBe(0);
+    } finally {
+      await harness.close();
+    }
+  });
+});

--- a/packages/typegraph/tests/bundle-member-access.test.ts
+++ b/packages/typegraph/tests/bundle-member-access.test.ts
@@ -43,9 +43,9 @@ const ANNOTATED_RESIDUE_KEYS = [
   "backend/migrate-recorded-time.ts:167#executeStatement",
   "identity/sql-target.ts:101#executeStatement",
   "identity/sql-target.ts:155#executeStatement",
-  "store/recorded-capture/guards.ts:71#executeStatement",
-  "store/recorded-capture/guards.ts:88#executeStatement",
-  "store/recorded-capture/guards.ts:233#executeStatement",
+  "store/recorded-capture/guards.ts:76#executeStatement",
+  "store/recorded-capture/guards.ts:93#executeStatement",
+  "store/recorded-capture/guards.ts:238#executeStatement",
 ] as const;
 
 function rowKey(

--- a/packages/typegraph/tests/pglite-project-inventory.test.ts
+++ b/packages/typegraph/tests/pglite-project-inventory.test.ts
@@ -10,6 +10,7 @@ const PGLITE_BOOT_MARKERS = [
   /\bcreateLoggedPostgresBackend\(/u,
   /\bcreateRecordedPostgresStore\(/u,
   /\bcreateTransactionFaultInjector\(/u,
+  /\bcreateNeonHttpBatchEngineHarness\(/u,
 ] as const;
 
 function discoverRootPgliteSuites(): readonly string[] {

--- a/packages/typegraph/vitest.pglite-project.ts
+++ b/packages/typegraph/vitest.pglite-project.ts
@@ -12,6 +12,7 @@ export const PGLITE_TEST_FILES = [
   "tests/atomic-resolved-update-batch-pglite.test.ts",
   "tests/atomic-transport-conformance.test.ts",
   "tests/base-schema-adoption.test.ts",
+  "tests/batch-engine-semantics.test.ts",
   "tests/caller-serialized-queue.test.ts",
   "tests/capability-bundle-dialect-honesty.test.ts",
   "tests/capability-declaration-validation.test.ts",


### PR DESCRIPTION
Makes the batch tier's contract explicit and tests it against real engines. The premise this branch started from was that a "guarded batch" whose first statement asserts the schema version would be new work; the code already does that in substance, since every fused single-statement write and every certified atomic program folds the active-schema-version assertion into the statement that writes, on both dialects, and a stale version writes nothing. What was missing is delivered here: `unitOfWork` had no consumer, one write kind fell through to a refusal while its bulk twin succeeded, batch atomicity had never been tested against an engine, and the docs disagreed with the code.

## Real-engine batch harnesses

`tests/batch-engine-harness.ts` builds a fake D1 client (`prepare(sql).bind(...)`, `batch(statements)`) over a real better-sqlite3 database inside one `BEGIN`/`COMMIT`, rolling the whole batch back when any statement throws, whose session the bundled detection classifies as D1; and a fake Neon HTTP callable (`query`, `transaction(queries)`) over a real PGlite connection with the same semantics. Both are wrapped by the real Drizzle drivers and the real bundled factories, with an interactive peer over the same physical engine for schema commits. `tests/batch-engine-semantics.test.ts` proves on both: a bulk insert whose second chunk carries a missing endpoint leaves no row from the first chunk (the NULL primary-key sentinel), a stale schema version writes nothing and surfaces `StaleVersionError` after the re-diagnosis read, a constrained write inside the claim envelope conflicts on its claim row and leaves no row, and `unitOfWork` reads `batch` on both. The existing D1 and Neon mocks were audited: they test dispatch, chunking, and defensive classification of adversarial responses, none of which a correct engine can produce, so they stay.

## One verdict for schema-managed writes on batch engines

`resolveBatchWriteVerdict` (`src/backend/capabilities/batch-write-verdict.ts`) is the one classifier: given a write's proven need (interactive callback, probe-then-write constraint, Operational Identity, history, schema commit) it returns `BATCH_WRITE_UNSUPPORTED` with the reason and one explanation. Every enforcing gate that used to phrase its own batch limitation (the constrained-write fence, `store.transaction`, the identity checks, recorded capture's guards, each dialect's schema-commit refusal) now takes its wording from the verdict and nests `{ code, reason }` under `details.batchRefusal`. The portable schema-version fence keeps its plain `SCHEMA_WRITE_FENCE_UNSUPPORTED` for what is not one of those five needs, rather than guessing a reason. `unitOfWork` is read by the verdict and the fused-insert eligibility test; absent means not-batch and fails closed.

## Supplied-id creates fuse

A singleton `create` with a caller-supplied id fuses its schema fence on a batch engine as a generated id already did, when the kind carries no declared unique constraint: the id-generation gate existed for an interactive root's autocommit durability, not for a batch that commits as a unit. `isAutocommitSingleStatementWrite` is deliberately not relaxed; the fused supplied-id path proves `insertNodeIfAbsentWithSchemaFence` through the hooked write plan. Review found that the tombstone-resurrection path a supplied id can fall through to ran unfenced on a batch root; it is now fenced immediately before it runs, matching the edge path, with a mutation-proven test.

## Docs

`limitations.md` names the guard every fused kind shares and carries the refusal-reason table; the Neon HTTP and D1 sections state the fused reality (including singleton node update, upsert-by-id and delete, and edge update and delete, which already fuse through one-entry certified programs; delete even on a kind with a declared unique, because the program releases the claim in the same statement), corrected in every place the old absolute "first write fails closed" claim appeared; `errors.md` gains `BATCH_WRITE_UNSUPPORTED`. Bundled interactive behavior and emitted SQL are unchanged; the parity snapshots do not move.
