### PR TITLE
chore(build): raise the declaration-bundling heap ceiling to 12 GB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 # Declaration bundling traverses the full public backend and store type graph.
 # Keep its worker above Node's default old-space ceiling as that API grows.
 env:
-  NODE_OPTIONS: --max-old-space-size=8192
+  NODE_OPTIONS: --max-old-space-size=12288
 
 jobs:
   detect-release-metadata-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 # Declaration bundling traverses the full public backend and store type graph.
 # Keep its worker above Node's default old-space ceiling as that API grows.
 env:
-  NODE_OPTIONS: --max-old-space-size=8192
+  NODE_OPTIONS: --max-old-space-size=12288
 
 jobs:
   release:

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -111,8 +111,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "dev": "node --max-old-space-size=8192 node_modules/tsup/dist/cli-default.js --watch",
-    "build": "node --max-old-space-size=8192 node_modules/tsup/dist/cli-default.js",
+    "dev": "node --max-old-space-size=12288 node_modules/tsup/dist/cli-default.js --watch",
+    "build": "node --max-old-space-size=12288 node_modules/tsup/dist/cli-default.js",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "test:types": "node --import tsx scripts/test-types.ts all",

--- a/packages/typegraph/tests/ci-workflow-contract.test.ts
+++ b/packages/typegraph/tests/ci-workflow-contract.test.ts
@@ -127,10 +127,10 @@ describe("CI workflow contract", () => {
         ),
       ) as Readonly<{ scripts: Readonly<Record<string, string>> }>
     ).scripts["build"];
-    expect(buildScript).toContain("--max-old-space-size=8192");
+    expect(buildScript).toContain("--max-old-space-size=12288");
     for (const workflowPath of [WORKFLOW_PATH, RELEASE_WORKFLOW_PATH]) {
       expect(readFileSync(workflowPath, "utf8")).toContain(
-        "NODE_OPTIONS: --max-old-space-size=8192",
+        "NODE_OPTIONS: --max-old-space-size=12288",
       );
     }
   });


### PR DESCRIPTION
The merged declaration bundle now peaks at about 9.3 GB of resident memory in the tsup DTS worker (measured with `/usr/bin/time -l` on the branch that combines the acyclicity, composition, identity and removal work), so the 8 GB ceiling from #643 fails with `ERR_WORKER_OUT_OF_MEMORY` once those land together. 12 GB leaves headroom on the 16 GB public runners. The growth itself is a separate investigation (a declaration bundle should not need this much); this only keeps the build running.