### PR TITLE
test(ci): pin the raised declaration-bundling heap ceiling in the workflow contract

### DIFF
--- a/packages/typegraph/tests/ci-workflow-contract.test.ts
+++ b/packages/typegraph/tests/ci-workflow-contract.test.ts
@@ -115,9 +115,22 @@ describe("CI workflow contract", () => {
   });
 
   it("gives CI and release declaration builds enough worker heap", () => {
+    // The build script carries the declaration-bundling ceiling itself, so a
+    // local `pnpm build` never depends on an ambient NODE_OPTIONS; the
+    // workflow-wide ceiling covers the remaining steps and must not fall
+    // below the script's own.
+    const buildScript = (
+      JSON.parse(
+        readFileSync(
+          fileURLToPath(new URL("../package.json", import.meta.url)),
+          "utf8",
+        ),
+      ) as Readonly<{ scripts: Readonly<Record<string, string>> }>
+    ).scripts["build"];
+    expect(buildScript).toContain("--max-old-space-size=8192");
     for (const workflowPath of [WORKFLOW_PATH, RELEASE_WORKFLOW_PATH]) {
       expect(readFileSync(workflowPath, "utf8")).toContain(
-        "NODE_OPTIONS: --max-old-space-size=6144",
+        "NODE_OPTIONS: --max-old-space-size=8192",
       );
     }
   });


### PR DESCRIPTION
#643 raised the workflow-wide Node heap ceiling to 8 GB and moved the declaration-bundling ceiling into the build script, but the CI workflow contract test still pinned the old 6 GB value, so `tests/ci-workflow-contract.test.ts` has been red on the integration branch since. The test now asserts the build script carries its own ceiling and that both workflows' ambient ceiling matches it.