### PR TITLE
chore(build): raise the declaration-bundling heap ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 # Declaration bundling traverses the full public backend and store type graph.
 # Keep its worker above Node's default old-space ceiling as that API grows.
 env:
-  NODE_OPTIONS: --max-old-space-size=6144
+  NODE_OPTIONS: --max-old-space-size=8192
 
 jobs:
   detect-release-metadata-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 # Declaration bundling traverses the full public backend and store type graph.
 # Keep its worker above Node's default old-space ceiling as that API grows.
 env:
-  NODE_OPTIONS: --max-old-space-size=6144
+  NODE_OPTIONS: --max-old-space-size=8192
 
 jobs:
   release:

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -111,8 +111,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "dev": "tsup --watch",
-    "build": "tsup",
+    "dev": "node --max-old-space-size=8192 node_modules/tsup/dist/cli-default.js --watch",
+    "build": "node --max-old-space-size=8192 node_modules/tsup/dist/cli-default.js",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "test:types": "node --import tsx scripts/test-types.ts all",


### PR DESCRIPTION
The tsup declaration bundle now needs more than the 6 GB old-space ceiling the CI workflows set, so every job that builds the package on the integration branch died in the DTS worker with `ERR_WORKER_OUT_OF_MEMORY` (main still fits under the old ceiling, so this only showed on the integration branch).

The `build` and `dev` scripts now pass the ceiling to Node themselves, so a local `pnpm build` no longer depends on an ambient `NODE_OPTIONS`, and the workflow-wide ceiling moves to 8 GB to match. Declaration bundle growth across the program is about 5% (the largest chunk went from 392 KB to 412 KB); the old ceiling was already close to the edge on main.