### PR TITLE
feat(graph-merge): identity-aware three-way reconciliation, identity-driven pairing with the separation veto, and merge decision provenance

### DIFF
--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -760,6 +760,12 @@ export function captureCandidateWriteSetTarget<G extends GraphDef>(target: Store
 type Cardinality = "many" | "one" | "unique" | "oneActive";
 
 // @public
+type CascadeCauseNode = Readonly<{
+    kind: string;
+    id: string;
+}>;
+
+// @public
 type CatalogBackend = Pick<GraphBackend, "catalog">;
 
 // @public
@@ -3004,6 +3010,34 @@ type IdentityAssertion<G extends GraphDef> = Readonly<{
     validTo?: string;
 }>;
 
+// @public
+export type IdentityAssertionConflict = Readonly<{
+    reason: IdentityAssertionConflictReason;
+    semanticKey: string;
+    a: EntityRef;
+    b: EntityRef;
+    relation: IdentityRelation;
+    base: readonly IdentityTransferAssertion[];
+    asserted: readonly StagedIdentityAssertion[];
+    retracted: readonly StagedRetraction[];
+}>;
+
+// @public
+export type IdentityAssertionConflictPolicy = "refuse" | "assertWins" | "retractWins" | "flag" | ((conflict: IdentityAssertionConflict) => IdentityAssertionDecision);
+
+// @public
+export type IdentityAssertionConflictReason = "retract-reassert" | "opposing-relations" | "id-reuse" | "cross-kind-pairing";
+
+// @public
+export type IdentityAssertionDecision = Readonly<{
+    kind: "assert";
+    assertionId: string;
+}> | Readonly<{
+    kind: "retract";
+}> | Readonly<{
+    kind: "unresolved";
+}>;
+
 // @public (undocumented)
 type IdentityAssertionId = string & Readonly<{
     [__identityAssertionId]: true;
@@ -3026,6 +3060,16 @@ type IdentityChange = Readonly<{
 }>;
 
 // @public
+export type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     assertSame: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
     assertDifferent: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
@@ -3038,10 +3082,15 @@ type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
 }>;
 
 // @public
+export type IdentityMergeConflictCode = typeof MERGE_ERROR_CODES.identityConflict | typeof MERGE_ERROR_CODES.identitySeparationConflict | typeof MERGE_ERROR_CODES.identityUniquenessConflict | typeof MERGE_ERROR_CODES.identityProvenanceConflict;
+
+// @public
 export class IdentityMergeConflictError extends MergeError {
-    constructor(message: string, options?: MergeErrorOptions);
+    constructor(message: string, options?: MergeErrorOptions & Readonly<{
+        code?: IdentityMergeConflictCode;
+    }>);
     // (undocumented)
-    readonly code: "GRAPH_MERGE_IDENTITY_CONFLICT";
+    readonly code: IdentityMergeConflictCode;
 }
 
 // @public
@@ -3062,6 +3111,12 @@ type IdentityPair<G extends GraphDef> = Readonly<{
 }> & IdentityValidityWindow;
 
 // @public
+export type IdentityPairingScope = Readonly<{
+    pairing: "candidate" | "definitional";
+    assertions: readonly IdentityTransferAssertion[];
+}>;
+
+// @public
 type IdentityReadFacade<G extends GraphDef> = Readonly<{
     representativeOf: (ref: IdentityNodeRefInput<G>) => Promise<IdentityNodeReference<G> | undefined>;
     membersOf: (ref: IdentityNodeRefInput<G>) => Promise<readonly IdentityNodeReference<G>[]>;
@@ -3072,7 +3127,29 @@ type IdentityReadFacade<G extends GraphDef> = Readonly<{
 }>;
 
 // @public
-type IdentityRelation = "same" | "different";
+export type IdentityReconciliation = Readonly<{
+    semanticKey: string;
+    a: EntityRef;
+    b: EntityRef;
+    relation: IdentityRelation;
+    survivorAssertionId: string;
+    supersededAssertionIds: readonly string[];
+    rule: "earliest-valid-from" | "code-point-id" | "committed-id" | "policy";
+    policy?: string | undefined;
+    branches: readonly BranchId[];
+}>;
+
+// @public
+export type IdentityReconciliationOptions = Readonly<{
+    pairing?: "off" | "candidate" | "definitional";
+    onAssertionConflict?: IdentityAssertionConflictPolicy;
+    onEdgeConflict?: "repoint" | "flag";
+    onUniquenessConflict?: "refuse" | "flag";
+    onProvenanceConflict?: "keepBoth" | "refuse";
+}>;
+
+// @public
+export type IdentityRelation = "same" | "different";
 
 // @public (undocumented)
 type IdentityServiceContext<G extends GraphDef> = Readonly<{
@@ -3099,11 +3176,49 @@ type IdentityTableNames = Readonly<{
     identityTransitionRetention: string;
 }>;
 
+// @public (undocumented)
+export type IdentityTransferAssertion = Readonly<{
+    id: string;
+    relation: "same" | "different";
+    a: PlainNodeRef;
+    b: PlainNodeRef;
+    validFrom: string;
+    validTo?: string | undefined;
+    endedBy?: PlainNodeRef | undefined;
+}>;
+
 // @public
 type IdentityTraversalOption<G extends GraphDef> = G["identity"] extends GraphIdentityConfig ? Readonly<{
     includeIdentityMembers?: boolean;
 }> : Readonly<{
     includeIdentityMembers?: never;
+}>;
+
+// @public
+export type IdentityUnresolvedConflict = Readonly<{
+    kind: "assertion";
+    reason: IdentityAssertionConflictReason;
+    semanticKey: string;
+    a: EntityRef;
+    b: EntityRef;
+    relation: IdentityRelation;
+    assertionIds: readonly string[];
+    branches: readonly BranchId[];
+}> | Readonly<{
+    kind: "separation";
+    a: EntityRef;
+    b: EntityRef;
+    assertionIds: readonly string[];
+    source?: MatchSource | undefined;
+}> | Readonly<{
+    kind: "uniqueness";
+    constraintName: string;
+    members: readonly EntityRef[];
+    assertionIds: readonly string[];
+}> | Readonly<{
+    kind: "provenance";
+    canonical: EntityRef;
+    contributions: readonly ProvenanceRecord[];
 }>;
 
 // @public
@@ -3718,6 +3833,16 @@ export type MatchSource = Readonly<{
     kind: "custom";
     sourceId: string;
     metadata?: JsonValue | undefined;
+}>
+/**
+* An explicit `same` identity assertion recalled the pair. `assertionIds`
+* names every assertion that attributes it, sorted, so the evidence points
+* back at the ledger rows a reviewer can read.
+*/
+| Readonly<{
+    kind: "identity";
+    sourceId: string;
+    assertionIds: readonly string[];
 }>;
 
 // @public
@@ -3812,6 +3937,9 @@ export const MERGE_ERROR_CODES: {
     readonly conflict: "GRAPH_MERGE_CONFLICT";
     readonly constraintConflict: "GRAPH_MERGE_CONSTRAINT_CONFLICT";
     readonly identityConflict: "GRAPH_MERGE_IDENTITY_CONFLICT";
+    readonly identitySeparationConflict: "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT";
+    readonly identityUniquenessConflict: "GRAPH_MERGE_IDENTITY_UNIQUENESS_CONFLICT";
+    readonly identityProvenanceConflict: "GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT";
     readonly acyclicityConflict: "GRAPH_MERGE_ACYCLICITY_CONFLICT";
     readonly baseVersionMismatch: "GRAPH_MERGE_BASE_VERSION_MISMATCH";
     readonly planCapability: "GRAPH_MERGE_PLAN_CAPABILITY";
@@ -3839,6 +3967,13 @@ export const MERGE_OPTION_DEFAULTS: {
     readonly onComparisonCeiling: "error";
     readonly provenance: true;
     readonly persistProvenance: false;
+    readonly identity: {
+        readonly pairing: "off";
+        readonly onAssertionConflict: "refuse";
+        readonly onEdgeConflict: "repoint";
+        readonly onUniquenessConflict: "refuse";
+        readonly onProvenanceConflict: "keepBoth";
+    };
 };
 
 // @public (undocumented)
@@ -3912,7 +4047,7 @@ export class MergeError extends TypeGraphError {
 }
 
 // @public
-type MergeErrorOptions = Readonly<{
+export type MergeErrorOptions = Readonly<{
     details?: Record<string, unknown>;
     suggestion?: string;
     cause?: unknown;
@@ -3952,6 +4087,7 @@ export type MergeOptions<G extends GraphDef = GraphDef> = Readonly<{
     clusterMaxDiameter?: number;
     branchOrder?: readonly BranchId[];
     provenanceWeights?: ReadonlyMap<BranchId, number>;
+    identity?: IdentityReconciliationOptions;
 }>;
 
 // @public (undocumented)
@@ -3981,6 +4117,8 @@ export type MergePlanApplied = Readonly<{
 export type MergePlanApplyOptions<G extends GraphDef> = Readonly<{
     beforeApply?: (reads: MergePlanReadContext<G>) => Promise<void>;
     afterApply?: (tx: TransactionContext<G>, applied: MergePlanApplied) => Promise<void>;
+    reviewDigest?: string;
+    sourceId?: string;
 }>;
 
 // @public
@@ -4158,6 +4296,10 @@ export type MergePlanMatchSource = Readonly<{
     kind: "custom";
     sourceId: string;
     metadata?: JsonValue | undefined;
+}> | Readonly<{
+    kind: "identity";
+    sourceId: string;
+    assertionIds: readonly string[];
 }>;
 
 // @public
@@ -4240,6 +4382,8 @@ export type MergePlanReview = Readonly<{
     warnings: readonly string[];
     compositionOrphans: readonly MergePlanCompositionOrphan[];
     diagnostics?: MergePlanDiagnostics | undefined;
+    identityReconciliations?: readonly JsonValue[] | undefined;
+    identityConflicts?: readonly JsonValue[] | undefined;
 }>;
 
 // @public (undocumented)
@@ -4326,6 +4470,8 @@ export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
         graphId: string;
         count: number;
     }>;
+    identityReconciliations: readonly IdentityReconciliation[];
+    identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;
 
 // @public
@@ -4750,6 +4896,7 @@ export type NormalizedMergeOptions<G extends GraphDef = GraphDef> = Readonly<{
     candidateDiagnostics?: CandidateDiagnosticsOptions;
     branchOrder?: readonly BranchId[];
     provenanceWeights?: ReadonlyMap<BranchId, number>;
+    identity?: IdentityReconciliationOptions;
 }>;
 
 // @public
@@ -5699,6 +5846,14 @@ export type Result<T, E = Error> = Readonly<{
 }>;
 
 // @public
+export type RetractionCause = Readonly<{
+    kind: "explicit";
+}> | Readonly<{
+    kind: "cascade";
+    deletedNode: CascadeCauseNode;
+}>;
+
+// @public
 export function revalidateCandidateWriteSetReview<G extends GraphDef>(args: RevalidateCandidateWriteSetReviewArgs<G>): Promise<Result<MergeReviewRevalidation, MergeError>>;
 
 // @public (undocumented)
@@ -6082,6 +6237,7 @@ export type SourceScope = Readonly<{
     blockIndex?: string;
     keyless?: KeylessConfig;
     store?: BaseLookupStore;
+    identity?: IdentityPairingScope;
 }>;
 
 // @public
@@ -6209,6 +6365,17 @@ type SqlTableNames = Readonly<{
 type SqlTextChunk = Readonly<{
     kind: "text";
     value: string;
+}>;
+
+// @public
+export type StagedIdentityAssertion = Readonly<{
+    branchId: BranchId;
+    assertion: IdentityTransferAssertion;
+}>;
+
+// @public
+export type StagedRetraction = StagedIdentityAssertion & Readonly<{
+    cause: RetractionCause;
 }>;
 
 // @public
@@ -6546,7 +6713,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -539,7 +539,7 @@ export type CandidateDiagnostic = Readonly<{
     reason?: "noComparableValues";
     clusterDisposition?: "retained" | Readonly<{
         kind: "excluded";
-        reason: "diameter" | "baseAmbiguity";
+        reason: "diameter" | "baseAmbiguity" | "separation";
     }>;
 }> | Readonly<{
     evidence: Extract<MatchEvidence, Readonly<{
@@ -548,7 +548,7 @@ export type CandidateDiagnostic = Readonly<{
     scoreDecision: "accepted";
     clusterDisposition: Readonly<{
         kind: "excluded";
-        reason: "diameter" | "baseAmbiguity";
+        reason: "diameter" | "baseAmbiguity" | "separation";
     }>;
 }>;
 
@@ -3208,10 +3208,6 @@ export type IdentityUnresolvedConflict = Readonly<{
     b: EntityRef;
     assertionIds: readonly string[];
     source?: MatchSource | undefined;
-}> | Readonly<{
-    kind: "provenance";
-    canonical: EntityRef;
-    contributions: readonly ProvenanceRecord[];
 }>;
 
 // @public
@@ -4144,7 +4140,7 @@ export type MergePlanCandidateDiagnostic = Readonly<{
     reason?: "noComparableValues" | undefined;
     clusterDisposition?: "retained" | Readonly<{
         kind: "excluded";
-        reason: "diameter" | "baseAmbiguity";
+        reason: "diameter" | "baseAmbiguity" | "separation";
     }> | undefined;
 }>;
 

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -3026,7 +3026,7 @@ export type IdentityAssertionConflict = Readonly<{
 export type IdentityAssertionConflictPolicy = "refuse" | "assertWins" | "retractWins" | "flag" | ((conflict: IdentityAssertionConflict) => IdentityAssertionDecision);
 
 // @public
-export type IdentityAssertionConflictReason = "retract-reassert" | "opposing-relations" | "id-reuse" | "cross-kind-pairing";
+export type IdentityAssertionConflictReason = "retract-reassert" | "opposing-relations" | "cross-kind-pairing" | "out-of-scope-pairing";
 
 // @public
 export type IdentityAssertionDecision = Readonly<{
@@ -3082,7 +3082,7 @@ type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
 }>;
 
 // @public
-export type IdentityMergeConflictCode = typeof MERGE_ERROR_CODES.identityConflict | typeof MERGE_ERROR_CODES.identitySeparationConflict | typeof MERGE_ERROR_CODES.identityUniquenessConflict | typeof MERGE_ERROR_CODES.identityProvenanceConflict;
+export type IdentityMergeConflictCode = typeof MERGE_ERROR_CODES.identityConflict | typeof MERGE_ERROR_CODES.identitySeparationConflict | typeof MERGE_ERROR_CODES.identityProvenanceConflict;
 
 // @public
 export class IdentityMergeConflictError extends MergeError {
@@ -3132,7 +3132,7 @@ export type IdentityReconciliation = Readonly<{
     a: EntityRef;
     b: EntityRef;
     relation: IdentityRelation;
-    survivorAssertionId: string;
+    survivorAssertionId?: string | undefined;
     supersededAssertionIds: readonly string[];
     rule: "earliest-valid-from" | "code-point-id" | "committed-id" | "policy";
     policy?: string | undefined;
@@ -3143,8 +3143,6 @@ export type IdentityReconciliation = Readonly<{
 export type IdentityReconciliationOptions = Readonly<{
     pairing?: "off" | "candidate" | "definitional";
     onAssertionConflict?: IdentityAssertionConflictPolicy;
-    onEdgeConflict?: "repoint" | "flag";
-    onUniquenessConflict?: "refuse" | "flag";
     onProvenanceConflict?: "keepBoth" | "refuse";
 }>;
 
@@ -3210,11 +3208,6 @@ export type IdentityUnresolvedConflict = Readonly<{
     b: EntityRef;
     assertionIds: readonly string[];
     source?: MatchSource | undefined;
-}> | Readonly<{
-    kind: "uniqueness";
-    constraintName: string;
-    members: readonly EntityRef[];
-    assertionIds: readonly string[];
 }> | Readonly<{
     kind: "provenance";
     canonical: EntityRef;
@@ -3938,7 +3931,6 @@ export const MERGE_ERROR_CODES: {
     readonly constraintConflict: "GRAPH_MERGE_CONSTRAINT_CONFLICT";
     readonly identityConflict: "GRAPH_MERGE_IDENTITY_CONFLICT";
     readonly identitySeparationConflict: "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT";
-    readonly identityUniquenessConflict: "GRAPH_MERGE_IDENTITY_UNIQUENESS_CONFLICT";
     readonly identityProvenanceConflict: "GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT";
     readonly acyclicityConflict: "GRAPH_MERGE_ACYCLICITY_CONFLICT";
     readonly baseVersionMismatch: "GRAPH_MERGE_BASE_VERSION_MISMATCH";
@@ -3970,8 +3962,6 @@ export const MERGE_OPTION_DEFAULTS: {
     readonly identity: {
         readonly pairing: "off";
         readonly onAssertionConflict: "refuse";
-        readonly onEdgeConflict: "repoint";
-        readonly onUniquenessConflict: "refuse";
         readonly onProvenanceConflict: "keepBoth";
     };
 };

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -2890,6 +2890,16 @@ type IdentityChange = Readonly<{
 }>;
 
 // @public
+type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     assertSame: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
     assertDifferent: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
@@ -5646,7 +5656,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -2653,6 +2653,16 @@ type IdentityChange = Readonly<{
 }>;
 
 // @public
+type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     assertSame: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
     assertDifferent: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
@@ -5252,7 +5262,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -2631,6 +2631,16 @@ type IdentityChange = Readonly<{
 }>;
 
 // @public
+type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     assertSame: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
     assertDifferent: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
@@ -5272,7 +5282,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -2637,6 +2637,16 @@ type IdentityChange = Readonly<{
 }>;
 
 // @public
+type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     assertSame: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
     assertDifferent: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
@@ -5266,7 +5276,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -2663,6 +2663,16 @@ type IdentityChange = Readonly<{
 }>;
 
 // @public
+type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     assertSame: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
     assertDifferent: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>, window?: IdentityValidityWindow) => Promise<IdentityAssertionResult<G>>;
@@ -5279,7 +5289,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3821,6 +3821,16 @@ export type IdentityContradictionErrorDetails = Readonly<{
 }>;
 
 // @public
+type IdentityDecisionProvenance = Readonly<{
+    policy?: string | undefined;
+    branchId?: string | undefined;
+    branchAncestry?: readonly string[] | undefined;
+    mergePlanDigest?: string | undefined;
+    reviewDigest?: string | undefined;
+    sourceId?: string | undefined;
+}>;
+
+// @public
 export class IdentityEndpointValidityError extends TypeGraphError {
     constructor(details: IdentityEndpointValidityErrorDetails);
     // (undocumented)
@@ -7344,7 +7354,7 @@ type StoreRuntime<G extends GraphDef> = Readonly<{
             kind: string;
             id: string;
         }> | undefined;
-    }>[]) => Promise<Readonly<{
+    }>[], decision?: IdentityDecisionProvenance) => Promise<Readonly<{
         created: number;
         retracted: number;
     }>>;

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3821,7 +3821,7 @@ export type IdentityContradictionErrorDetails = Readonly<{
 }>;
 
 // @public
-type IdentityDecisionProvenance = Readonly<{
+export type IdentityDecisionProvenance = Readonly<{
     policy?: string | undefined;
     branchId?: string | undefined;
     branchAncestry?: readonly string[] | undefined;

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -663,28 +663,28 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   // lists: EDGE_TEMPORAL_READ_NAMES, IDENTITY_READ_NAMES, and NODE_READ_NAMES.
   // These three implementation constants are referenced, not public exports.
   "./graph-merge": {
-    count: 749,
-    sha256: "c304435d0da14a9633d332d1e8ceef75fa192b6d7dfeb67a6d9e10b9f1c3f5a6",
+    count: 748,
+    sha256: "5254cd3a314fd6d88b20791cf2dbb8c4d82ff5b3b796503b67bdc41cd8233eb5",
   },
   "./indexes": {
     count: 46,
     sha256: "5a43d419097711d242c6208632e7e498374a5977eb10a7faba904b10e13f35cd",
   },
   "./interchange": {
-    count: 732,
-    sha256: "d02b7aca8c5e6617add2fd9f4490a2c4b586740cdfca7c12645205e9521647e3",
+    count: 733,
+    sha256: "ff4ae7c2e607565e6619e104900072d4c8e5cb08ce3a1088724c1a4be07b9c49",
   },
   "./postgres/pglite": {
-    count: 729,
-    sha256: "c0e2b712d191e1805a523599dc1e8c401df66db27b04908fc94a28098afae4b7",
+    count: 730,
+    sha256: "8910191f6fce05ca905e7a984c616bd7ce46dc9646a50f58785816618a36adcc",
   },
   "./profiler": {
-    count: 734,
-    sha256: "b37ca8d07e93fc38e1d6d086edc0c0f84df7d1b73612268ee9d5c37f898f92e5",
+    count: 735,
+    sha256: "c060979abe65e40be9f63ebb6a23c4a53abe4c976e60717eef3adb39d5aefe2f",
   },
   "./provenance": {
-    count: 740,
-    sha256: "bbdc084313ebd205f871f93737ffe0866045c412092ad72432d1cbd77f5b2acf",
+    count: 741,
+    sha256: "886d33930d90fc3827e69656f3b6a190f66ffc211b0404dbd54236e9b5811542",
   },
   // Identity transition log: `ensureSchema`'s inline `{ preloaded?: ... }`
   // options type was extracted into the named (but non-exported)
@@ -700,8 +700,8 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "92a8fa1ad38d8093a5b4fe1d53afdfefc7fe374cbc2e8e4b263e6b04bba58a30",
   },
   "./sqlite/local": {
-    count: 729,
-    sha256: "c0e2b712d191e1805a523599dc1e8c401df66db27b04908fc94a28098afae4b7",
+    count: 730,
+    sha256: "8910191f6fce05ca905e7a984c616bd7ce46dc9646a50f58785816618a36adcc",
   },
 };
 

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -591,6 +591,21 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
 // that only `ensureSchemaInternal` (imported directly by `store.ts`, never
 // re-exported) accepts, so it renders at no entrypoint at all — no ledger
 // entry to update for that change.
+// `IdentityDecisionProvenance` (+1 on `.`, `./graph-merge`, `./interchange`,
+// `./postgres/pglite`, `./profiler`, `./provenance` and `./sqlite/local`): the
+// graph-merge identity apply threads the governing merge decision through
+// `StoreRuntime.applyIdentityMergeAtTarget`, so the runtime port's declared
+// parameter type renders at every entrypoint that projects `StoreRuntime`.
+// Naming the type on the port is the point — a structurally-inlined copy of the
+// decision shape would be a second spelling of "what a governing decision is" —
+// and every one of these entries retires when the release slice exports
+// `IdentityDecisionProvenance` from the package barrel.
+//
+// `./graph-merge` nets DOWN despite that +1: the identity reconciliation
+// surface (`IdentityReconciliationOptions`, the conflict/decision types, the
+// staged-assertion shapes a policy callback receives, the pairing scope) is
+// exported deliberately from `src/graph-merge/index.ts` rather than left as
+// debt, which retires more forgotten exports than the port adds.
 const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
   // Roadmap F (meta-edge removal): removing the public `InferenceType`
   // union (never re-exported from most entrypoints, only pulled in

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -591,18 +591,20 @@ const EMPTY_FORGOTTEN_EXPORT_DEBT: ForgottenExportDebt = {
 // that only `ensureSchemaInternal` (imported directly by `store.ts`, never
 // re-exported) accepts, so it renders at no entrypoint at all — no ledger
 // entry to update for that change.
-// `IdentityDecisionProvenance` (+1 on `.`, `./graph-merge`, `./interchange`,
-// `./postgres/pglite`, `./profiler`, `./provenance` and `./sqlite/local`): the
-// graph-merge identity apply threads the governing merge decision through
+// `IdentityDecisionProvenance` (+1 on `./interchange`, `./postgres/pglite`,
+// `./profiler`, `./provenance` and `./sqlite/local`): the graph-merge identity
+// apply threads the governing merge decision through
 // `StoreRuntime.applyIdentityMergeAtTarget`, so the runtime port's declared
 // parameter type renders at every entrypoint that projects `StoreRuntime`.
 // Naming the type on the port is the point — a structurally-inlined copy of the
-// decision shape would be a second spelling of "what a governing decision is" —
-// and every one of these entries retires when the release slice exports
-// `IdentityDecisionProvenance` from the package barrel.
+// decision shape would be a second spelling of "what a governing decision is".
+// It is exported from the package barrel and from `src/graph-merge/index.ts`,
+// which is what keeps `.` and `./graph-merge` off this list; the five above
+// each carry their own narrow barrel that has no business re-exporting an
+// identity type, so their entry is the honest cost of naming it on the port.
 //
-// `./graph-merge` nets DOWN despite that +1: the identity reconciliation
-// surface (`IdentityReconciliationOptions`, the conflict/decision types, the
+// `./graph-merge` nets DOWN: the identity reconciliation surface
+// (`IdentityReconciliationOptions`, the conflict/decision types, the
 // staged-assertion shapes a policy callback receives, the pairing scope) is
 // exported deliberately from `src/graph-merge/index.ts` rather than left as
 // debt, which retires more forgotten exports than the port adds.

--- a/packages/typegraph/src/graph-merge/apply-callbacks.ts
+++ b/packages/typegraph/src/graph-merge/apply-callbacks.ts
@@ -56,6 +56,20 @@ export type MergePlanApplyOptions<G extends GraphDef> = Readonly<{
     tx: TransactionContext<G>,
     applied: MergePlanApplied,
   ) => Promise<void>;
+  /**
+   * The digest of the review artifact this plan was approved under
+   * (`MergeReviewArtifact.digest.value`), recorded on every identity transition
+   * the apply causes. The plan artifact alone does not name its review, so this
+   * is the only place the apply can learn it — omitted for a plan applied
+   * outside a review workflow.
+   */
+  reviewDigest?: string;
+  /**
+   * The candidate write set's `sourceId`, for a plan applied on the ingestion
+   * path. Recorded on the identity transitions so an incoming feed's identity
+   * effects stay attributable to the feed.
+   */
+  sourceId?: string;
 }>;
 
 function pickReadMethods<T, K extends keyof T>(

--- a/packages/typegraph/src/graph-merge/errors.ts
+++ b/packages/typegraph/src/graph-merge/errors.ts
@@ -24,7 +24,6 @@ export const MERGE_ERROR_CODES = {
   constraintConflict: "GRAPH_MERGE_CONSTRAINT_CONFLICT",
   identityConflict: "GRAPH_MERGE_IDENTITY_CONFLICT",
   identitySeparationConflict: "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
-  identityUniquenessConflict: "GRAPH_MERGE_IDENTITY_UNIQUENESS_CONFLICT",
   identityProvenanceConflict: "GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT",
   acyclicityConflict: "GRAPH_MERGE_ACYCLICITY_CONFLICT",
   baseVersionMismatch: "GRAPH_MERGE_BASE_VERSION_MISMATCH",
@@ -270,11 +269,10 @@ export class MergeCompositionOrphanError extends MergeError {
 
 /**
  * The identity dimension of a merge refusal: opposing or retract/reassert
- * truth, a class-lifted `different` that vetoes a match, a uniqueness
- * collision an identity pairing induced, or contradictory provenance across
- * paired members.
+ * truth, a class-lifted `different` that vetoes a match, or contradictory
+ * provenance across paired members.
  *
- * ONE class, four codes. Each of those is a distinct machine-readable
+ * ONE class, three codes. Each of those is a distinct machine-readable
  * `MERGE_ERROR_CODES` entry so a caller can branch precisely, but they share
  * this class — and therefore `category: "conflict"` — so every consumer that
  * already handles an identity merge conflict keeps handling all of them, and
@@ -294,11 +292,10 @@ export class IdentityMergeConflictError extends MergeError {
   }
 }
 
-/** The four codes {@link IdentityMergeConflictError} can carry. */
+/** The three codes {@link IdentityMergeConflictError} can carry. */
 export type IdentityMergeConflictCode =
   | typeof MERGE_ERROR_CODES.identityConflict
   | typeof MERGE_ERROR_CODES.identitySeparationConflict
-  | typeof MERGE_ERROR_CODES.identityUniquenessConflict
   | typeof MERGE_ERROR_CODES.identityProvenanceConflict;
 
 /** One offending edge named in an {@link AcyclicityMergeConflictError}. */

--- a/packages/typegraph/src/graph-merge/errors.ts
+++ b/packages/typegraph/src/graph-merge/errors.ts
@@ -23,6 +23,9 @@ export const MERGE_ERROR_CODES = {
   conflict: "GRAPH_MERGE_CONFLICT",
   constraintConflict: "GRAPH_MERGE_CONSTRAINT_CONFLICT",
   identityConflict: "GRAPH_MERGE_IDENTITY_CONFLICT",
+  identitySeparationConflict: "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
+  identityUniquenessConflict: "GRAPH_MERGE_IDENTITY_UNIQUENESS_CONFLICT",
+  identityProvenanceConflict: "GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT",
   acyclicityConflict: "GRAPH_MERGE_ACYCLICITY_CONFLICT",
   baseVersionMismatch: "GRAPH_MERGE_BASE_VERSION_MISMATCH",
   planCapability: "GRAPH_MERGE_PLAN_CAPABILITY",
@@ -265,15 +268,38 @@ export class MergeCompositionOrphanError extends MergeError {
   }
 }
 
-/** Raised when identity branches contain opposing or retract/reassert truth. */
+/**
+ * The identity dimension of a merge refusal: opposing or retract/reassert
+ * truth, a class-lifted `different` that vetoes a match, a uniqueness
+ * collision an identity pairing induced, or contradictory provenance across
+ * paired members.
+ *
+ * ONE class, four codes. Each of those is a distinct machine-readable
+ * `MERGE_ERROR_CODES` entry so a caller can branch precisely, but they share
+ * this class — and therefore `category: "conflict"` — so every consumer that
+ * already handles an identity merge conflict keeps handling all of them, and
+ * `GRAPH_MERGE_IDENTITY_CONFLICT` keeps every case it raises today.
+ */
 export class IdentityMergeConflictError extends MergeError {
-  override readonly code = MERGE_ERROR_CODES.identityConflict;
+  override readonly code: IdentityMergeConflictCode;
 
-  constructor(message: string, options: MergeErrorOptions = {}) {
+  constructor(
+    message: string,
+    options: MergeErrorOptions &
+      Readonly<{ code?: IdentityMergeConflictCode }> = {},
+  ) {
     super(message, options);
+    this.code = options.code ?? MERGE_ERROR_CODES.identityConflict;
     this.name = "IdentityMergeConflictError";
   }
 }
+
+/** The four codes {@link IdentityMergeConflictError} can carry. */
+export type IdentityMergeConflictCode =
+  | typeof MERGE_ERROR_CODES.identityConflict
+  | typeof MERGE_ERROR_CODES.identitySeparationConflict
+  | typeof MERGE_ERROR_CODES.identityUniquenessConflict
+  | typeof MERGE_ERROR_CODES.identityProvenanceConflict;
 
 /** One offending edge named in an {@link AcyclicityMergeConflictError}. */
 export type AcyclicityMergeConflictEdge = Readonly<{

--- a/packages/typegraph/src/graph-merge/evidence.ts
+++ b/packages/typegraph/src/graph-merge/evidence.ts
@@ -91,7 +91,7 @@ export type CandidateDiagnostic =
         | "retained"
         | Readonly<{
             kind: "excluded";
-            reason: "diameter" | "baseAmbiguity";
+            reason: "diameter" | "baseAmbiguity" | "separation";
           }>;
     }>
   | Readonly<{
@@ -99,7 +99,7 @@ export type CandidateDiagnostic =
       scoreDecision: "accepted";
       clusterDisposition: Readonly<{
         kind: "excluded";
-        reason: "diameter" | "baseAmbiguity";
+        reason: "diameter" | "baseAmbiguity" | "separation";
       }>;
     }>;
 

--- a/packages/typegraph/src/graph-merge/evidence.ts
+++ b/packages/typegraph/src/graph-merge/evidence.ts
@@ -40,6 +40,16 @@ export type MatchSource =
       kind: "custom";
       sourceId: string;
       metadata?: JsonValue | undefined;
+    }>
+  /**
+   * An explicit `same` identity assertion recalled the pair. `assertionIds`
+   * names every assertion that attributes it, sorted, so the evidence points
+   * back at the ledger rows a reviewer can read.
+   */
+  | Readonly<{
+      kind: "identity";
+      sourceId: string;
+      assertionIds: readonly string[];
     }>;
 
 /** JSON-safe description of the strategy that actually scored a pair. */
@@ -114,6 +124,9 @@ const SOURCE_KIND_ORDER: Readonly<Record<MatchSource["kind"], number>> = {
   keyless: 4,
   retype: 5,
   custom: 6,
+  // APPENDED, never inserted: an existing source's ordering integer must not
+  // move, or every stored plan's source ordering changes with this release.
+  identity: 7,
 };
 
 /** Canonical JSON key for source deduplication and ordering. */
@@ -144,6 +157,15 @@ function sourceKey(source: MatchSource): string {
         SOURCE_KIND_ORDER.custom,
         source.sourceId,
         source.metadata === undefined ? "" : canonicalValueKey(source.metadata),
+      ]);
+    }
+    case "identity": {
+      return JSON.stringify([
+        SOURCE_KIND_ORDER.identity,
+        source.sourceId,
+        [...source.assertionIds].sort((left, right) =>
+          compareStrings(left, right),
+        ),
       ]);
     }
     default: {

--- a/packages/typegraph/src/graph-merge/identity-decision.ts
+++ b/packages/typegraph/src/graph-merge/identity-decision.ts
@@ -54,7 +54,7 @@ export function branchAncestryFromAnchors(
  * exercise — a stated `onAssertionConflict` that no conflict ever reached is
  * not a decision the transition log should claim was made.
  */
-export function identityDecisionPolicy(
+function identityDecisionPolicy(
   reconciliations: readonly IdentityReconciliation[],
 ): string | undefined {
   const arms = new Set<string>();

--- a/packages/typegraph/src/graph-merge/identity-decision.ts
+++ b/packages/typegraph/src/graph-merge/identity-decision.ts
@@ -1,0 +1,105 @@
+/**
+ * The governing DECISION a merge attaches to the identity transitions it
+ * causes.
+ *
+ * When a merge folds or splits an identity class, the transition log records
+ * WHY. Without this, a fold triggered by a merged node create is filed as an
+ * anonymous `fold` and a reviewer replaying the class can see that it happened
+ * but not which plan, review, branch or policy arm produced it.
+ *
+ * Everything here is evidence ALREADY IN HAND at the apply site — the plan
+ * artifact's own digest, the anchors it was built from, the policy the
+ * classifier actually exercised. Nothing is read, recomputed, or invented; a
+ * field the caller cannot evidence stays absent rather than being guessed.
+ */
+import type { MergePlanAnchors } from "./plan-schema";
+import type { IdentityDecisionProvenance } from "./typegraph-internal";
+import type { IdentityReconciliation } from "./types";
+
+/**
+ * Root-first branch ancestry: the base (or fork-point) graph, then each branch
+ * in the anchors' own wire order.
+ *
+ * Ancestry here is the PLAN's `MergePlanAnchors` — what this merge combined —
+ * not a per-graph lineage the store would have to reconstruct. That is the only
+ * ancestry the apply site can evidence without reading anything.
+ */
+export function branchAncestryOf(
+  rootGraphId: string,
+  branchIds: readonly string[],
+): readonly string[] {
+  return [rootGraphId, ...branchIds];
+}
+
+/** The same ancestry, read off a plan artifact's anchors. */
+export function branchAncestryFromAnchors(
+  anchors: MergePlanAnchors,
+): readonly string[] {
+  const root =
+    anchors.kind === "snapshot" ?
+      anchors.base.graphId
+    : anchors.forkPoint.graphId;
+  return branchAncestryOf(
+    root,
+    anchors.branches.map((branch) => branch.branchId),
+  );
+}
+
+/**
+ * The policy arm that actually DECIDED something, or `undefined` when the merge
+ * arbitrated nothing by policy.
+ *
+ * Read off the reconciliations the classifier produced rather than off the
+ * stated options, so an ordinary apply never writes a policy string it did not
+ * exercise — a stated `onAssertionConflict` that no conflict ever reached is
+ * not a decision the transition log should claim was made.
+ */
+export function identityDecisionPolicy(
+  reconciliations: readonly IdentityReconciliation[],
+): string | undefined {
+  const arms = new Set<string>();
+  for (const reconciliation of reconciliations) {
+    if (reconciliation.policy !== undefined) {
+      arms.add(`assertion:${reconciliation.policy}`);
+    }
+  }
+  if (arms.size === 0) return undefined;
+  return [...arms].toSorted().join(",");
+}
+
+/** The evidence an apply site has for the decision it is about to record. */
+export type MergeIdentityDecisionInput = Readonly<{
+  branchAncestry: readonly string[];
+  reconciliations: readonly IdentityReconciliation[];
+  mergePlanDigest?: string | undefined;
+  reviewDigest?: string | undefined;
+  sourceId?: string | undefined;
+}>;
+
+/**
+ * Builds the decision, omitting every field the caller could not evidence.
+ * `branchId` is present only in the single-branch case, where "which branch"
+ * has an unambiguous answer.
+ */
+export function mergeIdentityDecision(
+  input: MergeIdentityDecisionInput,
+): IdentityDecisionProvenance {
+  const policy = identityDecisionPolicy(input.reconciliations);
+  // [root, branch] — exactly one branch merged, so naming it is unambiguous.
+  const soleBranch =
+    input.branchAncestry.length === 2 ? input.branchAncestry[1] : undefined;
+  return {
+    ...(policy === undefined ? {} : { policy }),
+    ...(soleBranch === undefined ? {} : { branchId: soleBranch }),
+    ...(input.branchAncestry.length === 0 ?
+      {}
+    : { branchAncestry: input.branchAncestry }),
+    ...(input.mergePlanDigest === undefined ?
+      {}
+    : { mergePlanDigest: input.mergePlanDigest }),
+    ...(input.reviewDigest === undefined ?
+      {}
+    : { reviewDigest: input.reviewDigest }),
+    ...(input.sourceId === undefined ? {} : { sourceId: input.sourceId }),
+  };
+}

--- a/packages/typegraph/src/graph-merge/identity-pairing.ts
+++ b/packages/typegraph/src/graph-merge/identity-pairing.ts
@@ -10,19 +10,26 @@
  * assertions that separated them.
  *
  * The facts are captured ONCE, before planning, from the merge target's own
- * identity context, and consumed by two application points that both read this
- * single fact set:
+ * identity context, and consumed by three application points that all read
+ * this single fact set:
  *
- *   1. the candidate-edge veto, which drops a scored edge and refuses a forced
- *      one; and
- *   2. the post-cluster assertion, which catches a TRANSITIVE fusion — `a`–`b`
+ *   1. the candidate-edge veto, which DROPS a scored edge (recall the ledger
+ *      forbids) and reports it as a typed `separation` conflict;
+ *   2. the surviving-edge refusal, which fails the plan on a DEFINITIONAL edge
+ *      that outlived the base and diameter guards; and
+ *   3. the post-cluster assertion, which catches a TRANSITIVE fusion — `a`–`b`
  *      and `b`–`c` each clearing the threshold while `a` and `c` are held
  *      apart, so no single candidate edge is separated yet the cluster fuses
  *      all three.
  *
- * Capturing once is what lets the second point stay synchronous inside plan
- * construction, and what makes it structurally impossible for the two points
- * to disagree.
+ * Points 2 and 3 run AFTER the guards on purpose. A forced base pairing whose
+ * component the base guard severs never fuses anything, so refusing it up
+ * front would fail a merge that is harmless; only an edge (or a cluster) that
+ * survives the guards can actually collapse two separated classes.
+ *
+ * Capturing once is what lets the later points stay synchronous inside plan
+ * construction, and what makes it structurally impossible for them to
+ * disagree.
  *
  * ONE OWNER. The class-lifted `different` decision is `bulkIsSeparated`
  * (`src/identity/separation.ts`) — this module resolves each participant to its

--- a/packages/typegraph/src/graph-merge/identity-pairing.ts
+++ b/packages/typegraph/src/graph-merge/identity-pairing.ts
@@ -1,0 +1,236 @@
+/**
+ * The identity SEPARATION VETO — the plan-time half of identity reconciliation.
+ *
+ * A `store.identity.assertDifferent(a, b)` is an integrity fact, not a recall
+ * heuristic, so the veto is ON for every identity-enabled merge regardless of
+ * `identity.pairing`. Without it a candidate match between two entities the
+ * ledger holds apart survives planning and dies in the commit on the
+ * separation relation's ordered-pair CHECK — a constraint violation at the
+ * wrong phase, naming table columns rather than the two entities and the
+ * assertions that separated them.
+ *
+ * The facts are captured ONCE, before planning, from the merge target's own
+ * identity context, and consumed by two application points that both read this
+ * single fact set:
+ *
+ *   1. the candidate-edge veto, which drops a scored edge and refuses a forced
+ *      one; and
+ *   2. the post-cluster assertion, which catches a TRANSITIVE fusion — `a`–`b`
+ *      and `b`–`c` each clearing the threshold while `a` and `c` are held
+ *      apart, so no single candidate edge is separated yet the cluster fuses
+ *      all three.
+ *
+ * Capturing once is what lets the second point stay synchronous inside plan
+ * construction, and what makes it structurally impossible for the two points
+ * to disagree.
+ *
+ * ONE OWNER. The class-lifted `different` decision is `bulkIsSeparated`
+ * (`src/identity/separation.ts`) — this module resolves each participant to its
+ * current identity class and asks that one predicate, never its own SQL and
+ * never a re-derivation of what "class-lifted difference" means.
+ */
+import type { MergeKey } from "./node-key";
+import { compareStrings, idOf, kindOf } from "./node-key";
+import type { GraphDef, PlainNodeRef, Store } from "./typegraph-internal";
+import {
+  bulkIsSeparated,
+  currentClassKey,
+  identityReferenceKeyOf,
+  loadCurrentStructuralClasses,
+  loadSpanningDifferentAssertion,
+  storeRuntime,
+} from "./typegraph-internal";
+
+/**
+ * The separation facts one merge plan is judged against: each candidate
+ * participant's current identity CLASS key, and the ordered class-key pairs the
+ * ledger holds as `different`.
+ *
+ * Evidence bound to the resource that earned it: both halves come from the
+ * merge target's own identity context, read before planning, and are consumed
+ * only by that plan.
+ */
+export type IdentitySeparationFacts = Readonly<{
+  /** Class key per candidate participant, from the target's current closure. */
+  classKeyOf: ReadonlyMap<MergeKey, string>;
+  /** NUL-joined, code-point-ordered class-key pairs the relation separates. */
+  separatedClassPairs: ReadonlySet<string>;
+  /**
+   * For each separated pair, the `different` assertion the ledger holds across
+   * it — the WITNESS a refusal names, so a caller reads WHICH assertion forbade
+   * the match rather than only that something did. Resolved eagerly, but only
+   * for the pairs the probe actually reported separated: a separation among
+   * fusion candidates is an exceptional state, never the steady one.
+   */
+  separatingAssertionIdOf: ReadonlyMap<string, string>;
+}>;
+
+/** The empty facts an identity-disabled graph is judged against: nothing is separated. */
+export const NO_IDENTITY_SEPARATION_FACTS: IdentitySeparationFacts = {
+  classKeyOf: new Map(),
+  separatedClassPairs: new Set(),
+  separatingAssertionIdOf: new Map(),
+};
+
+/**
+ * The single spelling of an ordered class-key pair, shared by the capture and
+ * every lookup so the two can never key the same separation differently. NUL
+ * joins the halves: a class key is JSON, which escapes NUL, so no two distinct
+ * pairs can collide on the joined string.
+ */
+function classPairKey(first: string, second: string): string {
+  return compareStrings(first, second) <= 0 ?
+      `${first}\u0000${second}`
+    : `${second}\u0000${first}`;
+}
+
+/**
+ * Every distinct unordered pair of participants that could FUSE, grouped so the
+ * probe stays bounded by what the plan can actually merge.
+ *
+ * A merge only ever fuses within a connected component of the candidate-edge
+ * graph, and the base/diameter guards only SPLIT components further — so the
+ * within-group pairs are a superset of every pair the plan can put in one
+ * cluster, and a strict subset of the quadratic all-participants enumeration.
+ */
+function fusionPairs(
+  groups: readonly (readonly MergeKey[])[],
+  classKeyOf: ReadonlyMap<MergeKey, string>,
+): readonly Readonly<{ first: string; second: string }>[] {
+  const seen = new Set<string>();
+  const pairs: Readonly<{ first: string; second: string }>[] = [];
+  for (const group of groups) {
+    for (const [index, left] of group.entries()) {
+      for (const right of group.slice(index + 1)) {
+        const first = classKeyOf.get(left);
+        const second = classKeyOf.get(right);
+        if (first === undefined || second === undefined) continue;
+        if (first === second) continue;
+        const key = classPairKey(first, second);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        pairs.push({ first, second });
+      }
+    }
+  }
+  return pairs;
+}
+
+/**
+ * Resolves every candidate participant to its current identity class and asks
+ * {@link bulkIsSeparated} which of the pairs the plan could fuse are held
+ * apart.
+ *
+ * `groups` are the participant sets a fusion could occur WITHIN — the connected
+ * components of the candidate-edge graph. Passing the flat participant list as
+ * one group is correct but quadratic; passing the components keeps the probe
+ * proportional to what the plan can actually merge.
+ *
+ * @throws {ConfigurationError} `IDENTITY_STORAGE_MISSING` when the separation
+ * relation this graph's veto reads has never been provisioned or filled —
+ * `bulkIsSeparated`'s refusal, surfaced here rather than answered "not
+ * separated".
+ */
+export async function captureIdentitySeparationFacts<G extends GraphDef>(
+  target: Store<G>,
+  groups: readonly (readonly MergeKey[])[],
+): Promise<IdentitySeparationFacts> {
+  const participants = [...new Set(groups.flat())];
+  if (participants.length === 0) return NO_IDENTITY_SEPARATION_FACTS;
+  const ctx = storeRuntime(target).identityContext();
+  const classes = await loadCurrentStructuralClasses(
+    ctx.backend,
+    ctx.schema,
+    ctx.graphId,
+    participants.map((key) => ({ kind: kindOf(key), id: idOf(key) })),
+  );
+  const classKeyOf = new Map<MergeKey, string>();
+  const membersByClassKey = new Map<string, readonly PlainNodeRef[]>();
+  for (const key of participants) {
+    const ref = { kind: kindOf(key), id: idOf(key) };
+    // `loadCurrentStructuralClasses` keys on the identity module's OWN
+    // reference key — reached here rather than re-spelled — and coalesces an
+    // unclosed node onto itself, so a node belonging to no class is still
+    // answered, as its own singleton class.
+    const members = classes.get(identityReferenceKeyOf(ref)) ?? [ref];
+    const classKey = currentClassKey(members);
+    classKeyOf.set(key, classKey);
+    membersByClassKey.set(classKey, members);
+  }
+  const pairs = fusionPairs(groups, classKeyOf);
+  if (pairs.length === 0) {
+    return {
+      classKeyOf,
+      separatedClassPairs: new Set(),
+      separatingAssertionIdOf: new Map(),
+    };
+  }
+  const verdicts = await bulkIsSeparated(
+    ctx.backend,
+    ctx.schema,
+    ctx.graphId,
+    pairs,
+    ctx.registry,
+  );
+  const separatedClassPairs = new Set<string>();
+  const separated: Readonly<{ first: string; second: string }>[] = [];
+  for (const [index, pair] of pairs.entries()) {
+    if (verdicts[index] !== true) continue;
+    separatedClassPairs.add(classPairKey(pair.first, pair.second));
+    separated.push(pair);
+  }
+  const separatingAssertionIdOf = new Map<string, string>();
+  for (const pair of separated) {
+    const witness = await loadSpanningDifferentAssertion(
+      ctx.backend,
+      ctx.schema,
+      ctx.graphId,
+      membersByClassKey.get(pair.first) ?? [],
+      membersByClassKey.get(pair.second) ?? [],
+    );
+    if (witness !== undefined) {
+      separatingAssertionIdOf.set(
+        classPairKey(pair.first, pair.second),
+        witness.id,
+      );
+    }
+  }
+  return { classKeyOf, separatedClassPairs, separatingAssertionIdOf };
+}
+
+/**
+ * The `different` assertion ids a refusal should name for this pair — empty
+ * when the relation reported a separation the ledger's witness could not be
+ * resolved for (a mismatch the identity module's own rebuild guard owns).
+ */
+export function separatingAssertionIds(
+  facts: IdentitySeparationFacts,
+  a: MergeKey,
+  b: MergeKey,
+): readonly string[] {
+  const first = facts.classKeyOf.get(a);
+  const second = facts.classKeyOf.get(b);
+  if (first === undefined || second === undefined) return [];
+  const witness = facts.separatingAssertionIdOf.get(
+    classPairKey(first, second),
+  );
+  return witness === undefined ? [] : [witness];
+}
+
+/**
+ * Whether the ledger holds these two candidate participants' identity classes
+ * apart. A pure lookup into facts already captured — never a read — so a plan
+ * builder can ask it synchronously.
+ */
+export function isSeparatedPair(
+  facts: IdentitySeparationFacts,
+  a: MergeKey,
+  b: MergeKey,
+): boolean {
+  const first = facts.classKeyOf.get(a);
+  const second = facts.classKeyOf.get(b);
+  if (first === undefined || second === undefined || first === second) {
+    return false;
+  }
+  return facts.separatedClassPairs.has(classPairKey(first, second));
+}

--- a/packages/typegraph/src/graph-merge/identity-pairing.ts
+++ b/packages/typegraph/src/graph-merge/identity-pairing.ts
@@ -42,6 +42,7 @@ import type { GraphDef, PlainNodeRef, Store } from "./typegraph-internal";
 import {
   bulkIsSeparated,
   currentClassKey,
+  hasLiveDifferentAssertions,
   identityReferenceKeyOf,
   loadCurrentStructuralClasses,
   loadSpanningDifferentAssertion,
@@ -145,6 +146,32 @@ export async function captureIdentitySeparationFacts<G extends GraphDef>(
   const participants = [...new Set(groups.flat())];
   if (participants.length === 0) return NO_IDENTITY_SEPARATION_FACTS;
   const ctx = storeRuntime(target).identityContext();
+  // A graph holding no `different` assertion can separate nothing, so the whole
+  // capture — the class resolution AND the within-component pair enumeration,
+  // which is quadratic in component size — is skipped for one indexed
+  // existence probe. That is the STEADY state of every graph that uses only
+  // `assertSame`, and the state where the veto's cost would otherwise be pure
+  // waste. The predicate is the identity module's own
+  // (`hasLiveDifferentAssertions`), never a second spelling of "is anything
+  // separated here": it is the same fact `bulkIsSeparated` consults to decide
+  // that an EMPTY separation relation is correct rather than unfilled.
+  //
+  // Consequence, deliberately: a legacy store whose separation relation was
+  // never provisioned no longer refuses a stated `identity.pairing` when it
+  // holds no `different` assertion either. Refusing there was a false alarm —
+  // there is nothing for the veto to read, and the identity module already
+  // treats "no live `different` assertion" as proof that an empty relation is
+  // correct. A store that does hold one still reaches the refusal below.
+  if (
+    !(await hasLiveDifferentAssertions(
+      ctx.backend,
+      ctx.schema,
+      ctx.graphId,
+      ctx.registry,
+    ))
+  ) {
+    return NO_IDENTITY_SEPARATION_FACTS;
+  }
   const classes = await loadCurrentStructuralClasses(
     ctx.backend,
     ctx.schema,

--- a/packages/typegraph/src/graph-merge/identity-pairing.ts
+++ b/packages/typegraph/src/graph-merge/identity-pairing.ts
@@ -46,6 +46,7 @@ import {
   identityReferenceKeyOf,
   loadCurrentStructuralClasses,
   loadSpanningDifferentAssertion,
+  separationFactsKnownEmpty,
   storeRuntime,
 } from "./typegraph-internal";
 
@@ -156,6 +157,13 @@ export async function captureIdentitySeparationFacts<G extends GraphDef>(
   // separated here": it is the same fact `bulkIsSeparated` consults to decide
   // that an EMPTY separation relation is correct rather than unfilled.
   //
+  // `separationFactsKnownEmpty` is asked FIRST, never a second decision: it is
+  // the read side of the identical per-(registry, graphId) proof
+  // `bulkIsSeparated`'s own zero-rows branch maintains, so a graph an earlier
+  // `assertSame`/`assertDifferent` on this Store handle already proved
+  // separates-nothing skips the round trip here entirely rather than paying it
+  // again on every merge.
+  //
   // Consequence, deliberately: a legacy store whose separation relation was
   // never provisioned no longer refuses a stated `identity.pairing` when it
   // holds no `different` assertion either. Refusing there was a false alarm —
@@ -163,6 +171,7 @@ export async function captureIdentitySeparationFacts<G extends GraphDef>(
   // treats "no live `different` assertion" as proof that an empty relation is
   // correct. A store that does hold one still reaches the refusal below.
   if (
+    separationFactsKnownEmpty(ctx.registry, ctx.graphId) ||
     !(await hasLiveDifferentAssertions(
       ctx.backend,
       ctx.schema,

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -1,20 +1,41 @@
 /**
- * The identity survivor rule and semantic pair key: the ONE place that decides
- * which of several colliding identity assertions survives a merge, and the
- * ONE place that computes the semantic key two assertions are compared under.
+ * The identity survivor rule and semantic pair key, and the THREE-WAY
+ * classifier built on top of them: one classifier absorbing what used to be
+ * three separate inline arbitrations in `merge-identity.ts` —
+ * `dedupeIdentityAssertions`, `assertNoOpposingIdentityRelations`, and
+ * `assertNoRetractReassertRace`. Every arm keeps today's behavior verbatim
+ * under the default `"refuse"` policy; a caller-supplied resolving policy
+ * (`"assertWins"` / `"retractWins"` / `"flag"` / a function) turns a subset of
+ * those refusals into a recorded resolution instead of a thrown error.
  *
- * Extracted out of `merge-identity.ts` so both the plan-time dedupe
- * (`merge-identity.ts`) and the post-remap re-dedupe it runs after endpoint
- * canonicalization call the SAME comparator — a second inline copy of the
- * survivor rule is exactly the kind of decision this repository's contract
- * discipline forbids re-spelling.
+ * Extracted out of `merge-identity.ts` so both the plan-time dedupe and the
+ * post-remap re-dedupe it runs after endpoint canonicalization call the SAME
+ * comparator — a second inline copy of the survivor rule is exactly the kind
+ * of decision this repository's contract discipline forbids re-spelling.
  */
 import { identityAssertionSemanticKey } from "../identity/assertion-key";
+import type { IdentityRelation } from "../identity/types";
+import { identityValidityWindowsOverlap } from "../identity/validity-window";
+import { requireDefined } from "../utils/presence";
 import { encodeTupleKey } from "../utils/tuple-key";
+import { IdentityMergeConflictError, InvalidMergeOptionsError } from "./errors";
+import { type EntityRef, entityRef } from "./evidence";
+import { compareStrings, mergeKeyOf } from "./node-key";
+import type {
+  StagedIdentityAssertion,
+  StagedRetraction,
+  StagingSet,
+} from "./staging";
 import {
   compareCodePoints,
   type IdentityTransferAssertion,
 } from "./typegraph-internal";
+import type {
+  DroppedItem,
+  IdentityAssertionConflictReason,
+  IdentityReconciliation,
+  IdentityUnresolvedConflict,
+} from "./types";
 
 /**
  * The semantic key two identity assertions are compared under: the relation
@@ -53,8 +74,7 @@ export function identityDedupeKey(
  * deterministic survivor: earliest `validFrom` wins, and a tie breaks on the
  * assertion id's code-point order. Callers needing the COMMITTED-id override
  * (an id the target already holds with the exact staged truth always wins
- * regardless of this order) apply it before falling back to this comparator —
- * see `merge-identity.ts`'s `dedupeIdentityAssertions`.
+ * regardless of this order) apply it before falling back to this comparator.
  */
 export function compareIdentitySurvivors(
   left: IdentityTransferAssertion,
@@ -62,4 +82,921 @@ export function compareIdentitySurvivors(
 ): number {
   const byValidity = compareCodePoints(left.validFrom, right.validFrom);
   return byValidity === 0 ? compareCodePoints(left.id, right.id) : byValidity;
+}
+
+/**
+ * Reason recorded when two branches asserted the SAME semantic pair and the
+ * survivor rule kept only one of the two assertion ids.
+ */
+export const DUPLICATE_IDENTITY_ASSERTION_DROP_REASON =
+  "identity:duplicate-assertion";
+
+/**
+ * Reason recorded when a `"retractWins"`/function resolution overruled a
+ * branch's re-assertion of a pair another branch retracted.
+ */
+export const REASSERT_OVERRULED_DROP_REASON = "identity:reassert-overruled";
+
+/**
+ * Reason recorded when an `"assertWins"`/function resolution overruled a
+ * branch's OWN staged end for a pair another branch re-asserted under a new
+ * id — the pair's base row still ends (a merge can never leave the ledger
+ * holding two CURRENT assertions for one pair), just not at the overruled
+ * branch's chosen instant.
+ */
+export const RETRACT_OVERRULED_DROP_REASON = "identity:retract-overruled";
+
+function droppedIdentityAssertion(
+  assertion: IdentityTransferAssertion,
+  reason: string,
+): DroppedItem {
+  return { kind: "identity", id: assertion.id, reason };
+}
+
+/** Structural (kind, id) tuple key for one identity assertion ENDPOINT PAIR. */
+function pairEndpointKey(
+  assertion: Readonly<{ a: EntityRef; b: EntityRef }>,
+): string {
+  return encodeTupleKey([
+    assertion.a.kind,
+    assertion.a.id,
+    assertion.b.kind,
+    assertion.b.id,
+  ]);
+}
+
+function entityRefOf(ref: Readonly<{ kind: string; id: string }>): EntityRef {
+  return entityRef(mergeKeyOf(ref));
+}
+
+/**
+ * One irreconcilable identity-assertion disagreement, fully populated so a
+ * resolving policy (a `"flag"` classification or a function callback) has
+ * everything it needs to decide, and so `"refuse"` can report exactly what
+ * collided.
+ */
+export type IdentityAssertionConflict = Readonly<{
+  reason: IdentityAssertionConflictReason;
+  semanticKey: string;
+  a: EntityRef;
+  b: EntityRef;
+  relation: IdentityRelation;
+  base: readonly IdentityTransferAssertion[];
+  asserted: readonly StagedIdentityAssertion[];
+  retracted: readonly StagedRetraction[];
+}>;
+
+/**
+ * What a resolving policy decided for one {@link IdentityAssertionConflict}.
+ * `"assert"` must name an id present in the conflict's own `asserted` array —
+ * a callback cannot invent an assertion the merge never staged.
+ */
+export type IdentityAssertionDecision =
+  | Readonly<{ kind: "assert"; assertionId: string }>
+  | Readonly<{ kind: "retract" }>
+  | Readonly<{ kind: "unresolved" }>;
+
+/**
+ * How the merge arbitrates an identity-assertion conflict it cannot resolve
+ * by rule alone. `"refuse"` (the default) reproduces today's behavior
+ * byte-for-byte: an unresolvable conflict throws {@link IdentityMergeConflictError}
+ * and the merge plans nothing. A resolving policy turns that refusal into a
+ * recorded resolution instead.
+ */
+export type IdentityAssertionConflictPolicy =
+  | "refuse"
+  | "assertWins"
+  | "retractWins"
+  | "flag"
+  | ((conflict: IdentityAssertionConflict) => IdentityAssertionDecision);
+
+/** What classifying one identity pair (one semantic key, one validity window) decided. */
+export type IdentityPairOutcome =
+  | Readonly<{ kind: "unchanged" }>
+  | Readonly<{
+      kind: "asserted";
+      survivor: IdentityTransferAssertion;
+      superseded: readonly DroppedItem[];
+      reconciliation?: IdentityReconciliation | undefined;
+    }>
+  | Readonly<{ kind: "retracted"; retraction: IdentityTransferAssertion }>
+  | Readonly<{ kind: "unresolved"; conflict: IdentityAssertionConflict }>;
+
+/** Whether `policy` is anything other than the byte-identical default. */
+function isResolvingPolicy(policy: IdentityAssertionConflictPolicy): boolean {
+  return policy !== "refuse";
+}
+
+/**
+ * Reduces N candidate assertions for the SAME window to one survivor: an id
+ * already committed on the target with the exact staged truth ALWAYS wins
+ * (the applier is idempotent per pair; a fresh challenger would never be
+ * written), otherwise {@link compareIdentitySurvivors} decides. Two branches
+ * staging the IDENTICAL row (same id, same complete truth) collapse silently
+ * — reporting one as dropped while it is the very row applied would make the
+ * report self-contradictory.
+ */
+function reduceIdentitySurvivor(
+  candidates: readonly StagedIdentityAssertion[],
+  committedIds: ReadonlySet<string>,
+): Readonly<{
+  survivor: StagedIdentityAssertion;
+  superseded: readonly DroppedItem[];
+  /** Why the final survivor beat the last candidate it displaced. */
+  rule: IdentityReconciliation["rule"];
+}> {
+  const [first, ...rest] = candidates;
+  let survivor = requireDefined(first);
+  let rule: IdentityReconciliation["rule"] = "code-point-id";
+  const superseded: DroppedItem[] = [];
+  for (const candidate of rest) {
+    const candidateCommitted = committedIds.has(candidate.assertion.id);
+    const survivorCommitted = committedIds.has(survivor.assertion.id);
+    if (candidateCommitted === survivorCommitted) {
+      rule =
+        (
+          compareCodePoints(
+            candidate.assertion.validFrom,
+            survivor.assertion.validFrom,
+          ) === 0
+        ) ?
+          "code-point-id"
+        : "earliest-valid-from";
+    } else {
+      rule = "committed-id";
+    }
+    const [winner, loser] =
+      candidateCommitted === survivorCommitted ?
+        compareIdentitySurvivors(candidate.assertion, survivor.assertion) < 0 ?
+          [candidate, survivor]
+        : [survivor, candidate]
+      : candidateCommitted ? [candidate, survivor]
+      : [survivor, candidate];
+    survivor = winner;
+    if (
+      loser.assertion.id === winner.assertion.id &&
+      loser.assertion.validFrom === winner.assertion.validFrom &&
+      (loser.assertion.validTo ?? undefined) ===
+        (winner.assertion.validTo ?? undefined)
+    ) {
+      continue;
+    }
+    superseded.push(
+      droppedIdentityAssertion(
+        loser.assertion,
+        DUPLICATE_IDENTITY_ASSERTION_DROP_REASON,
+      ),
+    );
+  }
+  return { survivor, superseded, rule };
+}
+
+/** Reduces N staged retractions of the SAME base row to one: earliest end wins. */
+function reduceIdentityRetraction(
+  candidates: readonly StagedRetraction[],
+): StagedRetraction {
+  return candidates.reduce((earliest, candidate) =>
+    (
+      compareCodePoints(
+        candidate.assertion.validTo ?? "",
+        earliest.assertion.validTo ?? "",
+      ) < 0
+    ) ?
+      candidate
+    : earliest,
+  );
+}
+
+/**
+ * Builds an {@link IdentityReconciliation} for a duplicate-assertion survivor
+ * pick, when the merge is configured to make one visible (§3.2:
+ * `policy !== "refuse"` — a plain default-policy merge stays byte-identical
+ * to today, which never recorded this).
+ */
+function buildReconciliation(
+  semanticKey: string,
+  candidates: readonly StagedIdentityAssertion[],
+  survivor: StagedIdentityAssertion,
+  superseded: readonly DroppedItem[],
+  rule: IdentityReconciliation["rule"],
+  policy: IdentityAssertionConflictPolicy,
+): IdentityReconciliation | undefined {
+  if (!isResolvingPolicy(policy) || superseded.length === 0) return undefined;
+  return {
+    semanticKey,
+    a: entityRefOf(survivor.assertion.a),
+    b: entityRefOf(survivor.assertion.b),
+    relation: survivor.assertion.relation,
+    survivorAssertionId: survivor.assertion.id,
+    supersededAssertionIds: superseded
+      .map((item) => item.id)
+      .toSorted(compareStrings),
+    rule,
+    branches: [
+      ...new Set(candidates.map((staged) => staged.branchId)),
+    ].toSorted(compareStrings),
+  };
+}
+
+/**
+ * Reduces raw (unstaged) identity assertions across POTENTIALLY MANY semantic
+ * pairs to one survivor per pair, via {@link identityDedupeKey} /
+ * {@link compareIdentitySurvivors} — the same rule
+ * {@link classifyIdentityPair}'s absent-pair arm applies, generalized to a
+ * flat list spanning multiple pairs.
+ *
+ * The single owner `remapIdentityAssertionEndpoints` (`merge-identity.ts`)
+ * calls for its post-remap re-dedupe: node-reconciliation canonicalization
+ * can collapse two previously-distinct pairs onto one semantic key AFTER
+ * the plan-time classification above already ran, so that re-dedupe must
+ * call the identical comparator rather than re-spell the survivor rule.
+ */
+export function dedupeIdentityAssertionsRaw(
+  assertions: readonly IdentityTransferAssertion[],
+  committedIds: ReadonlySet<string>,
+): Readonly<{
+  survivors: readonly IdentityTransferAssertion[];
+  dropped: readonly DroppedItem[];
+}> {
+  const survivorBySemantic = new Map<string, IdentityTransferAssertion>();
+  const dropped: DroppedItem[] = [];
+  for (const assertion of assertions) {
+    const key = identityDedupeKey(assertion);
+    const previous = survivorBySemantic.get(key);
+    if (previous === undefined) {
+      survivorBySemantic.set(key, assertion);
+      continue;
+    }
+    const assertionCommitted = committedIds.has(assertion.id);
+    const previousCommitted = committedIds.has(previous.id);
+    const [survivor, loser] =
+      assertionCommitted === previousCommitted ?
+        compareIdentitySurvivors(assertion, previous) < 0 ?
+          ([assertion, previous] as const)
+        : ([previous, assertion] as const)
+      : assertionCommitted ? ([assertion, previous] as const)
+      : ([previous, assertion] as const);
+    survivorBySemantic.set(key, survivor);
+    if (
+      loser.id === survivor.id &&
+      loser.validFrom === survivor.validFrom &&
+      (loser.validTo ?? undefined) === (survivor.validTo ?? undefined)
+    ) {
+      continue;
+    }
+    dropped.push(
+      droppedIdentityAssertion(loser, DUPLICATE_IDENTITY_ASSERTION_DROP_REASON),
+    );
+  }
+  return {
+    survivors: [...survivorBySemantic.values()].toSorted((left, right) =>
+      compareCodePoints(identityDedupeKey(left), identityDedupeKey(right)),
+    ),
+    dropped,
+  };
+}
+
+/**
+ * Unconditional (non-policy) opposing-relations re-validation over a FLAT,
+ * unstaged assertion list — what `remapIdentityAssertionEndpoints` runs after
+ * canonicalization, since node reconciliation can pull two previously
+ * distinct endpoint pairs onto one canonical pair and manufacture a
+ * collision no branch ever staged. Always throws: there is no branch
+ * attribution left to hand a resolving policy at this point, and the
+ * pre-remap classification above already gave the caller's policy its say.
+ */
+export function assertNoOpposingIdentityRelationsRaw(
+  assertions: readonly IdentityTransferAssertion[],
+): void {
+  const byEndpoint = new Map<string, IdentityTransferAssertion[]>();
+  for (const assertion of assertions) {
+    const key = pairEndpointKey({
+      a: entityRefOf(assertion.a),
+      b: entityRefOf(assertion.b),
+    });
+    const group = byEndpoint.get(key) ?? [];
+    group.push(assertion);
+    byEndpoint.set(key, group);
+  }
+  for (const [endpoint, group] of byEndpoint) {
+    const same = group.filter((assertion) => assertion.relation === "same");
+    const different = group.filter(
+      (assertion) => assertion.relation === "different",
+    );
+    for (const sameAssertion of same) {
+      for (const differentAssertion of different) {
+        if (
+          !identityValidityWindowsOverlap(sameAssertion, differentAssertion)
+        ) {
+          continue;
+        }
+        throw new IdentityMergeConflictError(
+          "Branches asserted opposing identity relations for one endpoint pair.",
+          {
+            details: {
+              endpoint,
+              assertions: [sameAssertion, differentAssertion],
+            },
+          },
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Classifies one identity pair — one semantic key, one validity window —
+ * against the staged base slice. `base` is the target's CURRENT truth for
+ * this pair at staging time (empty when the pair has none); `asserted` /
+ * `retracted` are every branch's staged claims for it.
+ *
+ * The four table arms this absorbs, arm-for-arm (design §4.2 / plan §1.4):
+ *
+ *  - base absent, one branch asserts → `asserted`.
+ *  - base absent, ≥2 branches assert under different ids → `asserted`, with
+ *    the loser(s) `superseded` (the old `dedupeIdentityAssertions` rule).
+ *  - base present, every/some branch retracts and nobody reasserts →
+ *    `retracted` (earliest end).
+ *  - base present, one branch retracts AND reasserts (convergent) →
+ *    `asserted`, ending the base row at the retraction's own instant.
+ *
+ * A genuine RACE (base present, one branch retracts while a DIFFERENT branch
+ * reasserts under a new id without retracting) and an OPPOSING-RELATIONS
+ * collision (both `same` and `different` staged for one endpoint with
+ * overlapping windows) span more than one pair and are therefore classified
+ * by {@link planIdentityThreeWay} itself, which calls this function only for
+ * pairs neither cross-cutting check claimed.
+ */
+export function classifyIdentityPair(
+  semanticKey: string,
+  base: readonly IdentityTransferAssertion[],
+  asserted: readonly StagedIdentityAssertion[],
+  retracted: readonly StagedRetraction[],
+  policy: IdentityAssertionConflictPolicy,
+  committedIds: ReadonlySet<string>,
+): IdentityPairOutcome {
+  if (base.length === 0) {
+    if (asserted.length === 0) return { kind: "unchanged" };
+    if (asserted.length === 1) {
+      return {
+        kind: "asserted",
+        survivor: requireDefined(asserted[0]).assertion,
+        superseded: [],
+      };
+    }
+    const { survivor, superseded, rule } = reduceIdentitySurvivor(
+      asserted,
+      committedIds,
+    );
+    return {
+      kind: "asserted",
+      survivor: survivor.assertion,
+      superseded,
+      reconciliation: buildReconciliation(
+        semanticKey,
+        asserted,
+        survivor,
+        superseded,
+        rule,
+        policy,
+      ),
+    };
+  }
+
+  if (retracted.length === 0) {
+    if (asserted.length === 0) return { kind: "unchanged" };
+    // Today's existing gap (documented, not introduced here): a fresh
+    // assertion for an already-present pair with NO accompanying retraction
+    // is not detected as a race at plan time — see `planIdentityThreeWay`'s
+    // race detector, which only fires when a retraction is staged. Preserved
+    // verbatim so the default policy stays byte-identical.
+    const { survivor, superseded, rule } =
+      asserted.length === 1 ?
+        {
+          survivor: requireDefined(asserted[0]),
+          superseded: [],
+          rule: "code-point-id" as const,
+        }
+      : reduceIdentitySurvivor(asserted, committedIds);
+    return {
+      kind: "asserted",
+      survivor: survivor.assertion,
+      superseded,
+      reconciliation: buildReconciliation(
+        semanticKey,
+        asserted,
+        survivor,
+        superseded,
+        rule,
+        policy,
+      ),
+    };
+  }
+
+  if (asserted.length === 0) {
+    const retraction = reduceIdentityRetraction(retracted);
+    return { kind: "retracted", retraction: retraction.assertion };
+  }
+
+  // Convergent: at least one branch retracted AND (the same or another)
+  // branch reasserted — but this call is only reached for pairs
+  // `planIdentityThreeWay` did NOT classify as a cross-branch race, so every
+  // reassertion here is accompanied by SOME branch's own retraction of the
+  // pair. `planIdentityThreeWay` itself attaches the base row's ending (at
+  // the retraction's own honest instant — nothing here is a policy question)
+  // once it sees this outcome alongside a non-empty `retracted` group.
+  const { survivor, superseded, rule } =
+    asserted.length === 1 ?
+      {
+        survivor: requireDefined(asserted[0]),
+        superseded: [],
+        rule: "code-point-id" as const,
+      }
+    : reduceIdentitySurvivor(asserted, committedIds);
+  return {
+    kind: "asserted",
+    survivor: survivor.assertion,
+    superseded,
+    reconciliation: buildReconciliation(
+      semanticKey,
+      asserted,
+      survivor,
+      superseded,
+      rule,
+      policy,
+    ),
+  };
+}
+
+/**
+ * The plan-time result of three-way classifying every staged identity pair:
+ * every arm's assertions/retractions on one side, and the two forms of
+ * VISIBILITY the classifier adds beyond today's plain refuse-or-apply
+ * behavior — resolved duplicate reconciliations and conflicts a `"flag"`
+ * policy chose to keep rather than refuse.
+ */
+export type IdentityThreeWayResult = Readonly<{
+  assertions: readonly IdentityTransferAssertion[];
+  retractions: readonly IdentityTransferAssertion[];
+  dropped: readonly DroppedItem[];
+  reconciliations: readonly IdentityReconciliation[];
+  unresolved: readonly IdentityUnresolvedConflict[];
+}>;
+
+/** Applies `policy` to a fully-populated conflict, honoring every arm. */
+function resolveConflict(
+  conflict: IdentityAssertionConflict,
+  policy: IdentityAssertionConflictPolicy,
+  refuse: () => never,
+): IdentityAssertionDecision {
+  if (policy === "refuse") refuse();
+  if (policy === "flag") return { kind: "unresolved" };
+  if (policy === "assertWins" || policy === "retractWins") {
+    if (conflict.reason !== "retract-reassert") {
+      throw new InvalidMergeOptionsError(
+        `onAssertionConflict: ${JSON.stringify(policy)} only arbitrates a retract/reassert race; this conflict has no assert/retract axis to decide (reason: ${conflict.reason}).`,
+        {
+          details: {
+            option: "onAssertionConflict",
+            policy,
+            reason: conflict.reason,
+          },
+        },
+      );
+    }
+    if (policy === "assertWins") {
+      const winner = conflict.asserted[0];
+      if (winner === undefined) return { kind: "retract" };
+      return { kind: "assert", assertionId: winner.assertion.id };
+    }
+    return { kind: "retract" };
+  }
+  const decision = policy(conflict);
+  if (
+    decision.kind === "assert" &&
+    !conflict.asserted.some(
+      (staged) => staged.assertion.id === decision.assertionId,
+    )
+  ) {
+    throw new InvalidMergeOptionsError(
+      `onAssertionConflict's callback returned an assertion id ${JSON.stringify(decision.assertionId)} that was never staged for this conflict.`,
+      {
+        details: {
+          option: "onAssertionConflict",
+          assertionId: decision.assertionId,
+        },
+      },
+    );
+  }
+  return decision;
+}
+
+/**
+ * Detects OPPOSING-RELATIONS collisions: branches asserted BOTH `same` and
+ * `different` for one endpoint pair with overlapping validity windows. Spans
+ * two semantic keys (one per relation) sharing an endpoint pair, so it is
+ * detected once, up front, over every staged new assertion — exactly the
+ * scope `assertNoOpposingIdentityRelations` always had.
+ */
+type OpposingRelationsGroup = Readonly<{
+  sameKey: string;
+  differentKey: string;
+  a: EntityRef;
+  b: EntityRef;
+  same: readonly StagedIdentityAssertion[];
+  different: readonly StagedIdentityAssertion[];
+}>;
+
+function detectOpposingRelationsConflicts(
+  staging: StagingSet,
+): readonly OpposingRelationsGroup[] {
+  const byEndpoint = new Map<string, StagedIdentityAssertion[]>();
+  for (const staged of staging.newIdentityAssertions) {
+    const key = pairEndpointKey({
+      a: entityRefOf(staged.assertion.a),
+      b: entityRefOf(staged.assertion.b),
+    });
+    const group = byEndpoint.get(key) ?? [];
+    group.push(staged);
+    byEndpoint.set(key, group);
+  }
+  const conflicts: OpposingRelationsGroup[] = [];
+  for (const group of byEndpoint.values()) {
+    const same = group.filter((staged) => staged.assertion.relation === "same");
+    const different = group.filter(
+      (staged) => staged.assertion.relation === "different",
+    );
+    const overlaps = same.some((sameStaged) =>
+      different.some((differentStaged) =>
+        identityValidityWindowsOverlap(
+          sameStaged.assertion,
+          differentStaged.assertion,
+        ),
+      ),
+    );
+    if (!overlaps) continue;
+    const anchor = requireDefined(group[0]);
+    conflicts.push({
+      sameKey: identitySemanticKey({ ...anchor.assertion, relation: "same" }),
+      differentKey: identitySemanticKey({
+        ...anchor.assertion,
+        relation: "different",
+      }),
+      a: entityRefOf(anchor.assertion.a),
+      b: entityRefOf(anchor.assertion.b),
+      same,
+      different,
+    });
+  }
+  return conflicts;
+}
+
+/**
+ * Detects a RETRACT/REASSERT RACE: one branch retracts a pair's committed
+ * truth while a DIFFERENT branch reasserts that pair under a new id WITHOUT
+ * also retracting it. Exactly `assertNoRetractReassertRace`'s scope: a branch
+ * that retracts AND reasserts the same pair itself is convergent, not a race.
+ */
+function detectRetractReassertRaces(staging: StagingSet): ReadonlyMap<
+  string,
+  Readonly<{
+    retracted: readonly StagedRetraction[];
+    asserted: readonly StagedIdentityAssertion[];
+  }>
+> {
+  const retractedBySemantic = new Map<string, StagedRetraction[]>();
+  for (const staged of staging.retractedIdentityAssertions) {
+    const key = identitySemanticKey(staged.assertion);
+    const group = retractedBySemantic.get(key) ?? [];
+    group.push(staged);
+    retractedBySemantic.set(key, group);
+  }
+  const races = new Map<
+    string,
+    { retracted: StagedRetraction[]; asserted: StagedIdentityAssertion[] }
+  >();
+  for (const staged of staging.newIdentityAssertions) {
+    const semanticKey = identitySemanticKey(staged.assertion);
+    const retractions = retractedBySemantic.get(semanticKey) ?? [];
+    const selfRetracted = retractions.some(
+      (retraction) => retraction.branchId === staged.branchId,
+    );
+    if (selfRetracted) continue;
+    const crossBranchRetractions = retractions.filter(
+      (retraction) => retraction.assertion.id !== staged.assertion.id,
+    );
+    if (crossBranchRetractions.length === 0) continue;
+    const race = races.get(semanticKey) ?? { retracted: [], asserted: [] };
+    for (const retraction of crossBranchRetractions) {
+      if (!race.retracted.includes(retraction)) race.retracted.push(retraction);
+    }
+    race.asserted.push(staged);
+    races.set(semanticKey, race);
+  }
+  return races;
+}
+
+/**
+ * Three-way classifies every staged identity pair against the staged base
+ * slice: absorbs `dedupeIdentityAssertions`, `assertNoOpposingIdentityRelations`,
+ * and `assertNoRetractReassertRace` into arms of ONE classifier, keyed by the
+ * `IdentityAssertionConflictPolicy` a caller may supply. Under the default
+ * `"refuse"` policy every arm reproduces today's behavior byte-for-byte —
+ * same thrown errors, same drop reasons, same survivor rule.
+ */
+export function planIdentityThreeWay(
+  staging: StagingSet,
+  policy: IdentityAssertionConflictPolicy,
+  committedIds: ReadonlySet<string>,
+): IdentityThreeWayResult {
+  const assertions: IdentityTransferAssertion[] = [];
+  const retractions: IdentityTransferAssertion[] = [];
+  const dropped: DroppedItem[] = [];
+  const reconciliations: IdentityReconciliation[] = [];
+  const unresolved: IdentityUnresolvedConflict[] = [];
+
+  const refuseOpposing = (
+    same: StagedIdentityAssertion,
+    different: StagedIdentityAssertion,
+    endpoint: string,
+  ): never => {
+    throw new IdentityMergeConflictError(
+      "Branches asserted opposing identity relations for one endpoint pair.",
+      {
+        details: {
+          endpoint,
+          assertions: [same.assertion, different.assertion],
+        },
+      },
+    );
+  };
+
+  const opposing = detectOpposingRelationsConflicts(staging);
+  const handledOpposingKeys = new Set<string>();
+  for (const group of opposing) {
+    const semanticKey = group.sameKey;
+    handledOpposingKeys.add(group.sameKey);
+    handledOpposingKeys.add(group.differentKey);
+    const endpoint = pairEndpointKey(group);
+    const anchorSame = group.same[0];
+    const anchorDifferent = group.different[0];
+    const conflict: IdentityAssertionConflict = {
+      reason: "opposing-relations",
+      semanticKey,
+      a: group.a,
+      b: group.b,
+      relation: "same",
+      base: [],
+      asserted: [...group.same, ...group.different],
+      retracted: [],
+    };
+    const decision = resolveConflict(conflict, policy, () =>
+      refuseOpposing(
+        requireDefined(anchorSame),
+        requireDefined(anchorDifferent),
+        endpoint,
+      ),
+    );
+    if (decision.kind === "unresolved") {
+      unresolved.push({
+        kind: "assertion",
+        reason: "opposing-relations",
+        semanticKey,
+        a: group.a,
+        b: group.b,
+        relation: "same",
+        assertionIds: conflict.asserted.map((staged) => staged.assertion.id),
+        branches: [
+          ...new Set(conflict.asserted.map((staged) => staged.branchId)),
+        ].toSorted(compareStrings),
+      });
+      continue;
+    }
+    if (decision.kind === "retract") {
+      for (const staged of conflict.asserted) {
+        dropped.push(
+          droppedIdentityAssertion(
+            staged.assertion,
+            REASSERT_OVERRULED_DROP_REASON,
+          ),
+        );
+      }
+      continue;
+    }
+    const winner = requireDefined(
+      conflict.asserted.find(
+        (staged) => staged.assertion.id === decision.assertionId,
+      ),
+    );
+    assertions.push(winner.assertion);
+    for (const staged of conflict.asserted) {
+      if (staged.assertion.id === winner.assertion.id) continue;
+      dropped.push(
+        droppedIdentityAssertion(
+          staged.assertion,
+          REASSERT_OVERRULED_DROP_REASON,
+        ),
+      );
+    }
+  }
+
+  const races = detectRetractReassertRaces(staging);
+  const handledRaceKeys = new Set(races.keys());
+  for (const [semanticKey, race] of races) {
+    const anchor = race.retracted[0] ?? race.asserted[0];
+    const anchorAssertion = (
+      anchor as StagedIdentityAssertion | StagedRetraction
+    ).assertion;
+    const conflict: IdentityAssertionConflict = {
+      reason: "retract-reassert",
+      semanticKey,
+      a: entityRefOf(anchorAssertion.a),
+      b: entityRefOf(anchorAssertion.b),
+      relation: anchorAssertion.relation,
+      base: [],
+      asserted: race.asserted,
+      retracted: race.retracted,
+    };
+    const refuseRace = (): never => {
+      const retraction = requireDefined(race.retracted[0]);
+      const reassertion = requireDefined(race.asserted[0]);
+      throw new IdentityMergeConflictError(
+        "Branches contain a retract/reassert race for one identity pair.",
+        {
+          details: {
+            retractedAssertion: retraction.assertion,
+            retractedBy: retraction.branchId,
+            reassertedAssertion: reassertion.assertion,
+            reassertedBy: reassertion.branchId,
+          },
+        },
+      );
+    };
+    const decision = resolveConflict(conflict, policy, refuseRace);
+    if (decision.kind === "unresolved") {
+      unresolved.push({
+        kind: "assertion",
+        reason: "retract-reassert",
+        semanticKey,
+        a: conflict.a,
+        b: conflict.b,
+        relation: conflict.relation,
+        assertionIds: [
+          ...race.retracted.map((staged) => staged.assertion.id),
+          ...race.asserted.map((staged) => staged.assertion.id),
+        ],
+        branches: [
+          ...new Set([
+            ...race.retracted.map((staged) => staged.branchId),
+            ...race.asserted.map((staged) => staged.branchId),
+          ]),
+        ].toSorted(compareStrings),
+      });
+      continue;
+    }
+    if (decision.kind === "retract") {
+      const retraction = reduceIdentityRetraction(race.retracted);
+      retractions.push(retraction.assertion);
+      for (const staged of race.asserted) {
+        dropped.push(
+          droppedIdentityAssertion(
+            staged.assertion,
+            REASSERT_OVERRULED_DROP_REASON,
+          ),
+        );
+      }
+      continue;
+    }
+    const winner = requireDefined(
+      race.asserted.find(
+        (staged) => staged.assertion.id === decision.assertionId,
+      ),
+    );
+    assertions.push(winner.assertion);
+    for (const staged of race.asserted) {
+      if (staged.assertion.id === winner.assertion.id) continue;
+      dropped.push(
+        droppedIdentityAssertion(
+          staged.assertion,
+          REASSERT_OVERRULED_DROP_REASON,
+        ),
+      );
+    }
+    for (const staged of race.retracted) {
+      dropped.push(
+        droppedIdentityAssertion(
+          staged.assertion,
+          RETRACT_OVERRULED_DROP_REASON,
+        ),
+      );
+    }
+    retractions.push({
+      ...requireDefined(race.retracted[0]).assertion,
+      validTo: winner.assertion.validFrom,
+    });
+  }
+
+  const baseByDedupe = new Map<string, IdentityTransferAssertion[]>();
+  const baseIdToDedupeKey = new Map<string, string>();
+  for (const assertion of staging.baseIdentityAssertions) {
+    const key = identityDedupeKey(assertion);
+    const group = baseByDedupe.get(key) ?? [];
+    group.push(assertion);
+    baseByDedupe.set(key, group);
+    baseIdToDedupeKey.set(assertion.id, key);
+  }
+  const assertedByDedupe = new Map<string, StagedIdentityAssertion[]>();
+  for (const staged of staging.newIdentityAssertions) {
+    const semanticKey = identitySemanticKey(staged.assertion);
+    if (handledOpposingKeys.has(semanticKey)) continue;
+    if (handledRaceKeys.has(semanticKey)) continue;
+    const key = identityDedupeKey(staged.assertion);
+    const group = assertedByDedupe.get(key) ?? [];
+    group.push(staged);
+    assertedByDedupe.set(key, group);
+  }
+  const retractedByDedupe = new Map<string, StagedRetraction[]>();
+  for (const staged of staging.retractedIdentityAssertions) {
+    if (handledRaceKeys.has(identitySemanticKey(staged.assertion))) continue;
+    const key = baseIdToDedupeKey.get(staged.assertion.id);
+    if (key === undefined) continue; // orphan: `planIdentityChanges` re-validates by id.
+    const group = retractedByDedupe.get(key) ?? [];
+    group.push(staged);
+    retractedByDedupe.set(key, group);
+  }
+
+  const groupKeys = new Set<string>([
+    ...baseByDedupe.keys(),
+    ...assertedByDedupe.keys(),
+  ]);
+  for (const groupKey of groupKeys) {
+    const base = baseByDedupe.get(groupKey) ?? [];
+    const asserted = assertedByDedupe.get(groupKey) ?? [];
+    const retracted = retractedByDedupe.get(groupKey) ?? [];
+    const anchor = base[0] ?? asserted[0]?.assertion;
+    if (anchor === undefined) continue;
+    const semanticKey = identitySemanticKey(anchor);
+    const outcome = classifyIdentityPair(
+      semanticKey,
+      base,
+      asserted,
+      retracted,
+      policy,
+      committedIds,
+    );
+    if (outcome.kind === "unchanged") continue;
+    if (outcome.kind === "asserted") {
+      assertions.push(outcome.survivor);
+      dropped.push(...outcome.superseded);
+      if (outcome.reconciliation !== undefined) {
+        reconciliations.push(outcome.reconciliation);
+      }
+      // CONVERGENT case: base is present and SOME branch retracted it (not a
+      // race — races are excluded from this loop above) while a reassertion
+      // also survived. The base row must still end, at its own honestly
+      // staged instant — nothing here is a policy question, unlike the
+      // race's overruled ending.
+      if (retracted.length > 0) {
+        retractions.push(reduceIdentityRetraction(retracted).assertion);
+      }
+      continue;
+    }
+    if (outcome.kind === "retracted") {
+      retractions.push(outcome.retraction);
+      continue;
+    }
+    // Unreachable today: `classifyIdentityPair` only returns `"unresolved"`
+    // for a conflict, and both conflict-producing shapes (opposing-relations,
+    // retract-reassert) are detected and resolved BEFORE this loop runs, so
+    // no group reaching here can still be conflicted. Converted defensively
+    // rather than asserted away, so a future arm that DOES return one here
+    // degrades to a typed report entry instead of a silent drop.
+    const { conflict } = outcome;
+    unresolved.push({
+      kind: "assertion",
+      reason: conflict.reason,
+      semanticKey: conflict.semanticKey,
+      a: conflict.a,
+      b: conflict.b,
+      relation: conflict.relation,
+      assertionIds: [
+        ...conflict.asserted.map((staged) => staged.assertion.id),
+        ...conflict.retracted.map((staged) => staged.assertion.id),
+      ],
+      branches: [
+        ...new Set([
+          ...conflict.asserted.map((staged) => staged.branchId),
+          ...conflict.retracted.map((staged) => staged.branchId),
+        ]),
+      ].toSorted(compareStrings),
+    });
+  }
+
+  return {
+    assertions,
+    retractions,
+    dropped,
+    reconciliations,
+    unresolved,
+  };
 }

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -4,9 +4,16 @@
  * three separate inline arbitrations in `merge-identity.ts` —
  * `dedupeIdentityAssertions`, `assertNoOpposingIdentityRelations`, and
  * `assertNoRetractReassertRace`. Every arm keeps today's behavior verbatim
- * under the default `"refuse"` policy; a caller-supplied resolving policy
- * (`"assertWins"` / `"retractWins"` / `"flag"` / a function) turns a subset of
- * those refusals into a recorded resolution instead of a thrown error.
+ * under the default `"refuse"` policy, WITH ONE DECLARED EXCEPTION: when two
+ * branches end the same base identity assertion at different valid-time
+ * instants, {@link reduceIdentityRetraction} now picks the EARLIEST staged
+ * `validTo` — deterministic and order-independent — where the inline code it
+ * replaced let whichever retraction was staged LAST win, a branch-order
+ * dependency no caller could rely on. See "ending a doubly-retracted base row
+ * picks the EARLIEST end" in `identity-three-way.test.ts`. A caller-supplied
+ * resolving policy (`"assertWins"` / `"retractWins"` / `"flag"` / a function)
+ * turns a subset of the classifier's refusals into a recorded resolution
+ * instead of a thrown error.
  *
  * Extracted out of `merge-identity.ts` so both the plan-time dedupe and the
  * post-remap re-dedupe it runs after endpoint canonicalization call the SAME
@@ -162,6 +169,16 @@ export const DUPLICATE_IDENTITY_ASSERTION_DROP_REASON =
  * branch's re-assertion of a pair another branch retracted.
  */
 export const REASSERT_OVERRULED_DROP_REASON = "identity:reassert-overruled";
+
+/**
+ * Reason recorded when a resolving policy overruled one side of an
+ * `"opposing-relations"` conflict (branches asserted BOTH `same` and
+ * `different` for one pair with overlapping windows) — a distinct shape from
+ * `REASSERT_OVERRULED_DROP_REASON`'s retract/reassert race, since nothing here
+ * was reasserted: the policy chose one relation over the other.
+ */
+export const OPPOSING_RELATIONS_OVERRULED_DROP_REASON =
+  "identity:opposing-relations-overruled";
 
 /**
  * Reason recorded when an `"assertWins"`/function resolution overruled a
@@ -783,7 +800,9 @@ function detectRetractReassertRaces(staging: StagingSet): ReadonlyMap<
  * and `assertNoRetractReassertRace` into arms of ONE classifier, keyed by the
  * `IdentityAssertionConflictPolicy` a caller may supply. Under the default
  * `"refuse"` policy every arm reproduces today's behavior byte-for-byte —
- * same thrown errors, same drop reasons, same survivor rule.
+ * same thrown errors, same drop reasons, same survivor rule — EXCEPT the
+ * doubly-retracted-base-row ending, which now picks the earliest staged end
+ * rather than the last one staged (module docblock above).
  */
 export function planIdentityThreeWay(
   staging: StagingSet,
@@ -795,6 +814,20 @@ export function planIdentityThreeWay(
   const dropped: DroppedItem[] = [];
   const reconciliations: IdentityReconciliation[] = [];
   const unresolved: IdentityUnresolvedConflict[] = [];
+
+  // Base truth for every semantic pair, so a conflict can hand a resolving
+  // policy the ROW ONE BRANCH RACED AGAINST — a race by definition has a base
+  // row, and `IdentityAssertionConflict.base` is public callback input
+  // documented as exactly that. Built once here (rather than left to the
+  // later `baseByDedupe` grouping, which splits a bounded assertion further
+  // by window and would under-populate a conflict that spans several windows).
+  const baseBySemanticKey = new Map<string, IdentityTransferAssertion[]>();
+  for (const assertion of staging.baseIdentityAssertions) {
+    const key = identitySemanticKey(assertion);
+    const group = baseBySemanticKey.get(key) ?? [];
+    group.push(assertion);
+    baseBySemanticKey.set(key, group);
+  }
 
   const refuseOpposing = (
     same: StagedIdentityAssertion,
@@ -827,7 +860,10 @@ export function planIdentityThreeWay(
       a: group.a,
       b: group.b,
       relation: "same",
-      base: [],
+      base: [
+        ...(baseBySemanticKey.get(group.sameKey) ?? []),
+        ...(baseBySemanticKey.get(group.differentKey) ?? []),
+      ],
       asserted: [...group.same, ...group.different],
       retracted: [],
     };
@@ -858,7 +894,7 @@ export function planIdentityThreeWay(
         dropped.push(
           droppedIdentityAssertion(
             staged.assertion,
-            REASSERT_OVERRULED_DROP_REASON,
+            OPPOSING_RELATIONS_OVERRULED_DROP_REASON,
           ),
         );
       }
@@ -886,7 +922,7 @@ export function planIdentityThreeWay(
       dropped.push(
         droppedIdentityAssertion(
           staged.assertion,
-          REASSERT_OVERRULED_DROP_REASON,
+          OPPOSING_RELATIONS_OVERRULED_DROP_REASON,
         ),
       );
     }
@@ -915,7 +951,7 @@ export function planIdentityThreeWay(
       a: entityRefOf(anchorAssertion.a),
       b: entityRefOf(anchorAssertion.b),
       relation: anchorAssertion.relation,
-      base: [],
+      base: baseBySemanticKey.get(semanticKey) ?? [],
       asserted: race.asserted,
       retracted: race.retracted,
     };
@@ -1007,8 +1043,13 @@ export function planIdentityThreeWay(
         ),
       );
     }
+    // The same survivor rule the `retract` decision above uses for its base
+    // row, not raw staging order (R7): a race whose base row two branches
+    // retracted must pick the SAME base row here, under `assertWins`, that
+    // `retractWins`/the plain-retraction path would pick for the identical
+    // fixture — only the ending instant differs (the winner's own start).
     retractions.push({
-      ...requireDefined(race.retracted[0]).assertion,
+      ...reduceIdentityRetraction(race.retracted).assertion,
       validTo: winner.assertion.validFrom,
     });
     reconciliations.push(

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -43,7 +43,7 @@ import type {
  * Two assertions sharing this key describe the same claim about the same
  * pair, whatever window each one carries.
  */
-export function identitySemanticKey(
+function identitySemanticKey(
   assertion: IdentityTransferAssertion,
 ): string {
   return identityAssertionSemanticKey(
@@ -76,7 +76,7 @@ export function identityDedupeKey(
  * (an id the target already holds with the exact staged truth always wins
  * regardless of this order) apply it before falling back to this comparator.
  */
-export function compareIdentitySurvivors(
+function compareIdentitySurvivors(
   left: IdentityTransferAssertion,
   right: IdentityTransferAssertion,
 ): number {

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -1044,7 +1044,7 @@ export function planIdentityThreeWay(
       );
     }
     // The same survivor rule the `retract` decision above uses for its base
-    // row, not raw staging order (R7): a race whose base row two branches
+    // row, not raw staging order: a race whose base row two branches
     // retracted must pick the SAME base row here, under `assertWins`, that
     // `retractWins`/the plain-retraction path would pick for the identical
     // fixture — only the ending instant differs (the winner's own start).

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -43,9 +43,7 @@ import type {
  * Two assertions sharing this key describe the same claim about the same
  * pair, whatever window each one carries.
  */
-function identitySemanticKey(
-  assertion: IdentityTransferAssertion,
-): string {
+function identitySemanticKey(assertion: IdentityTransferAssertion): string {
   return identityAssertionSemanticKey(
     assertion.relation,
     assertion.a,

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -1,0 +1,65 @@
+/**
+ * The identity survivor rule and semantic pair key: the ONE place that decides
+ * which of several colliding identity assertions survives a merge, and the
+ * ONE place that computes the semantic key two assertions are compared under.
+ *
+ * Extracted out of `merge-identity.ts` so both the plan-time dedupe
+ * (`merge-identity.ts`) and the post-remap re-dedupe it runs after endpoint
+ * canonicalization call the SAME comparator — a second inline copy of the
+ * survivor rule is exactly the kind of decision this repository's contract
+ * discipline forbids re-spelling.
+ */
+import { identityAssertionSemanticKey } from "../identity/assertion-key";
+import { encodeTupleKey } from "../utils/tuple-key";
+import {
+  compareCodePoints,
+  type IdentityTransferAssertion,
+} from "./typegraph-internal";
+
+/**
+ * The semantic key two identity assertions are compared under: the relation
+ * plus the code-point-normalized endpoint pair, WITHOUT the validity window.
+ * Two assertions sharing this key describe the same claim about the same
+ * pair, whatever window each one carries.
+ */
+export function identitySemanticKey(
+  assertion: IdentityTransferAssertion,
+): string {
+  return identityAssertionSemanticKey(
+    assertion.relation,
+    assertion.a,
+    assertion.b,
+  );
+}
+
+/**
+ * The WINDOW-AWARE dedupe key: the semantic key, further split by validity
+ * window for a BOUNDED assertion (one with a `validTo`). An unbounded
+ * (current) assertion dedupes purely on the semantic key — there is only ever
+ * one "current" truth for a pair — while two branches asserting the SAME
+ * bounded window are treated as the same claim and two DIFFERENT bounded
+ * windows are kept distinct.
+ */
+export function identityDedupeKey(
+  assertion: IdentityTransferAssertion,
+): string {
+  const semantic = identitySemanticKey(assertion);
+  if (assertion.validTo === undefined) return semantic;
+  return encodeTupleKey([semantic, assertion.validFrom, assertion.validTo]);
+}
+
+/**
+ * Orders two colliding identity assertions so the caller can pick a
+ * deterministic survivor: earliest `validFrom` wins, and a tie breaks on the
+ * assertion id's code-point order. Callers needing the COMMITTED-id override
+ * (an id the target already holds with the exact staged truth always wins
+ * regardless of this order) apply it before falling back to this comparator —
+ * see `merge-identity.ts`'s `dedupeIdentityAssertions`.
+ */
+export function compareIdentitySurvivors(
+  left: IdentityTransferAssertion,
+  right: IdentityTransferAssertion,
+): number {
+  const byValidity = compareCodePoints(left.validFrom, right.validFrom);
+  return byValidity === 0 ? compareCodePoints(left.id, right.id) : byValidity;
+}

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -496,6 +496,43 @@ export function assertNoOpposingIdentityRelationsRaw(
 }
 
 /**
+ * The `"asserted"` outcome for a pair with at least one surviving assertion:
+ * reduces to one survivor (skipping the reduction machinery entirely when
+ * there is nothing to reduce) and attaches whatever reconciliation the
+ * survivor pick earns. The one place `classifyIdentityPair`'s three
+ * asserted-outcome arms (base absent, retracted-empty, convergent) reduce
+ * through, so they cannot drift on how a survivor is picked or reported.
+ */
+function assertedOutcome(
+  semanticKey: string,
+  asserted: readonly StagedIdentityAssertion[],
+  committedIds: ReadonlySet<string>,
+  policy: IdentityAssertionConflictPolicy,
+): IdentityPairOutcome {
+  const { survivor, superseded, rule } =
+    asserted.length === 1 ?
+      {
+        survivor: requireDefined(asserted[0]),
+        superseded: [] as readonly DroppedItem[],
+        rule: "code-point-id" as const,
+      }
+    : reduceIdentitySurvivor(asserted, committedIds);
+  return {
+    kind: "asserted",
+    survivor: survivor.assertion,
+    superseded,
+    reconciliation: buildReconciliation(
+      semanticKey,
+      asserted,
+      survivor,
+      superseded,
+      rule,
+      policy,
+    ),
+  };
+}
+
+/**
  * Classifies one identity pair — one semantic key, one validity window —
  * against the staged base slice. `base` is the target's CURRENT truth for
  * this pair at staging time (empty when the pair has none); `asserted` /
@@ -528,30 +565,7 @@ export function classifyIdentityPair(
 ): IdentityPairOutcome {
   if (base.length === 0) {
     if (asserted.length === 0) return { kind: "unchanged" };
-    if (asserted.length === 1) {
-      return {
-        kind: "asserted",
-        survivor: requireDefined(asserted[0]).assertion,
-        superseded: [],
-      };
-    }
-    const { survivor, superseded, rule } = reduceIdentitySurvivor(
-      asserted,
-      committedIds,
-    );
-    return {
-      kind: "asserted",
-      survivor: survivor.assertion,
-      superseded,
-      reconciliation: buildReconciliation(
-        semanticKey,
-        asserted,
-        survivor,
-        superseded,
-        rule,
-        policy,
-      ),
-    };
+    return assertedOutcome(semanticKey, asserted, committedIds, policy);
   }
 
   if (retracted.length === 0) {
@@ -561,27 +575,7 @@ export function classifyIdentityPair(
     // is not detected as a race at plan time — see `planIdentityThreeWay`'s
     // race detector, which only fires when a retraction is staged. Preserved
     // verbatim so the default policy stays byte-identical.
-    const { survivor, superseded, rule } =
-      asserted.length === 1 ?
-        {
-          survivor: requireDefined(asserted[0]),
-          superseded: [],
-          rule: "code-point-id" as const,
-        }
-      : reduceIdentitySurvivor(asserted, committedIds);
-    return {
-      kind: "asserted",
-      survivor: survivor.assertion,
-      superseded,
-      reconciliation: buildReconciliation(
-        semanticKey,
-        asserted,
-        survivor,
-        superseded,
-        rule,
-        policy,
-      ),
-    };
+    return assertedOutcome(semanticKey, asserted, committedIds, policy);
   }
 
   if (asserted.length === 0) {
@@ -596,27 +590,7 @@ export function classifyIdentityPair(
   // pair. `planIdentityThreeWay` itself attaches the base row's ending (at
   // the retraction's own honest instant — nothing here is a policy question)
   // once it sees this outcome alongside a non-empty `retracted` group.
-  const { survivor, superseded, rule } =
-    asserted.length === 1 ?
-      {
-        survivor: requireDefined(asserted[0]),
-        superseded: [],
-        rule: "code-point-id" as const,
-      }
-    : reduceIdentitySurvivor(asserted, committedIds);
-  return {
-    kind: "asserted",
-    survivor: survivor.assertion,
-    superseded,
-    reconciliation: buildReconciliation(
-      semanticKey,
-      asserted,
-      survivor,
-      superseded,
-      rule,
-      policy,
-    ),
-  };
+  return assertedOutcome(semanticKey, asserted, committedIds, policy);
 }
 
 /**

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -43,7 +43,9 @@ import type {
  * Two assertions sharing this key describe the same claim about the same
  * pair, whatever window each one carries.
  */
-function identitySemanticKey(assertion: IdentityTransferAssertion): string {
+export function identitySemanticKey(
+  assertion: IdentityTransferAssertion,
+): string {
   return identityAssertionSemanticKey(
     assertion.relation,
     assertion.a,

--- a/packages/typegraph/src/graph-merge/identity-three-way.ts
+++ b/packages/typegraph/src/graph-merge/identity-three-way.ts
@@ -84,6 +84,72 @@ function compareIdentitySurvivors(
   return byValidity === 0 ? compareCodePoints(left.id, right.id) : byValidity;
 }
 
+/** Why one identity assertion beat the one it displaced. */
+type IdentitySurvivorRule = IdentityReconciliation["rule"];
+
+/**
+ * THE survivor decision for two identity assertions describing one semantic
+ * pair, and the only place the committed-id override, the comparator and the
+ * rule label are spelled. Every path that must choose between two colliding
+ * assertions — the staged classifier, the post-remap re-dedupe, and a
+ * resolving policy's `assertWins` arm — reduces through this one function, so
+ * no caller can spell a survivor rule of its own and drift from the rest.
+ *
+ * An id the target ALREADY holds with the exact staged truth always wins: the
+ * applier is idempotent per semantic pair, so a freshly minted branch id could
+ * never displace the target's committed row, and choosing it would report an
+ * id as applied that is never written while listing the target's own row as
+ * dropped.
+ */
+function pickIdentitySurvivor<
+  T extends Readonly<{ assertion: IdentityTransferAssertion }>,
+>(
+  candidate: T,
+  incumbent: T,
+  committedIds: ReadonlySet<string>,
+): Readonly<{ winner: T; loser: T; rule: IdentitySurvivorRule }> {
+  const candidateCommitted = committedIds.has(candidate.assertion.id);
+  const incumbentCommitted = committedIds.has(incumbent.assertion.id);
+  if (candidateCommitted !== incumbentCommitted) {
+    const [winner, loser] =
+      candidateCommitted ?
+        ([candidate, incumbent] as const)
+      : ([incumbent, candidate] as const);
+    return { winner, loser, rule: "committed-id" };
+  }
+  const rule: IdentitySurvivorRule =
+    (
+      compareCodePoints(
+        candidate.assertion.validFrom,
+        incumbent.assertion.validFrom,
+      ) === 0
+    ) ?
+      "code-point-id"
+    : "earliest-valid-from";
+  const [winner, loser] =
+    compareIdentitySurvivors(candidate.assertion, incumbent.assertion) < 0 ?
+      ([candidate, incumbent] as const)
+    : ([incumbent, candidate] as const);
+  return { winner, loser, rule };
+}
+
+/**
+ * Whether the loser is the very row that won: the same id carrying the same
+ * complete truth. Two branches staging the IDENTICAL row collapse silently —
+ * reporting one as dropped while it is the row applied would make the report
+ * self-contradictory.
+ */
+function isIdenticalIdentityRow(
+  left: IdentityTransferAssertion,
+  right: IdentityTransferAssertion,
+): boolean {
+  return (
+    left.id === right.id &&
+    left.validFrom === right.validFrom &&
+    (left.validTo ?? undefined) === (right.validTo ?? undefined)
+  );
+}
+
 /**
  * Reason recorded when two branches asserted the SAME semantic pair and the
  * survivor rule kept only one of the two assertion ids.
@@ -203,47 +269,21 @@ function reduceIdentitySurvivor(
   survivor: StagedIdentityAssertion;
   superseded: readonly DroppedItem[];
   /** Why the final survivor beat the last candidate it displaced. */
-  rule: IdentityReconciliation["rule"];
+  rule: IdentitySurvivorRule;
 }> {
   const [first, ...rest] = candidates;
   let survivor = requireDefined(first);
-  let rule: IdentityReconciliation["rule"] = "code-point-id";
+  let rule: IdentitySurvivorRule = "code-point-id";
   const superseded: DroppedItem[] = [];
   for (const candidate of rest) {
-    const candidateCommitted = committedIds.has(candidate.assertion.id);
-    const survivorCommitted = committedIds.has(survivor.assertion.id);
-    if (candidateCommitted === survivorCommitted) {
-      rule =
-        (
-          compareCodePoints(
-            candidate.assertion.validFrom,
-            survivor.assertion.validFrom,
-          ) === 0
-        ) ?
-          "code-point-id"
-        : "earliest-valid-from";
-    } else {
-      rule = "committed-id";
-    }
-    const [winner, loser] =
-      candidateCommitted === survivorCommitted ?
-        compareIdentitySurvivors(candidate.assertion, survivor.assertion) < 0 ?
-          [candidate, survivor]
-        : [survivor, candidate]
-      : candidateCommitted ? [candidate, survivor]
-      : [survivor, candidate];
-    survivor = winner;
-    if (
-      loser.assertion.id === winner.assertion.id &&
-      loser.assertion.validFrom === winner.assertion.validFrom &&
-      (loser.assertion.validTo ?? undefined) ===
-        (winner.assertion.validTo ?? undefined)
-    ) {
+    const picked = pickIdentitySurvivor(candidate, survivor, committedIds);
+    survivor = picked.winner;
+    rule = picked.rule;
+    if (isIdenticalIdentityRow(picked.loser.assertion, picked.winner.assertion))
       continue;
-    }
     superseded.push(
       droppedIdentityAssertion(
-        loser.assertion,
+        picked.loser.assertion,
         DUPLICATE_IDENTITY_ASSERTION_DROP_REASON,
       ),
     );
@@ -299,6 +339,48 @@ function buildReconciliation(
 }
 
 /**
+ * The label a resolved conflict records for the arm that decided it. A
+ * function policy is recorded as `"callback"` — its source is never part of
+ * the plan artifact, exactly as `reviewOptionEvidence` encodes it.
+ */
+function identityPolicyLabel(policy: IdentityAssertionConflictPolicy): string {
+  return typeof policy === "function" ? "callback" : policy;
+}
+
+/**
+ * The {@link IdentityReconciliation} a RESOLVING POLICY produced for one
+ * conflict — the only path that sets `rule: "policy"`, and therefore the only
+ * source of `IdentityDecisionProvenance.policy`. A merge whose conflicts were
+ * all resolved by rule (or refused) records no policy string it did not
+ * exercise.
+ */
+function policyReconciliation(
+  conflict: IdentityAssertionConflict,
+  policy: IdentityAssertionConflictPolicy,
+  survivorAssertionId: string | undefined,
+  supersededAssertionIds: readonly string[],
+): IdentityReconciliation {
+  return {
+    semanticKey: conflict.semanticKey,
+    a: conflict.a,
+    b: conflict.b,
+    relation: conflict.relation,
+    ...(survivorAssertionId === undefined ? {} : { survivorAssertionId }),
+    supersededAssertionIds: [...supersededAssertionIds].toSorted(
+      compareStrings,
+    ),
+    rule: "policy",
+    policy: identityPolicyLabel(policy),
+    branches: [
+      ...new Set([
+        ...conflict.asserted.map((staged) => staged.branchId),
+        ...conflict.retracted.map((staged) => staged.branchId),
+      ]),
+    ].toSorted(compareStrings),
+  };
+}
+
+/**
  * Reduces raw (unstaged) identity assertions across POTENTIALLY MANY semantic
  * pairs to one survivor per pair, via {@link identityDedupeKey} /
  * {@link compareIdentitySurvivors} — the same rule
@@ -327,23 +409,15 @@ export function dedupeIdentityAssertionsRaw(
       survivorBySemantic.set(key, assertion);
       continue;
     }
-    const assertionCommitted = committedIds.has(assertion.id);
-    const previousCommitted = committedIds.has(previous.id);
-    const [survivor, loser] =
-      assertionCommitted === previousCommitted ?
-        compareIdentitySurvivors(assertion, previous) < 0 ?
-          ([assertion, previous] as const)
-        : ([previous, assertion] as const)
-      : assertionCommitted ? ([assertion, previous] as const)
-      : ([previous, assertion] as const);
+    const picked = pickIdentitySurvivor(
+      { assertion },
+      { assertion: previous },
+      committedIds,
+    );
+    const survivor = picked.winner.assertion;
+    const loser = picked.loser.assertion;
     survivorBySemantic.set(key, survivor);
-    if (
-      loser.id === survivor.id &&
-      loser.validFrom === survivor.validFrom &&
-      (loser.validTo ?? undefined) === (survivor.validTo ?? undefined)
-    ) {
-      continue;
-    }
+    if (isIdenticalIdentityRow(loser, survivor)) continue;
     dropped.push(
       droppedIdentityAssertion(loser, DUPLICATE_IDENTITY_ASSERTION_DROP_REASON),
     );
@@ -547,6 +621,7 @@ export type IdentityThreeWayResult = Readonly<{
 function resolveConflict(
   conflict: IdentityAssertionConflict,
   policy: IdentityAssertionConflictPolicy,
+  committedIds: ReadonlySet<string>,
   refuse: () => never,
 ): IdentityAssertionDecision {
   if (policy === "refuse") refuse();
@@ -565,9 +640,15 @@ function resolveConflict(
       );
     }
     if (policy === "assertWins") {
-      const winner = conflict.asserted[0];
-      if (winner === undefined) return { kind: "retract" };
-      return { kind: "assert", assertionId: winner.assertion.id };
+      if (conflict.asserted.length === 0) return { kind: "retract" };
+      // Through the ONE survivor rule, never staging order: a race whose
+      // reassertions arrived under two ids must pick the same winner every
+      // other path would.
+      const { survivor } = reduceIdentitySurvivor(
+        conflict.asserted,
+        committedIds,
+      );
+      return { kind: "assert", assertionId: survivor.assertion.id };
     }
     return { kind: "retract" };
   }
@@ -750,7 +831,7 @@ export function planIdentityThreeWay(
       asserted: [...group.same, ...group.different],
       retracted: [],
     };
-    const decision = resolveConflict(conflict, policy, () =>
+    const decision = resolveConflict(conflict, policy, committedIds, () =>
       refuseOpposing(
         requireDefined(anchorSame),
         requireDefined(anchorDifferent),
@@ -781,6 +862,17 @@ export function planIdentityThreeWay(
           ),
         );
       }
+      // Nothing survives an opposing-relations conflict resolved by retraction
+      // — no reassertion is kept and no base row was staged for ending — so
+      // the reconciliation names the superseded ids alone.
+      reconciliations.push(
+        policyReconciliation(
+          conflict,
+          policy,
+          undefined,
+          conflict.asserted.map((staged) => staged.assertion.id),
+        ),
+      );
       continue;
     }
     const winner = requireDefined(
@@ -798,6 +890,16 @@ export function planIdentityThreeWay(
         ),
       );
     }
+    reconciliations.push(
+      policyReconciliation(
+        conflict,
+        policy,
+        winner.assertion.id,
+        conflict.asserted
+          .filter((staged) => staged.assertion.id !== winner.assertion.id)
+          .map((staged) => staged.assertion.id),
+      ),
+    );
   }
 
   const races = detectRetractReassertRaces(staging);
@@ -832,7 +934,12 @@ export function planIdentityThreeWay(
         },
       );
     };
-    const decision = resolveConflict(conflict, policy, refuseRace);
+    const decision = resolveConflict(
+      conflict,
+      policy,
+      committedIds,
+      refuseRace,
+    );
     if (decision.kind === "unresolved") {
       unresolved.push({
         kind: "assertion",
@@ -865,6 +972,16 @@ export function planIdentityThreeWay(
           ),
         );
       }
+      // The ended base row is the last id that spoke for the pair, so it is
+      // what governs after the merge.
+      reconciliations.push(
+        policyReconciliation(
+          conflict,
+          policy,
+          retraction.assertion.id,
+          race.asserted.map((staged) => staged.assertion.id),
+        ),
+      );
       continue;
     }
     const winner = requireDefined(
@@ -894,6 +1011,14 @@ export function planIdentityThreeWay(
       ...requireDefined(race.retracted[0]).assertion,
       validTo: winner.assertion.validFrom,
     });
+    reconciliations.push(
+      policyReconciliation(conflict, policy, winner.assertion.id, [
+        ...race.asserted
+          .filter((staged) => staged.assertion.id !== winner.assertion.id)
+          .map((staged) => staged.assertion.id),
+        ...race.retracted.map((staged) => staged.assertion.id),
+      ]),
+    );
   }
 
   const baseByDedupe = new Map<string, IdentityTransferAssertion[]>();
@@ -916,14 +1041,27 @@ export function planIdentityThreeWay(
     assertedByDedupe.set(key, group);
   }
   const retractedByDedupe = new Map<string, StagedRetraction[]>();
+  // Retractions with NO base group to classify against. The base slice is the
+  // target's CURRENT truth (`readCurrentIdentityAssertions("state")`, open rows
+  // only) while a retraction is derived from an archival read, so a branch that
+  // retracts a row the target has ALREADY ended stages a retraction whose base
+  // row is absent here. That is still a stated retraction: it is planned, and
+  // `planIdentityChanges`' stored-truth filter is the one owner that decides
+  // whether it applies or is dropped with `identity:retraction-target-mismatch`.
+  // Dropping it here would make it vanish from the plan with no reported reason.
+  const orphanRetractions: StagedRetraction[] = [];
   for (const staged of staging.retractedIdentityAssertions) {
     if (handledRaceKeys.has(identitySemanticKey(staged.assertion))) continue;
     const key = baseIdToDedupeKey.get(staged.assertion.id);
-    if (key === undefined) continue; // orphan: `planIdentityChanges` re-validates by id.
+    if (key === undefined) {
+      orphanRetractions.push(staged);
+      continue;
+    }
     const group = retractedByDedupe.get(key) ?? [];
     group.push(staged);
     retractedByDedupe.set(key, group);
   }
+  for (const staged of orphanRetractions) retractions.push(staged.assertion);
 
   const groupKeys = new Set<string>([
     ...baseByDedupe.keys(),

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -77,6 +77,11 @@ export type {
   MatchSource,
   MatchStrategy,
 } from "./evidence";
+export type {
+  IdentityAssertionConflict,
+  IdentityAssertionConflictPolicy,
+  IdentityAssertionDecision,
+} from "./identity-three-way";
 export { ingestionBranch } from "./ingestion-branch";
 export {
   applyMergePlan,
@@ -167,6 +172,10 @@ export type {
   Embedder,
   EntityResolution,
   GraphBranch,
+  IdentityAssertionConflictReason,
+  IdentityReconciliation,
+  IdentityReconciliationOptions,
+  IdentityUnresolvedConflict,
   IngestionBranch,
   IngestionNodeCollections,
   MergeBranch,

--- a/packages/typegraph/src/graph-merge/index.ts
+++ b/packages/typegraph/src/graph-merge/index.ts
@@ -41,7 +41,9 @@ export {
 export type {
   AcyclicityMergeConflictDetails,
   AcyclicityMergeConflictEdge,
+  IdentityMergeConflictCode,
   MergeConstraintConflictErrorDetails,
+  MergeErrorOptions,
 } from "./errors";
 export {
   AcyclicityMergeConflictError,
@@ -153,10 +155,18 @@ export { MERGE_REVIEW_FORMAT_VERSION } from "./review-schema";
 export type {
   BaseNodeLookup,
   CandidateSource,
+  IdentityPairingScope,
   KeylessConfig,
   SourceScope,
 } from "./sources";
-export type { IdentityAssertionWriteFacade } from "./typegraph-internal";
+export type { StagedIdentityAssertion, StagedRetraction } from "./staging";
+export type { RetractionCause } from "./state-diff";
+export type {
+  IdentityAssertionWriteFacade,
+  IdentityDecisionProvenance,
+  IdentityRelation,
+  IdentityTransferAssertion,
+} from "./typegraph-internal";
 export type {
   BaseAmbiguity,
   BaseVersion,

--- a/packages/typegraph/src/graph-merge/merge-identity.ts
+++ b/packages/typegraph/src/graph-merge/merge-identity.ts
@@ -37,7 +37,6 @@
  * `IdentitySeparationViolationError` — an `IDENTITY_`-coded refusal — is
  * translated here like any other applier refusal.
  */
-import { identityAssertionSemanticKey } from "../identity/assertion-key";
 import {
   identityReferenceKey,
   normalizeIdentityPair,
@@ -51,6 +50,11 @@ import {
   IdentityMergeConflictError,
   MergeError,
 } from "./errors";
+import {
+  compareIdentitySurvivors,
+  identityDedupeKey,
+  identitySemanticKey,
+} from "./identity-three-way";
 import {
   compareMergeKeys,
   compareStrings,
@@ -105,28 +109,6 @@ function endpointTuple(
 
 function identityEndpointKey(assertion: IdentityTransferAssertion): string {
   return encodeTupleKey(endpointTuple(assertion));
-}
-
-function identitySemanticKey(assertion: IdentityTransferAssertion): string {
-  return identityAssertionSemanticKey(
-    assertion.relation,
-    assertion.a,
-    assertion.b,
-  );
-}
-
-function identityDedupeKey(assertion: IdentityTransferAssertion): string {
-  const semantic = identitySemanticKey(assertion);
-  if (assertion.validTo === undefined) return semantic;
-  return encodeTupleKey([semantic, assertion.validFrom, assertion.validTo]);
-}
-
-function compareIdentitySurvivors(
-  left: IdentityTransferAssertion,
-  right: IdentityTransferAssertion,
-): number {
-  const byValidity = compareCodePoints(left.validFrom, right.validFrom);
-  return byValidity === 0 ? compareCodePoints(left.id, right.id) : byValidity;
 }
 
 /**

--- a/packages/typegraph/src/graph-merge/merge-identity.ts
+++ b/packages/typegraph/src/graph-merge/merge-identity.ts
@@ -217,18 +217,6 @@ export function planIdentityChanges(
   reconciliations: readonly IdentityReconciliation[];
   unresolved: readonly IdentityUnresolvedConflict[];
 }> {
-  // One id, one truth — over the RAW staged assertions, BEFORE the semantic
-  // survivor dedupe: two branches staging one id for the same pair with
-  // different validFrom values collapse into one survivor under the semantic
-  // key (which excludes validity), so a later check would never see the
-  // collision — while the report would list the id as both applied and
-  // dropped.
-  assertOneIdOneTruth(
-    staging.newIdentityAssertions.map((staged) => staged.assertion),
-    NO_STORED_ASSERTIONS,
-  );
-  assertRetractedIdsHaveOneTruth(staging);
-
   // Staged ids the target ALREADY holds with the exact staged truth. The
   // classifier's survivor rule must prefer these: the applier is idempotent
   // per semantic pair, so a freshly minted branch id can never displace the
@@ -251,6 +239,26 @@ export function planIdentityChanges(
     onAssertionConflict,
     committedIds,
   );
+
+  // One id, one truth — over the RAW staged assertions, never the classifier's
+  // survivors: two branches staging one id for the same pair with different
+  // validFrom values collapse into one survivor under the semantic key (which
+  // excludes validity), so a check reading the survivors would never see the
+  // collision — while the report would list the id as both applied and
+  // dropped.
+  //
+  // ORDER IS BEHAVIOR. A staging set that trips more than one check must
+  // report the same error it always has, so the two structural checks run
+  // where they always did relative to the classifier's own refusals:
+  // opposing-relations, then the retract/reassert race (both inside
+  // `planIdentityThreeWay`), then one-id-one-truth, then the retraction's
+  // two-truths check. The classifier throws nothing after those two arms, so
+  // running these afterwards over the raw slices is exactly that order.
+  assertOneIdOneTruth(
+    staging.newIdentityAssertions.map((staged) => staged.assertion),
+    NO_STORED_ASSERTIONS,
+  );
+  assertRetractedIdsHaveOneTruth(staging);
 
   const retractionById = new Map<string, IdentityTransferAssertion>();
   for (const retraction of classified.retractions) {

--- a/packages/typegraph/src/graph-merge/merge-identity.ts
+++ b/packages/typegraph/src/graph-merge/merge-identity.ts
@@ -41,7 +41,6 @@ import {
   identityReferenceKey,
   normalizeIdentityPair,
 } from "../identity/reference";
-import { identityValidityWindowsOverlap } from "../identity/validity-window";
 import { encodeTupleKey } from "../utils/tuple-key";
 import type { CanonicalEntity } from "./canonicalize";
 import {
@@ -51,9 +50,11 @@ import {
   MergeError,
 } from "./errors";
 import {
-  compareIdentitySurvivors,
+  assertNoOpposingIdentityRelationsRaw,
+  dedupeIdentityAssertionsRaw,
+  type IdentityAssertionConflictPolicy,
   identityDedupeKey,
-  identitySemanticKey,
+  planIdentityThreeWay,
 } from "./identity-three-way";
 import {
   compareMergeKeys,
@@ -64,7 +65,7 @@ import {
   mergeKey,
   mergeKeyOf,
 } from "./node-key";
-import type { StagedIdentityAssertion, StagingSet } from "./staging";
+import type { StagingSet } from "./staging";
 import { assertTemporalIdentityClosureConsistent } from "./temporal-identity-closure";
 import {
   compareCodePoints,
@@ -79,7 +80,11 @@ import {
   type TransactionBackend,
   TypeGraphError,
 } from "./typegraph-internal";
-import type { DroppedItem } from "./types";
+import type {
+  DroppedItem,
+  IdentityReconciliation,
+  IdentityUnresolvedConflict,
+} from "./types";
 
 /**
  * The identity-relevant slice of a resolved merge plan: a STRUCTURAL subset of
@@ -107,16 +112,7 @@ function endpointTuple(
   return [assertion.a.kind, assertion.a.id, assertion.b.kind, assertion.b.id];
 }
 
-function identityEndpointKey(assertion: IdentityTransferAssertion): string {
-  return encodeTupleKey(endpointTuple(assertion));
-}
-
-/**
- * Reason recorded when two branches asserted the SAME semantic pair and the
- * survivor rule kept only one of the two assertion ids.
- */
-export const DUPLICATE_IDENTITY_ASSERTION_DROP_REASON =
-  "identity:duplicate-assertion";
+export { DUPLICATE_IDENTITY_ASSERTION_DROP_REASON } from "./identity-three-way";
 
 /**
  * Reason recorded when node reconciliation collapsed both endpoints of a `same`
@@ -135,159 +131,6 @@ function droppedIdentityAssertion(
   reason: string,
 ): DroppedItem {
   return { kind: "identity", id: assertion.id, reason };
-}
-
-/**
- * Keeps one CURRENT assertion per semantic pair, while retaining every
- * distinct bounded window. Exact bounded duplicates still choose one survivor
- * and report the loser. Survivors come back in window-aware key order.
- *
- * An id in `committedIds` (already committed on the target with the exact
- * staged truth) ALWAYS wins over an uncommitted challenger, regardless of the
- * {@link compareIdentitySurvivors} order: the applier is idempotent per
- * dedupe key, so the challenger would never be written — picking it would
- * report an id as applied that never lands while listing the target's own row
- * as dropped. Between two ids of equal committed status the comparator
- * decides.
- */
-function dedupeIdentityAssertions(
-  assertions: readonly IdentityTransferAssertion[],
-  committedIds: ReadonlySet<string>,
-): Readonly<{
-  survivors: readonly IdentityTransferAssertion[];
-  dropped: readonly DroppedItem[];
-}> {
-  const survivorBySemantic = new Map<string, IdentityTransferAssertion>();
-  const dropped: DroppedItem[] = [];
-  for (const assertion of assertions) {
-    const key = identityDedupeKey(assertion);
-    const previous = survivorBySemantic.get(key);
-    if (previous === undefined) {
-      survivorBySemantic.set(key, assertion);
-      continue;
-    }
-    const assertionCommitted = committedIds.has(assertion.id);
-    const previousCommitted = committedIds.has(previous.id);
-    const [survivor, loser] =
-      assertionCommitted === previousCommitted ?
-        compareIdentitySurvivors(assertion, previous) < 0 ?
-          ([assertion, previous] as const)
-        : ([previous, assertion] as const)
-      : assertionCommitted ? ([assertion, previous] as const)
-      : ([previous, assertion] as const);
-    survivorBySemantic.set(key, survivor);
-    // Two branches staging the IDENTICAL row (same id, same complete truth —
-    // e.g. both imported one interchange document) is ONE assertion, not a
-    // survivor and a loser: reporting the id as dropped while it is applied
-    // would make the report self-contradictory.
-    if (
-      loser.id === survivor.id &&
-      loser.validFrom === survivor.validFrom &&
-      (loser.validTo ?? undefined) === (survivor.validTo ?? undefined)
-    ) {
-      continue;
-    }
-    dropped.push(
-      droppedIdentityAssertion(loser, DUPLICATE_IDENTITY_ASSERTION_DROP_REASON),
-    );
-  }
-  return {
-    survivors: [...survivorBySemantic.values()].toSorted((left, right) =>
-      compareCodePoints(identityDedupeKey(left), identityDedupeKey(right)),
-    ),
-    dropped,
-  };
-}
-
-function assertNoOpposingIdentityRelations(
-  assertions: readonly IdentityTransferAssertion[],
-): void {
-  const byEndpoint = new Map<string, IdentityTransferAssertion[]>();
-  for (const assertion of assertions) {
-    const key = identityEndpointKey(assertion);
-    const group = byEndpoint.get(key) ?? [];
-    group.push(assertion);
-    byEndpoint.set(key, group);
-  }
-  for (const [endpoint, group] of byEndpoint) {
-    const same = group.filter((assertion) => assertion.relation === "same");
-    const different = group.filter(
-      (assertion) => assertion.relation === "different",
-    );
-    for (const sameAssertion of same) {
-      for (const differentAssertion of different) {
-        if (
-          !identityValidityWindowsOverlap(sameAssertion, differentAssertion)
-        ) {
-          continue;
-        }
-        throw new IdentityMergeConflictError(
-          "Branches asserted opposing identity relations for one endpoint pair.",
-          {
-            details: {
-              endpoint,
-              assertions: [sameAssertion, differentAssertion],
-            },
-          },
-        );
-      }
-    }
-  }
-}
-
-/**
- * Refuses the retract/reassert RACE: one branch retracts the assertion for a
- * semantic pair while a DIFFERENT branch re-asserts that pair under a new id
- * WITHOUT retracting it — the branches disagree about whether the old truth still
- * holds, and no rule can pick between "the pair is not asserted" and "the pair is
- * asserted under a new id".
- *
- * Two nearby shapes are NOT races and must merge cleanly:
- *
- *   - A single fork that retracts then re-asserts the same pair (a normal linear
- *     edit): its final state is simply "old id retracted, new id asserted".
- *   - CONVERGENT edits, where the re-asserting branch ALSO retracted the pair:
- *     every branch agrees the old assertion dies, and one went further by
- *     re-asserting. The merge applies both effects.
- *
- * Both hinge on which branch produced which change, so this consults the staged
- * (branch-tagged) retractions — grouping by semantic key alone would drop exactly
- * the provenance that separates a race from agreement.
- */
-function assertNoRetractReassertRace(staging: StagingSet): void {
-  const retractedBySemantic = new Map<string, StagedIdentityAssertion[]>();
-  for (const staged of staging.retractedIdentityAssertions) {
-    const key = identitySemanticKey(staged.assertion);
-    const retractions = retractedBySemantic.get(key) ?? [];
-    retractions.push(staged);
-    retractedBySemantic.set(key, retractions);
-  }
-  for (const staged of staging.newIdentityAssertions) {
-    const retractions =
-      retractedBySemantic.get(identitySemanticKey(staged.assertion)) ?? [];
-    const selfRetracted = retractions.some(
-      (retraction) => retraction.branchId === staged.branchId,
-    );
-    if (selfRetracted) {
-      continue;
-    }
-    const crossBranchRetraction = retractions.find(
-      (retraction) => retraction.assertion.id !== staged.assertion.id,
-    );
-    if (crossBranchRetraction !== undefined) {
-      throw new IdentityMergeConflictError(
-        "Branches contain a retract/reassert race for one identity pair.",
-        {
-          details: {
-            retractedAssertion: crossBranchRetraction.assertion,
-            retractedBy: crossBranchRetraction.branchId,
-            reassertedAssertion: staged.assertion,
-            reassertedBy: staged.branchId,
-          },
-        },
-      );
-    }
-  }
 }
 
 /**
@@ -320,54 +163,16 @@ export const RETRACTION_DELETION_OVERRULED_DROP_REASON =
 export const NO_STORED_ASSERTIONS: ReadonlyMap<string, LedgerAssertion> =
   new Map();
 
-/** @internal Exported for deterministic phase-level verification. */
-export function planIdentityChanges(
-  staging: StagingSet,
-  storedIdentityRowsById: ReadonlyMap<string, LedgerAssertion>,
-): Readonly<{
-  assertions: readonly IdentityTransferAssertion[];
-  retractions: readonly IdentityTransferAssertion[];
-  dropped: readonly DroppedItem[];
-}> {
-  assertNoOpposingIdentityRelations(
-    staging.newIdentityAssertions.map((staged) => staged.assertion),
-  );
-  assertNoRetractReassertRace(staging);
-  // One id, one truth — over the RAW staged assertions, BEFORE the semantic
-  // survivor dedupe: two branches staging one id for the same pair with
-  // different validFrom values collapse into one survivor under the semantic
-  // key (which excludes validity), so a later check would never see the
-  // collision — while the report would list the id as both applied and
-  // dropped.
-  assertOneIdOneTruth(
-    staging.newIdentityAssertions.map((staged) => staged.assertion),
-    NO_STORED_ASSERTIONS,
-  );
-
-  // Staged ids the target ALREADY holds with the exact staged truth. The
-  // survivor dedupe must prefer these: the applier is idempotent per semantic
-  // pair, so a freshly minted branch id can never displace the target's
-  // committed row — choosing it would report an id as applied that is never
-  // written while listing the target's own row as dropped.
-  const committedIds = new Set<string>(
-    staging.newIdentityAssertions
-      .map((staged) => staged.assertion)
-      .filter((assertion) => {
-        const stored = storedIdentityRowsById.get(assertion.id);
-        return (
-          stored !== undefined &&
-          assertionTruthKey(stored) === assertionTruthKey(assertion)
-        );
-      })
-      .map((assertion) => assertion.id),
-  );
-  const deduped = dedupeIdentityAssertions(
-    staging.newIdentityAssertions.map((staged) => staged.assertion),
-    committedIds,
-  );
-  const retractionById = new Map<string, IdentityTransferAssertion>();
+/**
+ * Structural (not policy) validation: one assertion id was staged for
+ * retraction under two different identity truths — a data-integrity fault no
+ * `onAssertionConflict` policy can arbitrate, so it is checked once, up
+ * front, independent of the three-way classification below.
+ */
+function assertRetractedIdsHaveOneTruth(staging: StagingSet): void {
+  const seenById = new Map<string, IdentityTransferAssertion>();
   for (const staged of staging.retractedIdentityAssertions) {
-    const previous = retractionById.get(staged.assertion.id);
+    const previous = seenById.get(staged.assertion.id);
     if (
       previous !== undefined &&
       assertionIdentityKey(previous) !== assertionIdentityKey(staged.assertion)
@@ -383,7 +188,73 @@ export function planIdentityChanges(
         },
       );
     }
-    retractionById.set(staged.assertion.id, staged.assertion);
+    seenById.set(staged.assertion.id, staged.assertion);
+  }
+}
+
+/**
+ * @internal Exported for deterministic phase-level verification.
+ *
+ * Plans every identity change for one merge: three-way classifies the staged
+ * assertions against the staged base slice ({@link planIdentityThreeWay}, which
+ * absorbs what used to be three separate inline arbitrations here — the
+ * duplicate-assertion survivor rule, the opposing-relations refusal, and the
+ * retract/reassert race refusal), then applies the duties that stay owned
+ * here regardless of policy: the raw one-id-one-truth checks, the
+ * committed-id set the classifier's survivor rule needs, the retraction
+ * target-truth filter against the target's ACTUAL stored rows (independent of
+ * — and stricter than — the staged base slice the classifier reasons about),
+ * and the assert/retract id-collision backstop.
+ */
+export function planIdentityChanges(
+  staging: StagingSet,
+  storedIdentityRowsById: ReadonlyMap<string, LedgerAssertion>,
+  onAssertionConflict: IdentityAssertionConflictPolicy = "refuse",
+): Readonly<{
+  assertions: readonly IdentityTransferAssertion[];
+  retractions: readonly IdentityTransferAssertion[];
+  dropped: readonly DroppedItem[];
+  reconciliations: readonly IdentityReconciliation[];
+  unresolved: readonly IdentityUnresolvedConflict[];
+}> {
+  // One id, one truth — over the RAW staged assertions, BEFORE the semantic
+  // survivor dedupe: two branches staging one id for the same pair with
+  // different validFrom values collapse into one survivor under the semantic
+  // key (which excludes validity), so a later check would never see the
+  // collision — while the report would list the id as both applied and
+  // dropped.
+  assertOneIdOneTruth(
+    staging.newIdentityAssertions.map((staged) => staged.assertion),
+    NO_STORED_ASSERTIONS,
+  );
+  assertRetractedIdsHaveOneTruth(staging);
+
+  // Staged ids the target ALREADY holds with the exact staged truth. The
+  // classifier's survivor rule must prefer these: the applier is idempotent
+  // per semantic pair, so a freshly minted branch id can never displace the
+  // target's committed row — choosing it would report an id as applied that
+  // is never written while listing the target's own row as dropped.
+  const committedIds = new Set<string>(
+    staging.newIdentityAssertions
+      .map((staged) => staged.assertion)
+      .filter((assertion) => {
+        const stored = storedIdentityRowsById.get(assertion.id);
+        return (
+          stored !== undefined &&
+          assertionTruthKey(stored) === assertionTruthKey(assertion)
+        );
+      })
+      .map((assertion) => assertion.id),
+  );
+  const classified = planIdentityThreeWay(
+    staging,
+    onAssertionConflict,
+    committedIds,
+  );
+
+  const retractionById = new Map<string, IdentityTransferAssertion>();
+  for (const retraction of classified.retractions) {
+    retractionById.set(retraction.id, retraction);
   }
   const retractions: IdentityTransferAssertion[] = [];
   const retractionDropped: DroppedItem[] = [];
@@ -410,7 +281,7 @@ export function planIdentityChanges(
   // diff and the retraction truth filter each break every construction we
   // know — so refuse typed if a future path assembles it.
   const survivingIds = new Set(
-    deduped.survivors.map((survivor) => survivor.id),
+    classified.assertions.map((survivor) => survivor.id),
   );
   for (const retraction of retractions) {
     if (survivingIds.has(retraction.id)) {
@@ -421,11 +292,15 @@ export function planIdentityChanges(
     }
   }
   return {
-    assertions: deduped.survivors,
+    assertions: [...classified.assertions].sort((left, right) =>
+      compareCodePoints(identityDedupeKey(left), identityDedupeKey(right)),
+    ),
     retractions: retractions.toSorted((left, right) =>
       compareCodePoints(left.id, right.id),
     ),
-    dropped: [...deduped.dropped, ...retractionDropped],
+    dropped: [...classified.dropped, ...retractionDropped],
+    reconciliations: classified.reconciliations,
+    unresolved: classified.unresolved,
   };
 }
 
@@ -605,11 +480,11 @@ export function remapIdentityAssertionEndpoints(
       })
       .map((assertion) => assertion.id),
   );
-  const deduped = dedupeIdentityAssertions(remapped, committedIds);
+  const deduped = dedupeIdentityAssertionsRaw(remapped, committedIds);
   // Node reconciliation can collapse previously distinct endpoint pairs onto
   // the same canonical pair, so the pre-reconciliation check above is not
   // sufficient on its own.
-  assertNoOpposingIdentityRelations(deduped.survivors);
+  assertNoOpposingIdentityRelationsRaw(deduped.survivors);
   return {
     assertions: deduped.survivors,
     dropped: [...dropped, ...deduped.dropped],

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -113,6 +113,11 @@ import type {
   EntityRef,
 } from "./evidence";
 import { compareMatchEvidence, entityRef } from "./evidence";
+import {
+  branchAncestryFromAnchors,
+  branchAncestryOf,
+  mergeIdentityDecision,
+} from "./identity-decision";
 import type { IdentitySeparationFacts } from "./identity-pairing";
 import {
   captureIdentitySeparationFacts,
@@ -221,6 +226,7 @@ import type {
   UniqueIntrospection,
   ValidityEndMutation,
 } from "./typegraph-internal";
+import type { IdentityDecisionProvenance } from "./typegraph-internal";
 import {
   acyclicEdgeRelations,
   advanceRevisionClock,
@@ -2454,6 +2460,10 @@ async function applyIdentityRows<G extends GraphDef>(
   txBackend: TransactionBackend,
   assertions: readonly IdentityTransferAssertion[],
   retractions: readonly IdentityTransferAssertion[],
+  // The governing merge decision every transition this apply causes carries.
+  // Threaded to the ONE owner of "which decision is in force" — the capture
+  // session `applyIdentityChangesForContext` opens — never re-derived here.
+  decision: IdentityDecisionProvenance | undefined,
   assertConsistent?: () => Promise<void>,
 ): Promise<Readonly<{ asserted: number; retracted: number }>> {
   try {
@@ -2461,6 +2471,7 @@ async function applyIdentityRows<G extends GraphDef>(
       txBackend,
       retractions,
       assertions,
+      decision,
     );
     if (assertConsistent !== undefined) await assertConsistent();
     return { asserted: applied.created, retracted: applied.retracted };
@@ -2481,6 +2492,7 @@ async function applyInternalMergePlan<G extends GraphDef>(
   target: Store<G>,
   txBackend: TransactionBackend,
   deleteNodeWithPolicy: TransactionDeleteNodeWithPolicy,
+  decision: IdentityDecisionProvenance | undefined,
 ): Promise<MergedCounts> {
   const nodeDeletions = [...plan.nodeDeletions].map(([identity, kind]) => ({
     kind,
@@ -2512,6 +2524,7 @@ async function applyInternalMergePlan<G extends GraphDef>(
     txBackend,
     [],
     earlyIdentityRetractions,
+    decision,
   );
   let committedNodes: number;
   try {
@@ -2585,6 +2598,7 @@ async function applyInternalMergePlan<G extends GraphDef>(
     txBackend,
     plan.identityAssertions,
     plan.identityRetractions,
+    decision,
     () => assertMergedIdentityClassesConsistent(target, txBackend, plan),
   );
 
@@ -2641,6 +2655,7 @@ export async function commitPlan<G extends GraphDef>(
   target: Store<G>,
   plan: MergePlan<G>,
   expectedBaseVersion?: BaseVersion,
+  decision?: IdentityDecisionProvenance,
 ): Promise<MergedCounts> {
   if (!storeBackend(target).capabilities.execution.interactiveTransactions) {
     throw new MergeError(
@@ -2686,6 +2701,7 @@ export async function commitPlan<G extends GraphDef>(
             target,
             transactionBackend(tx),
             (work, policy) => transactionDeleteNodeWithPolicy(tx, work, policy),
+            decision,
           );
         }, mergeCommitTransactionOptions(target)),
     ),
@@ -2990,6 +3006,12 @@ type ResolvedMerge<G extends GraphDef> = Readonly<{
   target: Store<G>;
   plan: MergePlan<G>;
   options: NormalizedMergeOptions<G>;
+  /**
+   * Root-first: the base (or fork-point) graph, then every branch merged. The
+   * ancestry the identity decision records for a `merge()` that never produced
+   * a durable plan artifact to read anchors from.
+   */
+  branchAncestry: readonly string[];
   expectedBaseVersion?: BaseVersion;
   incrementalGuard?: IncrementalCommitGuard<G>;
 }>;
@@ -3865,6 +3887,12 @@ async function resolveMerge<G extends GraphDef, Output>(
         target,
         plan,
         options,
+        branchAncestry: branchAncestryOf(
+          store.graphId,
+          [...branches]
+            .map((branch) => branch.id as string)
+            .toSorted((left, right) => compareStrings(left, right)),
+        ),
         ...(expectedBaseVersion === undefined ? {} : { expectedBaseVersion }),
         ...(incrementalGuard === undefined ? {} : { incrementalGuard }),
       }),
@@ -3898,10 +3926,22 @@ async function commitResolvedMerge<G extends GraphDef>(
   if (provenanceStore !== undefined && isErr(provenanceStore)) {
     throw provenanceStore.error;
   }
+  // An unreviewed `merge()` has no plan artifact and therefore no digest, but
+  // it still explains itself: the policy arm that actually decided and the
+  // branch ancestry it combined.
+  const decision = mergeIdentityDecision({
+    branchAncestry: resolved.branchAncestry,
+    reconciliations: plan.identityReconciliations,
+  });
   const merged =
     resolved.incrementalGuard === undefined ?
-      await commitPlan(target, plan, resolved.expectedBaseVersion)
-    : await commitIncrementalPlan(target, plan, resolved.incrementalGuard);
+      await commitPlan(target, plan, resolved.expectedBaseVersion, decision)
+    : await commitIncrementalPlan(
+        target,
+        plan,
+        resolved.incrementalGuard,
+        decision,
+      );
 
   const provenance: ProvenanceIndex =
     options.provenance ?
@@ -4569,6 +4609,7 @@ async function applyWireMergeWrites<G extends GraphDef>(
   txBackend: TransactionBackend,
   artifact: MergePlanArtifactV2,
   deleteNodeWithPolicy: TransactionDeleteNodeWithPolicy,
+  decision: IdentityDecisionProvenance | undefined,
 ): Promise<MergedCounts> {
   const committedNodes = await applyNodeRows(
     target,
@@ -4612,6 +4653,7 @@ async function applyWireMergeWrites<G extends GraphDef>(
     txBackend,
     identityAssertions,
     identityRetractions,
+    decision,
     () =>
       storeRuntime(target).assertIdentityClassesConsistentAtTarget(
         txBackend,
@@ -4717,6 +4759,20 @@ export async function applyMergePlan<G extends GraphDef>(
       ),
     );
   }
+  // Built from evidence already in hand — the artifact's own digest, the
+  // anchors it names, the review digest the caller reviewed it under, and the
+  // policy arm the classifier actually exercised. Nothing here is read back or
+  // recomputed, and a field the apply cannot evidence stays absent.
+  const decision = mergeIdentityDecision({
+    branchAncestry: branchAncestryFromAnchors(artifact.anchors),
+    reconciliations: (artifact.review.identityReconciliations ??
+      []) as unknown as readonly IdentityReconciliation[],
+    mergePlanDigest: artifact.digest.value,
+    ...(options.reviewDigest === undefined ?
+      {}
+    : { reviewDigest: options.reviewDigest }),
+    ...(options.sourceId === undefined ? {} : { sourceId: options.sourceId }),
+  });
   try {
     const { beforeApply, afterApply } = options;
     const composed = beforeApply !== undefined || afterApply !== undefined;
@@ -4770,6 +4826,7 @@ export async function applyMergePlan<G extends GraphDef>(
             txBackend,
             artifact,
             (work, policy) => transactionDeleteNodeWithPolicy(tx, work, policy),
+            decision,
           );
           if (afterApply !== undefined) {
             assertMergeCallbackResult(
@@ -5725,6 +5782,7 @@ async function commitIncrementalPlan<G extends GraphDef>(
   target: Store<G>,
   plan: MergePlan<G>,
   guard: IncrementalCommitGuard<G>,
+  decision?: IdentityDecisionProvenance,
 ): Promise<MergedCounts> {
   if (!storeBackend(target).capabilities.execution.interactiveTransactions) {
     throw new MergeError(
@@ -5806,6 +5864,7 @@ async function commitIncrementalPlan<G extends GraphDef>(
             target,
             transactionBackend(tx),
             (work, policy) => transactionDeleteNodeWithPolicy(tx, work, policy),
+            decision,
           );
         }, mergeCommitTransactionOptions(target)),
     ),

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -743,12 +743,13 @@ function partitionIdentityPairingAssertions(
     // one entity; pairing on it would fuse exactly what the merge is ending.
     if (assertion.relation !== "same" || retracted.has(assertion.id)) continue;
     const unpairable: IdentityAssertionConflictReason | undefined =
-      assertion.a.kind === assertion.b.kind ? (
-        !stagedNewKeys.has(mergeKeyOf(assertion.a)) ||
-        !stagedNewKeys.has(mergeKeyOf(assertion.b))
-      ) ?
-        "out-of-scope-pairing"
-      : undefined
+      assertion.a.kind === assertion.b.kind ?
+        (
+          !stagedNewKeys.has(mergeKeyOf(assertion.a)) ||
+          !stagedNewKeys.has(mergeKeyOf(assertion.b))
+        ) ?
+          "out-of-scope-pairing"
+        : undefined
       : "cross-kind-pairing";
     if (unpairable !== undefined) {
       crossKind.push({
@@ -807,6 +808,19 @@ async function generateIdentityPairing(
     identity: { pairing, assertions },
   });
   return { pairs: produced.pairs, forcedEdges: produced.forcedEdges };
+}
+
+/**
+ * The ONE order merged branches are recorded in: code-point by branch id.
+ * A plan artifact's `MergePlanAnchors.branches` and the identity decision's
+ * `branchAncestry` both read it here, so the same logical merge run through
+ * `merge()` and through `planMerge` + `applyMergePlan` records comparable
+ * replay provenance instead of two orderings that only happen to agree.
+ */
+function branchesInAnchorOrder<G extends GraphDef>(
+  branches: readonly GraphBranch<G>[],
+): readonly GraphBranch<G>[] {
+  return [...branches].sort((left, right) => compareStrings(left.id, right.id));
 }
 
 async function generateAllCandidates<G extends GraphDef>(
@@ -4077,9 +4091,7 @@ async function resolveMerge<G extends GraphDef, Output>(
         options,
         branchAncestry: branchAncestryOf(
           store.graphId,
-          [...branches]
-            .map((branch) => branch.id as string)
-            .toSorted((left, right) => compareStrings(left, right)),
+          branchesInAnchorOrder(branches).map((branch) => branch.id as string),
         ),
         ...(expectedBaseVersion === undefined ? {} : { expectedBaseVersion }),
         ...(incrementalGuard === undefined ? {} : { incrementalGuard }),
@@ -4227,12 +4239,10 @@ export async function planMerge<G extends GraphDef>(
   const anchors: MergePlanAnchors = {
     kind: "snapshot",
     base: { graphId: store.graphId, baseVersion: precondition.data },
-    branches: [...branches]
-      .sort((left, right) => compareStrings(left.id, right.id))
-      .map((branch) => ({
-        branchId: branch.id,
-        baseVersion: branch.base,
-      })),
+    branches: branchesInAnchorOrder(branches).map((branch) => ({
+      branchId: branch.id,
+      baseVersion: branch.base,
+    })),
   };
   return resolveMerge(
     store,
@@ -4312,12 +4322,10 @@ export async function planMergeIncremental<G extends GraphDef>(
         hash: forkActiveSchema?.schema_hash ?? forkSchema,
       },
     },
-    branches: [...branches]
-      .sort((left, right) => compareStrings(left.id, right.id))
-      .map((branch) => ({
-        branchId: branch.id,
-        baseVersion: branch.base,
-      })),
+    branches: branchesInAnchorOrder(branches).map((branch) => ({
+      branchId: branch.id,
+      baseVersion: branch.base,
+    })),
   };
   return resolveMerge(
     forkPoint,

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -105,7 +105,11 @@ import {
   translateMergeCommitError,
   UnsupportedMergePlanVersionError,
 } from "./errors";
-import type { CandidateDiagnostic, CandidateDiagnostics } from "./evidence";
+import type {
+  CandidateDiagnostic,
+  CandidateDiagnostics,
+  EntityRef,
+} from "./evidence";
 import { compareMatchEvidence } from "./evidence";
 import { unwrapMergeBranches } from "./ingestion-branch";
 import {
@@ -238,6 +242,8 @@ import type {
   Embedder,
   EntityResolution,
   GraphBranch,
+  IdentityReconciliation,
+  IdentityUnresolvedConflict,
   MergeBranch,
   MergedCounts,
   MergeIncrementalArgs as MergeIncrementalArguments,
@@ -933,6 +939,10 @@ export type MergePlan<G extends GraphDef> = Readonly<{
   // validation layers (the plan-time filter and the in-transaction freshness
   // guard) compare it to the target's row before the id is ended.
   identityRetractions: readonly IdentityTransferAssertion[];
+  /** Duplicate-assertion survivor picks the three-way classifier resolved. */
+  identityReconciliations: readonly IdentityReconciliation[];
+  /** Identity-assertion conflicts a resolving `onAssertionConflict` kept rather than refused. */
+  identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;
 
 /**
@@ -955,7 +965,11 @@ function buildInternalMergePlan<G extends GraphDef>(
   targetPeers: readonly Readonly<{ kind: string; id: string }>[],
   preferredBranchId?: BranchId,
 ): MergePlan<G> {
-  const identity = planIdentityChanges(staging, storedIdentityRowsById);
+  const identity = planIdentityChanges(
+    staging,
+    storedIdentityRowsById,
+    options.identity?.onAssertionConflict,
+  );
   const provenanceRecords: ProvenanceRecord[] = [];
   // The contributions already recorded, keyed by `contributionKey` — the sidecar
   // row's own identity, so a repeat is the same row written twice and never new
@@ -1633,7 +1647,93 @@ function buildInternalMergePlan<G extends GraphDef>(
       }),
     identityAssertions: identityRemap.assertions,
     identityRetractions: survivingRetractions,
+    identityReconciliations: identity.reconciliations.toSorted((left, right) =>
+      compareIdentityReportKeys(
+        identityReconciliationSortKey(left),
+        identityReconciliationSortKey(right),
+      ),
+    ),
+    identityConflicts: identity.unresolved.toSorted((left, right) =>
+      compareIdentityReportKeys(
+        identityUnresolvedConflictSortKey(left),
+        identityUnresolvedConflictSortKey(right),
+      ),
+    ),
   };
+}
+
+/**
+ * Order-independent sort key: `semanticKey` then the endpoint pair for the
+ * `assertion` shape (§4.1), degrading to whatever identifying fields the
+ * other {@link IdentityUnresolvedConflict} kinds carry — never insertion
+ * order, which would depend on which branch's diff happened to stage the
+ * item first.
+ */
+type IdentityReportSortKey = Readonly<{
+  semanticKey: string;
+  a: EntityRef;
+  b: EntityRef;
+}>;
+
+function identityReconciliationSortKey(
+  reconciliation: IdentityReconciliation,
+): IdentityReportSortKey {
+  return {
+    semanticKey: reconciliation.semanticKey,
+    a: reconciliation.a,
+    b: reconciliation.b,
+  };
+}
+
+const UNKEYED_ENTITY_REF: EntityRef = { kind: "", id: "" as EntityRef["id"] };
+
+function identityUnresolvedConflictSortKey(
+  conflict: IdentityUnresolvedConflict,
+): IdentityReportSortKey {
+  switch (conflict.kind) {
+    case "assertion": {
+      return {
+        semanticKey: conflict.semanticKey,
+        a: conflict.a,
+        b: conflict.b,
+      };
+    }
+    case "separation": {
+      return { semanticKey: conflict.kind, a: conflict.a, b: conflict.b };
+    }
+    case "uniqueness": {
+      return {
+        semanticKey: `${conflict.kind}|${conflict.constraintName}`,
+        a: conflict.members[0] ?? UNKEYED_ENTITY_REF,
+        b: conflict.members[1] ?? UNKEYED_ENTITY_REF,
+      };
+    }
+    case "provenance": {
+      return {
+        semanticKey: conflict.kind,
+        a: conflict.canonical,
+        b: UNKEYED_ENTITY_REF,
+      };
+    }
+  }
+}
+
+function compareIdentityReportKeys(
+  left: IdentityReportSortKey,
+  right: IdentityReportSortKey,
+): number {
+  const bySemanticKey = compareStrings(left.semanticKey, right.semanticKey);
+  if (bySemanticKey !== 0) return bySemanticKey;
+  const byA = compareMergeKeys(
+    mergeKey(left.a.kind, left.a.id),
+    mergeKey(right.a.kind, right.a.id),
+  );
+  return byA === 0 ?
+      compareMergeKeys(
+        mergeKey(left.b.kind, left.b.id),
+        mergeKey(right.b.kind, right.b.id),
+      )
+    : byA;
 }
 
 /**
@@ -2916,6 +3016,21 @@ async function resolvedMergeArtifact<G extends GraphDef>(
       ...(plan.candidateDiagnostics === undefined ?
         {}
       : { diagnostics: plan.candidateDiagnostics }),
+      // Optional and omitted when empty (plan-G2 §4.2): a merge that
+      // reconciled nothing produces a review object byte-identical to
+      // today's, so the plan's stored format version never moves.
+      ...(plan.identityReconciliations.length === 0 ?
+        {}
+      : {
+          identityReconciliations:
+            plan.identityReconciliations as unknown as readonly JsonValue[],
+        }),
+      ...(plan.identityConflicts.length === 0 ?
+        {}
+      : {
+          identityConflicts:
+            plan.identityConflicts as unknown as readonly JsonValue[],
+        }),
     },
     provenance: {
       includeInReport: options.provenance,
@@ -3464,6 +3579,8 @@ async function commitResolvedMerge<G extends GraphDef>(
       {}
     : { candidateDiagnostics: plan.candidateDiagnostics }),
     ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
+    identityReconciliations: plan.identityReconciliations,
+    identityConflicts: plan.identityConflicts,
   };
 }
 
@@ -4196,6 +4313,10 @@ function reportFromArtifact<G extends GraphDef>(
           .diagnostics as unknown as CandidateDiagnostics,
       }),
     ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
+    identityReconciliations: (artifact.review.identityReconciliations ??
+      []) as unknown as readonly IdentityReconciliation[],
+    identityConflicts: (artifact.review.identityConflicts ??
+      []) as unknown as readonly IdentityUnresolvedConflict[],
   };
 }
 

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -2148,6 +2148,18 @@ function buildInternalMergePlan<G extends GraphDef>(
 }
 
 /**
+ * The `details.conflict` shape a provenance refusal throws. NOT an arm of the
+ * public `IdentityUnresolvedConflict` union: `onProvenanceConflict` has no
+ * resolving disposition that ever places one on `MergeReport.identityConflicts`
+ * or a plan artifact, so this shape is local to the thrown error alone.
+ */
+type IdentityProvenanceConflictDetails = Readonly<{
+  kind: "provenance";
+  canonical: EntityRef;
+  contributions: readonly ProvenanceRecord[];
+}>;
+
+/**
  * `onProvenanceConflict` — how a cluster that an identity assertion FUSED
  * handles contradictory source attribution across its members.
  *
@@ -2166,19 +2178,6 @@ function buildInternalMergePlan<G extends GraphDef>(
  * single branch asserting `same` over two rows it authored itself is not a
  * contradiction; two branches independently authoring the paired rows is.
  */
-/**
- * The `details.conflict` shape a provenance refusal throws. NOT an arm of the
- * public `IdentityUnresolvedConflict` union (R5): `onProvenanceConflict` has
- * no resolving disposition that ever places one on `MergeReport
- * .identityConflicts` or a plan artifact, so this shape is local to the
- * thrown error alone.
- */
-type IdentityProvenanceConflictDetails = Readonly<{
-  kind: "provenance";
-  canonical: EntityRef;
-  contributions: readonly ProvenanceRecord[];
-}>;
-
 function assertIdentityProvenanceAgreement(
   policy: "keepBoth" | "refuse",
   survivingEdges: readonly CandidateEdge[],

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -261,6 +261,7 @@ import type {
   Embedder,
   EntityResolution,
   GraphBranch,
+  IdentityAssertionConflictReason,
   IdentityReconciliation,
   IdentityUnresolvedConflict,
   MergeBranch,
@@ -693,15 +694,25 @@ type IdentityPairingPartition = Readonly<{
  * pairing source and the three-way classifier consume one slice and cannot
  * disagree about which assertions exist.
  *
- * A `same` assertion spanning two different merge KINDS is neither dropped nor
- * fatal: `orderEndpoints` keys on `(kind, id)` and a source scope is built per
- * kind, so no per-kind scope can carry it. It is reported as a typed
- * `cross-kind-pairing` conflict — the stated `pairing` option applied where it
- * can be and refused visibly where it cannot, never ignored.
+ * Two shapes of assertion are neither dropped nor fatal, because a per-kind
+ * candidate scope structurally cannot carry them — the stated `pairing` option
+ * is applied where it can be and refused VISIBLY where it cannot, never
+ * ignored:
+ *
+ *   - CROSS-KIND: `orderEndpoints` keys on `(kind, id)` and a source scope is
+ *     built per kind, so no scope spans two kinds.
+ *   - OUT OF SCOPE: an endpoint that is not a staged new node of its kind (a
+ *     committed target row, or a node no branch staged). Candidate generation
+ *     proposes over the nodes in scope, and this one is not among them.
  */
 function partitionIdentityPairingAssertions(
   staging: StagingSet,
+  stagedNewByKind: ReadonlyMap<string, readonly StagedNewNode[]>,
 ): IdentityPairingPartition {
+  const stagedNewKeys = new Set<MergeKey>();
+  for (const [kind, items] of stagedNewByKind) {
+    for (const item of items) stagedNewKeys.add(mergeKey(kind, item.node.id));
+  }
   const retracted = new Set(
     staging.retractedIdentityAssertions.map((staged) => staged.assertion.id),
   );
@@ -722,6 +733,7 @@ function partitionIdentityPairingAssertions(
     byId.set(staged.assertion.id, staged.assertion);
   }
   const sameByKind = new Map<string, IdentityTransferAssertion[]>();
+  /** Every `same` assertion no per-kind candidate scope can express. */
   const crossKind: Extract<
     IdentityUnresolvedConflict,
     Readonly<{ kind: "assertion" }>
@@ -730,10 +742,18 @@ function partitionIdentityPairingAssertions(
     // A retracted assertion states the branches STOPPED believing the pair is
     // one entity; pairing on it would fuse exactly what the merge is ending.
     if (assertion.relation !== "same" || retracted.has(assertion.id)) continue;
-    if (assertion.a.kind !== assertion.b.kind) {
+    const unpairable: IdentityAssertionConflictReason | undefined =
+      assertion.a.kind === assertion.b.kind ? (
+        !stagedNewKeys.has(mergeKeyOf(assertion.a)) ||
+        !stagedNewKeys.has(mergeKeyOf(assertion.b))
+      ) ?
+        "out-of-scope-pairing"
+      : undefined
+      : "cross-kind-pairing";
+    if (unpairable !== undefined) {
       crossKind.push({
         kind: "assertion",
-        reason: "cross-kind-pairing",
+        reason: unpairable,
         semanticKey: identitySemanticKey(assertion),
         a: { kind: assertion.a.kind, id: assertion.a.id as NodeId<NodeType> },
         b: { kind: assertion.b.kind, id: assertion.b.id as NodeId<NodeType> },
@@ -828,7 +848,7 @@ async function generateAllCandidates<G extends GraphDef>(
     : options.identity.pairing;
   const identityPairingScopes =
     identityPairing === undefined ? NO_IDENTITY_PAIRING : (
-      partitionIdentityPairingAssertions(staging)
+      partitionIdentityPairingAssertions(staging, byKind)
     );
   const sources =
     useBaseSources ?

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -641,6 +641,9 @@ function assertClusterNotSeparated(
 
 const EMPTY_ASSERTIONS: readonly IdentityTransferAssertion[] = [];
 
+/** No blocked buckets — the identity source pairs off the kind's staged nodes. */
+const EMPTY_BLOCKS: ReadonlyMap<string, readonly Node<NodeType>[]> = new Map();
+
 /** The identity pairing input for a merge that asked for no pairing at all. */
 const NO_IDENTITY_PAIRING: IdentityPairingPartition = {
   sameByKind: new Map(),
@@ -799,11 +802,51 @@ async function generateAllCandidates<G extends GraphDef>(
         >
       > => {
         const resolveConfig = options.resolve[kind];
+        const nodes = items.map((staged) => asNode(staged));
+        const identityAssertions =
+          identityPairingScopes.sameByKind.get(kind) ?? EMPTY_ASSERTIONS;
         if (resolveConfig === undefined) {
           // No resolution config for this kind: merge by id only (no candidate
-          // edges, so every new node stays a singleton cluster).
+          // edges, so every new node stays a singleton cluster) — UNLESS an
+          // explicit `same` assertion names two of its nodes and the caller
+          // asked for pairing. A DEFINITIONAL pairing needs no threshold, so it
+          // runs here; a `"candidate"` pairing is a SCORED proposal and this
+          // kind has no threshold to score it against, which is a stated option
+          // the state cannot honor rather than one to drop silently.
+          if (
+            identityPairing === undefined ||
+            identityAssertions.length === 0
+          ) {
+            return ok({
+              edges: [],
+              warnings: [],
+              baseMembers: [],
+              diagnostics: [],
+              diagnosticsTotal: 0,
+            });
+          }
+          if (identityPairing === "candidate") {
+            return err(
+              new InvalidMergeOptionsError(
+                `options.identity.pairing: "candidate" proposes a SCORED pair, but kind "${kind}" has no options.resolve entry and therefore no threshold to score it against.`,
+                {
+                  details: { option: "identity.pairing", kind },
+                  suggestion: `Add options.resolve.${kind} with a threshold, or use options.identity.pairing: "definitional" to force the pairing without scoring.`,
+                },
+              ),
+            );
+          }
+          const forced = await identitySource.generate({
+            kind,
+            blocks: EMPTY_BLOCKS,
+            nodes,
+            identity: {
+              pairing: identityPairing,
+              assertions: identityAssertions,
+            },
+          });
           return ok({
-            edges: [],
+            edges: forced.forcedEdges,
             warnings: [],
             baseMembers: [],
             diagnostics: [],
@@ -811,7 +854,6 @@ async function generateAllCandidates<G extends GraphDef>(
           });
         }
 
-        const nodes = items.map((staged) => asNode(staged));
         const uniqueConstraints = uniqueConstraintsFor(
           introspectionKinds,
           kind,
@@ -833,9 +875,7 @@ async function generateAllCandidates<G extends GraphDef>(
           : {
               identity: {
                 pairing: identityPairing,
-                assertions:
-                  identityPairingScopes.sameByKind.get(kind) ??
-                  EMPTY_ASSERTIONS,
+                assertions: identityAssertions,
               },
             }),
         };

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -550,18 +550,18 @@ async function captureSeparationFactsForPairing<G extends GraphDef>(
 
 /**
  * The always-on separation VETO at the candidate-edge application point: a
- * class-lifted `different` between two candidate endpoints refuses the match at
- * PLAN time, naming both entities and the assertion that separated them,
- * instead of surviving into the commit and aborting on the separation
- * relation's ordered-pair CHECK.
+ * SCORED match between two entities the ledger holds apart is recall the
+ * ledger forbids, so the proposal is dropped, the merge continues, and the
+ * drop is reported as a typed `separation` conflict.
  *
- * The two edge kinds get different treatment because they mean different
- * things. A SCORED edge is recall: similarity proposed a match the ledger
- * forbids, so the proposal is dropped, the merge continues, and the drop is
- * reported as a typed `separation` conflict. A FORCED edge is a DEFINITION — a
- * shared unique value, a rediscovered base row, or a `same` assertion under
- * `pairing: "definitional"` — so it is a direct contradiction between two
- * definitional claims and the plan fails.
+ * A FORCED edge is left alone here on purpose. It is a DEFINITION — a shared
+ * unique value, a rediscovered base row, or a `same` assertion under
+ * `pairing: "definitional"` — and refusing it at this point would fail merges
+ * the plan never had a problem with: the component base guard routinely severs
+ * a forced base pairing, so the two separated entities never land in one
+ * cluster and nothing is ever fused. The definitional refusal therefore runs
+ * on the edges that SURVIVE the base and diameter guards
+ * ({@link assertSurvivingEdgesNotSeparated}), where a contradiction is real.
  */
 function applyIdentitySeparationVeto(
   candidateEdges: readonly CandidateEdge[],
@@ -573,37 +573,57 @@ function applyIdentitySeparationVeto(
   const edges: CandidateEdge[] = [];
   const conflicts: IdentityUnresolvedConflict[] = [];
   for (const edge of candidateEdges) {
-    if (!isSeparatedPair(facts, edge.a, edge.b)) {
+    if (
+      edge.evidence.decision === "definitional" ||
+      !isSeparatedPair(facts, edge.a, edge.b)
+    ) {
       edges.push(edge);
       continue;
     }
-    const assertionIds = separatingAssertionIds(facts, edge.a, edge.b);
     const [source] = edge.evidence.sources;
-    if (edge.evidence.decision === "definitional") {
-      throw new IdentityMergeConflictError(
-        `Identity separation refuses a definitional match between ${kindOf(edge.a)}:${idOf(edge.a)} and ${kindOf(edge.b)}:${idOf(edge.b)}: the identity ledger holds their classes apart.`,
-        {
-          code: MERGE_ERROR_CODES.identitySeparationConflict,
-          details: {
-            a: entityRef(edge.a),
-            b: entityRef(edge.b),
-            assertionIds,
-            sources: edge.evidence.sources,
-          },
-          suggestion:
-            "Retract the `different` assertion separating these entities, or stop proposing them as one match, then re-plan the merge.",
-        },
-      );
-    }
     conflicts.push({
       kind: "separation",
       a: entityRef(edge.a),
       b: entityRef(edge.b),
-      assertionIds,
+      assertionIds: separatingAssertionIds(facts, edge.a, edge.b),
       ...(source === undefined ? {} : { source }),
     });
   }
   return { edges, conflicts };
+}
+
+/**
+ * The separation veto's refusal of a DEFINITIONAL claim, applied to the edges
+ * that survived the base and diameter guards — the only edges that can still
+ * fuse anything. A definitional edge spanning two classes the ledger holds
+ * apart is a direct contradiction between two definitional claims, so the plan
+ * fails here rather than in the commit on the separation relation's
+ * ordered-pair CHECK, naming both entities, the assertion that separated them
+ * and the sources that proposed the match.
+ */
+function assertSurvivingEdgesNotSeparated(
+  survivingEdges: readonly CandidateEdge[],
+  facts: IdentitySeparationFacts,
+): void {
+  if (facts.separatedClassPairs.size === 0) return;
+  for (const edge of survivingEdges) {
+    if (edge.evidence.decision !== "definitional") continue;
+    if (!isSeparatedPair(facts, edge.a, edge.b)) continue;
+    throw new IdentityMergeConflictError(
+      `Identity separation refuses a definitional match between ${kindOf(edge.a)}:${idOf(edge.a)} and ${kindOf(edge.b)}:${idOf(edge.b)}: the identity ledger holds their classes apart.`,
+      {
+        code: MERGE_ERROR_CODES.identitySeparationConflict,
+        details: {
+          a: entityRef(edge.a),
+          b: entityRef(edge.b),
+          assertionIds: separatingAssertionIds(facts, edge.a, edge.b),
+          sources: edge.evidence.sources,
+        },
+        suggestion:
+          "Retract the `different` assertion separating these entities, or stop proposing them as one match, then re-plan the merge.",
+      },
+    );
+  }
 }
 
 /**
@@ -643,6 +663,12 @@ const EMPTY_ASSERTIONS: readonly IdentityTransferAssertion[] = [];
 
 /** No blocked buckets — the identity source pairs off the kind's staged nodes. */
 const EMPTY_BLOCKS: ReadonlyMap<string, readonly Node<NodeType>[]> = new Map();
+
+/** What a kind with no identity pairing in scope contributes. */
+const NO_IDENTITY_CANDIDATES: Readonly<{
+  pairs: readonly CandidatePair[];
+  forcedEdges: readonly CandidateEdge[];
+}> = { pairs: [], forcedEdges: [] };
 
 /** The identity pairing input for a merge that asked for no pairing at all. */
 const NO_IDENTITY_PAIRING: IdentityPairingPartition = {
@@ -731,6 +757,38 @@ function partitionIdentityPairingAssertions(
   };
 }
 
+/**
+ * The ONE call site of {@link identitySource}. Both kinds of merge scope reach
+ * the identity pairing decision through here — the kind with an
+ * `options.resolve` entry, whose scored pairs still go through
+ * `scoreCandidates`, and the kind without one, which can only take a
+ * definitional (forced) pairing. `identitySource` is deliberately NOT a member
+ * of the driven source array: a second wiring of the same per-kind decision is
+ * exactly the copy that drifts.
+ */
+async function generateIdentityPairing(
+  kind: string,
+  nodes: readonly Node<NodeType>[],
+  pairing: "candidate" | "definitional" | undefined,
+  assertions: readonly IdentityTransferAssertion[],
+): Promise<
+  Readonly<{
+    pairs: readonly CandidatePair[];
+    forcedEdges: readonly CandidateEdge[];
+  }>
+> {
+  if (pairing === undefined || assertions.length === 0) {
+    return NO_IDENTITY_CANDIDATES;
+  }
+  const produced = await identitySource.generate({
+    kind,
+    blocks: EMPTY_BLOCKS,
+    nodes,
+    identity: { pairing, assertions },
+  });
+  return { pairs: produced.pairs, forcedEdges: produced.forcedEdges };
+}
+
 async function generateAllCandidates<G extends GraphDef>(
   target: Store<G>,
   staging: StagingSet,
@@ -772,12 +830,10 @@ async function generateAllCandidates<G extends GraphDef>(
     identityPairing === undefined ? NO_IDENTITY_PAIRING : (
       partitionIdentityPairingAssertions(staging)
     );
-  const sources = [
-    ...(useBaseSources ?
+  const sources =
+    useBaseSources ?
       [...CANDIDATE_SOURCES, baseUniqueSource, baseKeySource]
-    : CANDIDATE_SOURCES),
-    ...(identityPairing === undefined ? [] : [identitySource]),
-  ];
+    : CANDIDATE_SOURCES;
   // Base sources resolve staged nodes against the COMMITTED graph — the merge
   // TARGET, where prior runs' canonicals live — NOT the (possibly older) diff
   // reference. They coincide under the public snapshot path (target defaults to
@@ -836,15 +892,12 @@ async function generateAllCandidates<G extends GraphDef>(
               ),
             );
           }
-          const forced = await identitySource.generate({
+          const forced = await generateIdentityPairing(
             kind,
-            blocks: EMPTY_BLOCKS,
             nodes,
-            identity: {
-              pairing: identityPairing,
-              assertions: identityAssertions,
-            },
-          });
+            identityPairing,
+            identityAssertions,
+          );
           return ok({
             edges: forced.forcedEdges,
             warnings: [],
@@ -870,14 +923,6 @@ async function generateAllCandidates<G extends GraphDef>(
             {}
           : { blockIndex: resolveConfig.blockIndex }),
           ...(keylessConfig === undefined ? {} : { keyless: keylessConfig }),
-          ...(identityPairing === undefined ?
-            {}
-          : {
-              identity: {
-                pairing: identityPairing,
-                assertions: identityAssertions,
-              },
-            }),
         };
 
         const pairs: CandidatePair[] = [];
@@ -889,6 +934,16 @@ async function generateAllCandidates<G extends GraphDef>(
           forcedEdges.push(...produced.forcedEdges);
           kindBaseMembers.push(...produced.baseMembers);
         }
+        // A `"candidate"` pairing is a SCORED proposal: its pairs join the
+        // other sources' and `scoreCandidates` below still thresholds them.
+        const identityPaired = await generateIdentityPairing(
+          kind,
+          nodes,
+          identityPairing,
+          identityAssertions,
+        );
+        pairs.push(...identityPaired.pairs);
+        forcedEdges.push(...identityPaired.forcedEdges);
 
         // Base sources pull committed nodes into staged↔base pairs whose texts
         // were not in the staged-only precompute; embed them now so vector/hybrid
@@ -1432,18 +1487,21 @@ function buildInternalMergePlan<G extends GraphDef>(
         options.clusterMaxDiameter,
       );
   const clusters = diameterGuard.clusters;
-  // (4c) the second application point of the always-on separation veto: a
-  // TRANSITIVE fusion no single candidate edge exposed. Runs on the FINAL
-  // clusters — after the base and diameter guards have split what they split —
-  // so a cluster the guards already severed is never refused for a pair it no
-  // longer contains.
-  for (const cluster of clusters) {
-    assertClusterNotSeparated(cluster.members, separationFacts);
-  }
   const baseSurvivingEdges = new Set(guard.survivingEdges);
   const survivingEdges = diameterGuard.survivingEdges.filter((edge) =>
     baseSurvivingEdges.has(edge),
   );
+  // (4c) the second application point of the always-on separation veto, on the
+  // FINAL clusters and the edges that reached them — after the base and
+  // diameter guards have split what they split, so a pairing the guards
+  // already severed is never refused for a fusion it can no longer cause. The
+  // edge-level refusal runs first because it is the more specific diagnosis:
+  // a surviving DEFINITIONAL claim contradicting the ledger, named with the
+  // sources that proposed it, rather than the cluster it happens to sit in.
+  assertSurvivingEdgesNotSeparated(survivingEdges, separationFacts);
+  for (const cluster of clusters) {
+    assertClusterNotSeparated(cluster.members, separationFacts);
+  }
   const excludedByEndpoints = new Map<string, "diameter" | "baseAmbiguity">();
   for (const excluded of [
     ...guard.excludedEdges,

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -570,9 +570,15 @@ function applyIdentitySeparationVeto(
 ): Readonly<{
   edges: readonly CandidateEdge[];
   conflicts: readonly IdentityUnresolvedConflict[];
+  // The edges the veto itself dropped — reported to `candidateDiagnostics`
+  // with `clusterDisposition: { kind: "excluded", reason: "separation" }` the
+  // same way the base and diameter guards report theirs, so the diagnostic
+  // surface never says "retained" about a pair the merge actually refused.
+  vetoedEdges: readonly CandidateEdge[];
 }> {
   const edges: CandidateEdge[] = [];
   const conflicts: IdentityUnresolvedConflict[] = [];
+  const vetoedEdges: CandidateEdge[] = [];
   for (const edge of candidateEdges) {
     if (
       edge.evidence.decision === "definitional" ||
@@ -581,6 +587,7 @@ function applyIdentitySeparationVeto(
       edges.push(edge);
       continue;
     }
+    vetoedEdges.push(edge);
     const [source] = edge.evidence.sources;
     conflicts.push({
       kind: "separation",
@@ -590,7 +597,7 @@ function applyIdentitySeparationVeto(
       ...(source === undefined ? {} : { source }),
     });
   }
-  return { edges, conflicts };
+  return { edges, conflicts, vetoedEdges };
 }
 
 /**
@@ -752,18 +759,28 @@ function partitionIdentityPairingAssertions(
         : undefined
       : "cross-kind-pairing";
     if (unpairable !== undefined) {
-      crossKind.push({
-        kind: "assertion",
-        reason: unpairable,
-        semanticKey: identitySemanticKey(assertion),
-        a: { kind: assertion.a.kind, id: assertion.a.id as NodeId<NodeType> },
-        b: { kind: assertion.b.kind, id: assertion.b.id as NodeId<NodeType> },
-        relation: assertion.relation,
-        assertionIds: [assertion.id],
-        branches: (branchesById.get(assertion.id) ?? []).toSorted(
-          (left, right) => compareStrings(left, right),
-        ),
-      });
+      // An INHERITED `out-of-scope-pairing` assertion — no branch staged it,
+      // it is simply the target's existing ledger between two rows this merge
+      // never restaged — is not a conflict any branch caused. Only a
+      // branch-staged assertion (present in `branchesById`) is reported;
+      // `cross-kind-pairing` stays reported regardless of provenance, since
+      // that shape is a structural limit of per-kind candidate scopes, not a
+      // question of which rows are in scope.
+      const stagedByBranch = branchesById.get(assertion.id);
+      if (unpairable === "cross-kind-pairing" || stagedByBranch !== undefined) {
+        crossKind.push({
+          kind: "assertion",
+          reason: unpairable,
+          semanticKey: identitySemanticKey(assertion),
+          a: { kind: assertion.a.kind, id: assertion.a.id as NodeId<NodeType> },
+          b: { kind: assertion.b.kind, id: assertion.b.id as NodeId<NodeType> },
+          relation: assertion.relation,
+          assertionIds: [assertion.id],
+          branches: (stagedByBranch ?? []).toSorted((left, right) =>
+            compareStrings(left, right),
+          ),
+        });
+      }
       continue;
     }
     const forKind = sameByKind.get(assertion.a.kind);
@@ -1396,6 +1413,7 @@ function buildInternalMergePlan<G extends GraphDef>(
   targetPeers: readonly Readonly<{ kind: string; id: string }>[],
   separationFacts: IdentitySeparationFacts,
   identityCandidateConflicts: readonly IdentityUnresolvedConflict[],
+  vetoedEdges: readonly CandidateEdge[],
   preferredBranchId?: BranchId,
 ): MergePlan<G> {
   const identity = planIdentityChanges(
@@ -1536,7 +1554,10 @@ function buildInternalMergePlan<G extends GraphDef>(
   for (const cluster of clusters) {
     assertClusterNotSeparated(cluster.members, separationFacts);
   }
-  const excludedByEndpoints = new Map<string, "diameter" | "baseAmbiguity">();
+  const excludedByEndpoints = new Map<
+    string,
+    "diameter" | "baseAmbiguity" | "separation"
+  >();
   for (const excluded of [
     ...guard.excludedEdges,
     ...diameterGuard.excludedEdges,
@@ -1544,6 +1565,16 @@ function buildInternalMergePlan<G extends GraphDef>(
     excludedByEndpoints.set(
       JSON.stringify([excluded.edge.a, excluded.edge.b]),
       excluded.reason,
+    );
+  }
+  // The separation veto drops a candidate edge before it ever reaches the base
+  // or diameter guards, so it needs its own exclusion reason fed into the same
+  // map — otherwise the diagnostic surface says "retained" about a pair the
+  // merge actually refused for contradicting the identity ledger.
+  for (const edge of vetoedEdges) {
+    excludedByEndpoints.set(
+      JSON.stringify([edge.a, edge.b]),
+      "separation" as const,
     );
   }
   const diagnosticsWithDisposition: CandidateDiagnostic[] =
@@ -2127,7 +2158,27 @@ function buildInternalMergePlan<G extends GraphDef>(
  * contribution. `"refuse"` fails the plan naming the canonical entity and the
  * contributions that disagree, for a caller whose source attribution is a
  * correctness invariant rather than a record.
+ *
+ * "Source" here is the contributing BRANCH, not `ProvenanceRecord.sourceId` —
+ * that field is each member's own fork-local id, which an identity-paired
+ * cluster's distinct members always differ on, so comparing it would refuse
+ * every fusion regardless of whether the attribution actually disagrees. A
+ * single branch asserting `same` over two rows it authored itself is not a
+ * contradiction; two branches independently authoring the paired rows is.
  */
+/**
+ * The `details.conflict` shape a provenance refusal throws. NOT an arm of the
+ * public `IdentityUnresolvedConflict` union (R5): `onProvenanceConflict` has
+ * no resolving disposition that ever places one on `MergeReport
+ * .identityConflicts` or a plan artifact, so this shape is local to the
+ * thrown error alone.
+ */
+type IdentityProvenanceConflictDetails = Readonly<{
+  kind: "provenance";
+  canonical: EntityRef;
+  contributions: readonly ProvenanceRecord[];
+}>;
+
 function assertIdentityProvenanceAgreement(
   policy: "keepBoth" | "refuse",
   survivingEdges: readonly CandidateEdge[],
@@ -2156,7 +2207,14 @@ function assertIdentityProvenanceAgreement(
   for (const [canonical, records] of [...byCanonical].sort(([left], [right]) =>
     compareMergeKeys(left, right),
   )) {
-    const sources = new Set(records.map((record) => record.sourceId));
+    // `sourceId` is the contribution's FORK-LOCAL id (types.ts docblock) —
+    // an identity-paired cluster's two distinct members always differ there,
+    // so comparing it would refuse every fusion regardless of attribution.
+    // The real attribution key is `branchId`: which branch actually
+    // contributed the row. Two members a single branch asserted `same` over
+    // carry no contradiction; two members different branches independently
+    // authored do.
+    const sources = new Set(records.map((record) => record.branchId));
     if (sources.size <= 1) continue;
     throw new IdentityMergeConflictError(
       `Identity-paired entity ${kindOf(canonical)}:${idOf(canonical)} carries contributions from ${sources.size} different sources (${[...sources].toSorted().join(", ")}), which options.identity.onProvenanceConflict: "refuse" does not accept.`,
@@ -2167,10 +2225,7 @@ function assertIdentityProvenanceAgreement(
             kind: "provenance",
             canonical: entityRef(canonical),
             contributions: records,
-          } satisfies Extract<
-            IdentityUnresolvedConflict,
-            Readonly<{ kind: "provenance" }>
-          >,
+          } satisfies IdentityProvenanceConflictDetails,
         },
         suggestion:
           'Reconcile the source attribution of the paired members, or set options.identity.onProvenanceConflict: "keepBoth" to keep every contribution.',
@@ -2202,8 +2257,6 @@ function identityReconciliationSortKey(
   };
 }
 
-const UNKEYED_ENTITY_REF: EntityRef = { kind: "", id: "" as EntityRef["id"] };
-
 function identityUnresolvedConflictSortKey(
   conflict: IdentityUnresolvedConflict,
 ): IdentityReportSortKey {
@@ -2217,13 +2270,6 @@ function identityUnresolvedConflictSortKey(
     }
     case "separation": {
       return { semanticKey: conflict.kind, a: conflict.a, b: conflict.b };
-    }
-    case "provenance": {
-      return {
-        semanticKey: conflict.kind,
-        a: conflict.canonical,
-        b: UNKEYED_ENTITY_REF,
-      };
     }
   }
 }
@@ -3990,6 +4036,7 @@ async function resolveMerge<G extends GraphDef, Output>(
       targetPeers,
       separationFacts,
       identityCandidateConflicts,
+      veto.vetoedEdges,
       preferredBranchId,
     );
 

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -1877,6 +1877,13 @@ function buildInternalMergePlan<G extends GraphDef>(
     compareStrings(`${left.kind}|${left.id}`, `${right.kind}|${right.id}`),
   );
 
+  assertIdentityProvenanceAgreement(
+    options.identity?.onProvenanceConflict ?? "keepBoth",
+    survivingEdges,
+    canonicalOf,
+    provenanceRecords,
+  );
+
   return {
     canonicalEntities,
     survivingModifications: reconciledModifications.survivingModifications,
@@ -1975,6 +1982,69 @@ function buildInternalMergePlan<G extends GraphDef>(
       ),
     ),
   };
+}
+
+/**
+ * `onProvenanceConflict` — how a cluster that an identity assertion FUSED
+ * handles contradictory source attribution across its members.
+ *
+ * Only a cluster an `identity` match source actually pulled together is judged:
+ * every other cluster's multi-source provenance is the ordinary multi-branch
+ * case the merge has always kept, and re-classifying it here would change a
+ * default. `"keepBoth"` (the default, and today's behavior) keeps every
+ * contribution. `"refuse"` fails the plan naming the canonical entity and the
+ * contributions that disagree, for a caller whose source attribution is a
+ * correctness invariant rather than a record.
+ */
+function assertIdentityProvenanceAgreement(
+  policy: "keepBoth" | "refuse",
+  survivingEdges: readonly CandidateEdge[],
+  canonicalOf: ReadonlyMap<MergeKey, MergeKey>,
+  provenanceRecords: readonly ProvenanceRecord[],
+): void {
+  if (policy === "keepBoth") return;
+  const identityPairedCanonicals = new Set<MergeKey>();
+  for (const edge of survivingEdges) {
+    if (!edge.evidence.sources.some((source) => source.kind === "identity")) {
+      continue;
+    }
+    identityPairedCanonicals.add(canonicalOf.get(edge.a) ?? edge.a);
+    identityPairedCanonicals.add(canonicalOf.get(edge.b) ?? edge.b);
+  }
+  if (identityPairedCanonicals.size === 0) return;
+  const byCanonical = new Map<MergeKey, ProvenanceRecord[]>();
+  for (const record of provenanceRecords) {
+    if (record.role !== "node") continue;
+    const key = mergeKey(record.canonicalKind, record.canonicalId);
+    if (!identityPairedCanonicals.has(key)) continue;
+    const records = byCanonical.get(key);
+    if (records === undefined) byCanonical.set(key, [record]);
+    else records.push(record);
+  }
+  for (const [canonical, records] of [...byCanonical].sort(([left], [right]) =>
+    compareMergeKeys(left, right),
+  )) {
+    const sources = new Set(records.map((record) => record.sourceId));
+    if (sources.size <= 1) continue;
+    throw new IdentityMergeConflictError(
+      `Identity-paired entity ${kindOf(canonical)}:${idOf(canonical)} carries contributions from ${sources.size} different sources (${[...sources].toSorted().join(", ")}), which options.identity.onProvenanceConflict: "refuse" does not accept.`,
+      {
+        code: MERGE_ERROR_CODES.identityProvenanceConflict,
+        details: {
+          conflict: {
+            kind: "provenance",
+            canonical: entityRef(canonical),
+            contributions: records,
+          } satisfies Extract<
+            IdentityUnresolvedConflict,
+            Readonly<{ kind: "provenance" }>
+          >,
+        },
+        suggestion:
+          'Reconcile the source attribution of the paired members, or set options.identity.onProvenanceConflict: "keepBoth" to keep every contribution.',
+      },
+    );
+  }
 }
 
 /**

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -2126,13 +2126,6 @@ function identityUnresolvedConflictSortKey(
     case "separation": {
       return { semanticKey: conflict.kind, a: conflict.a, b: conflict.b };
     }
-    case "uniqueness": {
-      return {
-        semanticKey: `${conflict.kind}|${conflict.constraintName}`,
-        a: conflict.members[0] ?? UNKEYED_ENTITY_REF,
-        b: conflict.members[1] ?? UNKEYED_ENTITY_REF,
-      };
-    }
     case "provenance": {
       return {
         semanticKey: conflict.kind,
@@ -3051,8 +3044,15 @@ function tryNormalize<G extends GraphDef>(
   try {
     return ok(normalizeMergeOptions(optionsInput));
   } catch (error) {
+    // A refusal the normalizer already spelled as a typed invalid-option error
+    // travels unchanged: re-wrapping it would bury the `details.option` the
+    // caller needs to know WHICH option was refused (§3.3). Anything else —
+    // a zod parse failure, a bare validation throw — becomes the generic
+    // invalid-options refusal with the original attached as its cause.
     return err(
-      new InvalidMergeOptionsError("Invalid merge options.", { cause: error }),
+      error instanceof InvalidMergeOptionsError ? error : (
+        new InvalidMergeOptionsError("Invalid merge options.", { cause: error })
+      ),
     );
   }
 }

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -91,8 +91,10 @@ import {
   AcyclicityMergeConflictError,
   BaseVersionMismatchError,
   describeCause,
+  IdentityMergeConflictError,
   InvalidMergeOptionsError,
   InvalidMergePlanError,
+  MERGE_ERROR_CODES,
   MergeCompositionOrphanError,
   MergeError,
   MergePlanCapabilityError,
@@ -110,7 +112,15 @@ import type {
   CandidateDiagnostics,
   EntityRef,
 } from "./evidence";
-import { compareMatchEvidence } from "./evidence";
+import { compareMatchEvidence, entityRef } from "./evidence";
+import type { IdentitySeparationFacts } from "./identity-pairing";
+import {
+  captureIdentitySeparationFacts,
+  isSeparatedPair,
+  NO_IDENTITY_SEPARATION_FACTS,
+  separatingAssertionIds,
+} from "./identity-pairing";
+import { identitySemanticKey } from "./identity-three-way";
 import { unwrapMergeBranches } from "./ingestion-branch";
 import {
   assertIdentityEndpointsNotDeleted,
@@ -174,6 +184,7 @@ import {
   baseKeySource,
   baseUniqueSource,
   CANDIDATE_SOURCES,
+  identitySource,
   keylessConfigFor,
   ontologyRetypeEdges,
 } from "./sources";
@@ -213,12 +224,14 @@ import type {
 import {
   acyclicEdgeRelations,
   advanceRevisionClock,
+  ConfigurationError,
   createSqlSchema,
   edgeKindIsInAcyclicRelation,
   forceRecordedGraphRevision,
   forceWriteTransactionRevision,
   getDialect,
   type GraphWriteLock,
+  IDENTITY_STORAGE_MISSING_CODE,
   lockRecordedGraphWrite,
   planCompositionCascade,
   readProposedEdgeAcyclicityViolations,
@@ -454,6 +467,261 @@ async function embedMissingPairTexts(
  * Returns `err` when a kind's `onComparisonCeiling: "error"` ceiling trips or a
  * `vector`/`hybrid` strategy hits the no-embedder guard.
  */
+/**
+ * The participant sets a fusion could occur WITHIN, so the separation probe
+ * costs one pair per pair the plan can actually merge rather than one per pair
+ * of participants.
+ *
+ * A cluster is always a subset of a connected component of the candidate-edge
+ * graph — the base and diameter guards only SPLIT components — so the
+ * components bound the transitive check exactly. Under
+ * `reconcileTypes: "ontology"` two staged nodes sharing a bare id can also fuse
+ * through a retype edge, so every bare id's members form one more group: a
+ * deliberately COARSER bound than `ontologyRetypeEdges` computes, chosen over
+ * a second call to it so the retype compatibility decision keeps one owner.
+ */
+function identityFusionGroups(
+  candidateEdges: readonly CandidateEdge[],
+  participants: readonly MergeKey[],
+  ontologyRetype: boolean,
+): readonly (readonly MergeKey[])[] {
+  const groups = connectedComponents(candidateEdges, participants).map(
+    (component) => component.members,
+  );
+  if (!ontologyRetype) return groups;
+  const byBareId = new Map<string, MergeKey[]>();
+  for (const key of participants) {
+    const bare = idOf(key);
+    const members = byBareId.get(bare);
+    if (members === undefined) byBareId.set(bare, [key]);
+    else members.push(key);
+  }
+  return [
+    ...groups,
+    ...[...byBareId.values()].filter((members) => members.length > 1),
+  ];
+}
+
+/**
+ * Captures the separation facts, translating the ONE state a stated
+ * `identity.pairing` cannot be honored in.
+ *
+ * `bulkIsSeparated` refuses rather than answering "not separated" when the
+ * separation relation was never provisioned or never filled for this graph (a
+ * store opened before the identity upgrade). With `pairing` OFF that refusal is
+ * exactly what it says — the graph's identity storage is incomplete — and
+ * propagates unchanged. With a pairing mode STATED it is also an option the
+ * merge accepted and cannot honor, so it is re-raised as an invalid-option
+ * refusal naming the relation and the upgrade path, rather than surfacing as an
+ * opaque storage fault the caller cannot connect to the option they set.
+ */
+async function captureSeparationFactsForPairing<G extends GraphDef>(
+  target: Store<G>,
+  pairing: "off" | "candidate" | "definitional",
+  groups: readonly (readonly MergeKey[])[],
+): Promise<IdentitySeparationFacts> {
+  try {
+    return await captureIdentitySeparationFacts(target, groups);
+  } catch (error) {
+    if (
+      pairing === "off" ||
+      !(error instanceof ConfigurationError) ||
+      error.code !== IDENTITY_STORAGE_MISSING_CODE
+    ) {
+      throw error;
+    }
+    throw new InvalidMergeOptionsError(
+      `options.identity.pairing: "${pairing}" needs the identity separation relation, which graph "${target.graphId}" has not provisioned or filled.`,
+      {
+        details: { option: "identity.pairing", graphId: target.graphId },
+        suggestion:
+          "Reopen the store so the identity upgrade provisions and fills the separation relation, then re-plan the merge.",
+        cause: error,
+      },
+    );
+  }
+}
+
+/**
+ * The always-on separation VETO at the candidate-edge application point: a
+ * class-lifted `different` between two candidate endpoints refuses the match at
+ * PLAN time, naming both entities and the assertion that separated them,
+ * instead of surviving into the commit and aborting on the separation
+ * relation's ordered-pair CHECK.
+ *
+ * The two edge kinds get different treatment because they mean different
+ * things. A SCORED edge is recall: similarity proposed a match the ledger
+ * forbids, so the proposal is dropped, the merge continues, and the drop is
+ * reported as a typed `separation` conflict. A FORCED edge is a DEFINITION — a
+ * shared unique value, a rediscovered base row, or a `same` assertion under
+ * `pairing: "definitional"` — so it is a direct contradiction between two
+ * definitional claims and the plan fails.
+ */
+function applyIdentitySeparationVeto(
+  candidateEdges: readonly CandidateEdge[],
+  facts: IdentitySeparationFacts,
+): Readonly<{
+  edges: readonly CandidateEdge[];
+  conflicts: readonly IdentityUnresolvedConflict[];
+}> {
+  const edges: CandidateEdge[] = [];
+  const conflicts: IdentityUnresolvedConflict[] = [];
+  for (const edge of candidateEdges) {
+    if (!isSeparatedPair(facts, edge.a, edge.b)) {
+      edges.push(edge);
+      continue;
+    }
+    const assertionIds = separatingAssertionIds(facts, edge.a, edge.b);
+    const [source] = edge.evidence.sources;
+    if (edge.evidence.decision === "definitional") {
+      throw new IdentityMergeConflictError(
+        `Identity separation refuses a definitional match between ${kindOf(edge.a)}:${idOf(edge.a)} and ${kindOf(edge.b)}:${idOf(edge.b)}: the identity ledger holds their classes apart.`,
+        {
+          code: MERGE_ERROR_CODES.identitySeparationConflict,
+          details: {
+            a: entityRef(edge.a),
+            b: entityRef(edge.b),
+            assertionIds,
+            sources: edge.evidence.sources,
+          },
+          suggestion:
+            "Retract the `different` assertion separating these entities, or stop proposing them as one match, then re-plan the merge.",
+        },
+      );
+    }
+    conflicts.push({
+      kind: "separation",
+      a: entityRef(edge.a),
+      b: entityRef(edge.b),
+      assertionIds,
+      ...(source === undefined ? {} : { source }),
+    });
+  }
+  return { edges, conflicts };
+}
+
+/**
+ * The always-on separation veto at the POST-CLUSTER application point: a
+ * TRANSITIVE fusion. `a`–`b` and `b`–`c` can each clear the threshold with no
+ * separated candidate edge among them, and the cluster still fuses `a` with
+ * `c`. A pure lookup into facts captured before planning, so plan construction
+ * stays synchronous.
+ */
+function assertClusterNotSeparated(
+  members: readonly MergeKey[],
+  facts: IdentitySeparationFacts,
+): void {
+  if (facts.separatedClassPairs.size === 0) return;
+  for (const [index, left] of members.entries()) {
+    for (const right of members.slice(index + 1)) {
+      if (!isSeparatedPair(facts, left, right)) continue;
+      throw new IdentityMergeConflictError(
+        `Identity separation refuses a merge cluster containing both ${kindOf(left)}:${idOf(left)} and ${kindOf(right)}:${idOf(right)}: the identity ledger holds their classes apart.`,
+        {
+          code: MERGE_ERROR_CODES.identitySeparationConflict,
+          details: {
+            a: entityRef(left),
+            b: entityRef(right),
+            assertionIds: separatingAssertionIds(facts, left, right),
+            cluster: members.map((member) => entityRef(member)),
+          },
+          suggestion:
+            "Retract the `different` assertion separating these entities, or raise the match threshold so the cluster no longer spans them, then re-plan the merge.",
+        },
+      );
+    }
+  }
+}
+
+const EMPTY_ASSERTIONS: readonly IdentityTransferAssertion[] = [];
+
+/** The identity pairing input for a merge that asked for no pairing at all. */
+const NO_IDENTITY_PAIRING: IdentityPairingPartition = {
+  sameByKind: new Map(),
+  crossKind: [],
+};
+
+type IdentityPairingPartition = Readonly<{
+  /** `same` assertions whose two endpoints share ONE kind, keyed by that kind. */
+  sameByKind: ReadonlyMap<string, readonly IdentityTransferAssertion[]>;
+  /** Cross-kind `same` assertions, reported rather than silently skipped. */
+  crossKind: readonly IdentityUnresolvedConflict[];
+}>;
+
+/**
+ * Splits the merge's `same` identity assertions into the per-kind pairing
+ * scopes the identity candidate source consumes, and the CROSS-KIND remainder
+ * it structurally cannot express.
+ *
+ * The assertions are read from the staging slices — every branch's staged
+ * assertion plus the inherited current truth — and NOT from the store, so the
+ * pairing source and the three-way classifier consume one slice and cannot
+ * disagree about which assertions exist.
+ *
+ * A `same` assertion spanning two different merge KINDS is neither dropped nor
+ * fatal: `orderEndpoints` keys on `(kind, id)` and a source scope is built per
+ * kind, so no per-kind scope can carry it. It is reported as a typed
+ * `cross-kind-pairing` conflict — the stated `pairing` option applied where it
+ * can be and refused visibly where it cannot, never ignored.
+ */
+function partitionIdentityPairingAssertions(
+  staging: StagingSet,
+): IdentityPairingPartition {
+  const retracted = new Set(
+    staging.retractedIdentityAssertions.map((staged) => staged.assertion.id),
+  );
+  const branchesById = new Map<string, BranchId[]>();
+  for (const staged of staging.newIdentityAssertions) {
+    const branches = branchesById.get(staged.assertion.id);
+    if (branches === undefined) {
+      branchesById.set(staged.assertion.id, [staged.branchId]);
+    } else {
+      branches.push(staged.branchId);
+    }
+  }
+  const byId = new Map<string, IdentityTransferAssertion>();
+  for (const assertion of staging.baseIdentityAssertions) {
+    byId.set(assertion.id, assertion);
+  }
+  for (const staged of staging.newIdentityAssertions) {
+    byId.set(staged.assertion.id, staged.assertion);
+  }
+  const sameByKind = new Map<string, IdentityTransferAssertion[]>();
+  const crossKind: Extract<
+    IdentityUnresolvedConflict,
+    Readonly<{ kind: "assertion" }>
+  >[] = [];
+  for (const assertion of byId.values()) {
+    // A retracted assertion states the branches STOPPED believing the pair is
+    // one entity; pairing on it would fuse exactly what the merge is ending.
+    if (assertion.relation !== "same" || retracted.has(assertion.id)) continue;
+    if (assertion.a.kind !== assertion.b.kind) {
+      crossKind.push({
+        kind: "assertion",
+        reason: "cross-kind-pairing",
+        semanticKey: identitySemanticKey(assertion),
+        a: { kind: assertion.a.kind, id: assertion.a.id as NodeId<NodeType> },
+        b: { kind: assertion.b.kind, id: assertion.b.id as NodeId<NodeType> },
+        relation: assertion.relation,
+        assertionIds: [assertion.id],
+        branches: (branchesById.get(assertion.id) ?? []).toSorted(
+          (left, right) => compareStrings(left, right),
+        ),
+      });
+      continue;
+    }
+    const forKind = sameByKind.get(assertion.a.kind);
+    if (forKind === undefined) sameByKind.set(assertion.a.kind, [assertion]);
+    else forKind.push(assertion);
+  }
+  return {
+    sameByKind,
+    crossKind: crossKind.toSorted((left, right) =>
+      compareStrings(left.semanticKey, right.semanticKey),
+    ),
+  };
+}
+
 async function generateAllCandidates<G extends GraphDef>(
   target: Store<G>,
   staging: StagingSet,
@@ -470,6 +738,7 @@ async function generateAllCandidates<G extends GraphDef>(
       baseMembers: readonly BaseMember[];
       diagnostics: readonly CandidateDiagnostic[];
       diagnosticsTotal: number;
+      identityConflicts: readonly IdentityUnresolvedConflict[];
     }>,
     MergeError
   >
@@ -480,10 +749,26 @@ async function generateAllCandidates<G extends GraphDef>(
   const diagnostics: CandidateDiagnostic[] = [];
   let diagnosticsTotal = 0;
   const byKind = newNodesByKind(staging);
-  const sources =
-    useBaseSources ?
+  // The identity pairing source is constructed ONLY when the caller asked for
+  // a pairing mode, so a merge that never sets `identity` drives precisely the
+  // sources it always has and every candidate it produces is byte-identical.
+  const identityPairing =
+    (
+      options.identity?.pairing === undefined ||
+      options.identity.pairing === "off"
+    ) ?
+      undefined
+    : options.identity.pairing;
+  const identityPairingScopes =
+    identityPairing === undefined ? NO_IDENTITY_PAIRING : (
+      partitionIdentityPairingAssertions(staging)
+    );
+  const sources = [
+    ...(useBaseSources ?
       [...CANDIDATE_SOURCES, baseUniqueSource, baseKeySource]
-    : CANDIDATE_SOURCES;
+    : CANDIDATE_SOURCES),
+    ...(identityPairing === undefined ? [] : [identitySource]),
+  ];
   // Base sources resolve staged nodes against the COMMITTED graph — the merge
   // TARGET, where prior runs' canonicals live — NOT the (possibly older) diff
   // reference. They coincide under the public snapshot path (target defaults to
@@ -537,6 +822,16 @@ async function generateAllCandidates<G extends GraphDef>(
             {}
           : { blockIndex: resolveConfig.blockIndex }),
           ...(keylessConfig === undefined ? {} : { keyless: keylessConfig }),
+          ...(identityPairing === undefined ?
+            {}
+          : {
+              identity: {
+                pairing: identityPairing,
+                assertions:
+                  identityPairingScopes.sameByKind.get(kind) ??
+                  EMPTY_ASSERTIONS,
+              },
+            }),
         };
 
         const pairs: CandidatePair[] = [];
@@ -608,6 +903,7 @@ async function generateAllCandidates<G extends GraphDef>(
   }
 
   return ok({
+    identityConflicts: identityPairingScopes.crossKind,
     // The ONE shared `(a, b)` edge comparator (id-first `(kind, id)` order), so this
     // stage emits edges in exactly the order clustering consumes them.
     edges: allEdges.sort((left, right) => compareCandidateEdges(left, right)),
@@ -963,6 +1259,8 @@ function buildInternalMergePlan<G extends GraphDef>(
   identityContext: PlanIdentityContext,
   storedIdentityRowsById: ReadonlyMap<string, LedgerAssertion>,
   targetPeers: readonly Readonly<{ kind: string; id: string }>[],
+  separationFacts: IdentitySeparationFacts,
+  identityCandidateConflicts: readonly IdentityUnresolvedConflict[],
   preferredBranchId?: BranchId,
 ): MergePlan<G> {
   const identity = planIdentityChanges(
@@ -1088,6 +1386,14 @@ function buildInternalMergePlan<G extends GraphDef>(
         options.clusterMaxDiameter,
       );
   const clusters = diameterGuard.clusters;
+  // (4c) the second application point of the always-on separation veto: a
+  // TRANSITIVE fusion no single candidate edge exposed. Runs on the FINAL
+  // clusters — after the base and diameter guards have split what they split —
+  // so a cluster the guards already severed is never refused for a pair it no
+  // longer contains.
+  for (const cluster of clusters) {
+    assertClusterNotSeparated(cluster.members, separationFacts);
+  }
   const baseSurvivingEdges = new Set(guard.survivingEdges);
   const survivingEdges = diameterGuard.survivingEdges.filter((edge) =>
     baseSurvivingEdges.has(edge),
@@ -1653,7 +1959,10 @@ function buildInternalMergePlan<G extends GraphDef>(
         identityReconciliationSortKey(right),
       ),
     ),
-    identityConflicts: identity.unresolved.toSorted((left, right) =>
+    identityConflicts: [
+      ...identity.unresolved,
+      ...identityCandidateConflicts,
+    ].toSorted((left, right) =>
       compareIdentityReportKeys(
         identityUnresolvedConflictSortKey(left),
         identityUnresolvedConflictSortKey(right),
@@ -3255,6 +3564,23 @@ async function resolveMerge<G extends GraphDef, Output>(
     }
   }
 
+  // Accepted or refused, never ignored: every `identity.*` arm describes work
+  // the identity ledger does, so a graph that declared no `identity` cannot
+  // honor any of them — and quietly running an ordinary merge under a stated
+  // identity policy is the API lying to its caller.
+  if (options.identity !== undefined && target.graph.identity === undefined) {
+    return err(
+      new InvalidMergeOptionsError(
+        `options.identity was stated, but graph "${target.graphId}" declares no identity profile, so no identity pairing, separation veto or assertion arbitration can run.`,
+        {
+          details: { option: "identity", graphId: target.graphId },
+          suggestion:
+            "Declare `identity: {}` on the graph (and upgrade the store) before stating merge identity options, or drop options.identity.",
+        },
+      ),
+    );
+  }
+
   try {
     // (2) stage the provenance-tagged union of every branch's diff. For the
     // incremental path, capture the committed target branch's node versions from
@@ -3330,6 +3656,42 @@ async function resolveMerge<G extends GraphDef, Output>(
       return err(candidates.error);
     }
 
+    // The separation veto is ON for every identity-enabled merge, independent
+    // of `identity.pairing`: a `different` assertion is an integrity fact, not
+    // a recall heuristic. The facts are captured ONCE here, before planning, so
+    // the candidate-edge veto below and the post-cluster transitive assertion
+    // inside `buildInternalMergePlan` read one fact set and cannot disagree —
+    // and so plan construction stays synchronous.
+    const separationFacts =
+      target.graph.identity === undefined ?
+        NO_IDENTITY_SEPARATION_FACTS
+      : await captureSeparationFactsForPairing(
+          target,
+          options.identity?.pairing ?? "off",
+          identityFusionGroups(
+            candidates.data.edges,
+            [
+              ...new Set([
+                ...[...stagedNewByKind].flatMap(([kind, entries]) =>
+                  entries.map((entry) => mergeKey(kind, entry.node.id)),
+                ),
+                ...candidates.data.baseMembers.map((member) =>
+                  mergeKeyOf(member),
+                ),
+              ]),
+            ],
+            options.reconcileTypes === "ontology",
+          ),
+        );
+    const veto = applyIdentitySeparationVeto(
+      candidates.data.edges,
+      separationFacts,
+    );
+    const identityCandidateConflicts = [
+      ...candidates.data.identityConflicts,
+      ...veto.conflicts,
+    ];
+
     // Same-id folding joins nodes no assertion names, so the plan-time
     // contradiction simulation needs the LIVE target peers sharing any staged
     // or base id. One kind-free indexed probe.
@@ -3391,7 +3753,7 @@ async function resolveMerge<G extends GraphDef, Output>(
     // (4–8) resolve the whole merge into a commit-ready plan.
     const plan = buildInternalMergePlan(
       staging,
-      candidates.data.edges,
+      veto.edges,
       candidates.data.warnings,
       candidates.data.diagnostics,
       candidates.data.diagnosticsTotal,
@@ -3402,6 +3764,8 @@ async function resolveMerge<G extends GraphDef, Output>(
       identityContext,
       storedIdentityRowsById,
       targetPeers,
+      separationFacts,
+      identityCandidateConflicts,
       preferredBranchId,
     );
 

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -105,7 +105,11 @@ import {
   translateMergeCommitError,
   UnsupportedMergePlanVersionError,
 } from "./errors";
-import type { CandidateDiagnostic, CandidateDiagnostics } from "./evidence";
+import type {
+  CandidateDiagnostic,
+  CandidateDiagnostics,
+  EntityRef,
+} from "./evidence";
 import { compareMatchEvidence } from "./evidence";
 import { unwrapMergeBranches } from "./ingestion-branch";
 import {
@@ -238,6 +242,8 @@ import type {
   Embedder,
   EntityResolution,
   GraphBranch,
+  IdentityReconciliation,
+  IdentityUnresolvedConflict,
   MergeBranch,
   MergedCounts,
   MergeIncrementalArgs as MergeIncrementalArguments,
@@ -933,6 +939,10 @@ export type MergePlan<G extends GraphDef> = Readonly<{
   // validation layers (the plan-time filter and the in-transaction freshness
   // guard) compare it to the target's row before the id is ended.
   identityRetractions: readonly IdentityTransferAssertion[];
+  /** Duplicate-assertion survivor picks the three-way classifier resolved. */
+  identityReconciliations: readonly IdentityReconciliation[];
+  /** Identity-assertion conflicts a resolving `onAssertionConflict` kept rather than refused. */
+  identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;
 
 /**
@@ -955,7 +965,11 @@ function buildInternalMergePlan<G extends GraphDef>(
   targetPeers: readonly Readonly<{ kind: string; id: string }>[],
   preferredBranchId?: BranchId,
 ): MergePlan<G> {
-  const identity = planIdentityChanges(staging, storedIdentityRowsById);
+  const identity = planIdentityChanges(
+    staging,
+    storedIdentityRowsById,
+    options.identity?.onAssertionConflict,
+  );
   const provenanceRecords: ProvenanceRecord[] = [];
   // The contributions already recorded, keyed by `contributionKey` — the sidecar
   // row's own identity, so a repeat is the same row written twice and never new
@@ -1633,7 +1647,93 @@ function buildInternalMergePlan<G extends GraphDef>(
       }),
     identityAssertions: identityRemap.assertions,
     identityRetractions: survivingRetractions,
+    identityReconciliations: identity.reconciliations.toSorted((left, right) =>
+      compareIdentityReportKeys(
+        identityReconciliationSortKey(left),
+        identityReconciliationSortKey(right),
+      ),
+    ),
+    identityConflicts: identity.unresolved.toSorted((left, right) =>
+      compareIdentityReportKeys(
+        identityUnresolvedConflictSortKey(left),
+        identityUnresolvedConflictSortKey(right),
+      ),
+    ),
   };
+}
+
+/**
+ * Order-independent sort key: `semanticKey` then the endpoint pair for the
+ * `assertion` shape (§4.1), degrading to whatever identifying fields the
+ * other {@link IdentityUnresolvedConflict} kinds carry — never insertion
+ * order, which would depend on which branch's diff happened to stage the
+ * item first.
+ */
+type IdentityReportSortKey = Readonly<{
+  semanticKey: string;
+  a: EntityRef;
+  b: EntityRef;
+}>;
+
+function identityReconciliationSortKey(
+  reconciliation: IdentityReconciliation,
+): IdentityReportSortKey {
+  return {
+    semanticKey: reconciliation.semanticKey,
+    a: reconciliation.a,
+    b: reconciliation.b,
+  };
+}
+
+const UNKEYED_ENTITY_REF: EntityRef = { kind: "", id: "" as EntityRef["id"] };
+
+function identityUnresolvedConflictSortKey(
+  conflict: IdentityUnresolvedConflict,
+): IdentityReportSortKey {
+  switch (conflict.kind) {
+    case "assertion": {
+      return {
+        semanticKey: conflict.semanticKey,
+        a: conflict.a,
+        b: conflict.b,
+      };
+    }
+    case "separation": {
+      return { semanticKey: conflict.kind, a: conflict.a, b: conflict.b };
+    }
+    case "uniqueness": {
+      return {
+        semanticKey: `${conflict.kind}|${conflict.constraintName}`,
+        a: conflict.members[0] ?? UNKEYED_ENTITY_REF,
+        b: conflict.members[1] ?? UNKEYED_ENTITY_REF,
+      };
+    }
+    case "provenance": {
+      return {
+        semanticKey: conflict.kind,
+        a: conflict.canonical,
+        b: UNKEYED_ENTITY_REF,
+      };
+    }
+  }
+}
+
+function compareIdentityReportKeys(
+  left: IdentityReportSortKey,
+  right: IdentityReportSortKey,
+): number {
+  const bySemanticKey = compareStrings(left.semanticKey, right.semanticKey);
+  if (bySemanticKey !== 0) return bySemanticKey;
+  const byA = compareMergeKeys(
+    mergeKey(left.a.kind, left.a.id),
+    mergeKey(right.a.kind, right.a.id),
+  );
+  return byA === 0 ?
+      compareMergeKeys(
+        mergeKey(left.b.kind, left.b.id),
+        mergeKey(right.b.kind, right.b.id),
+      )
+    : byA;
 }
 
 /**
@@ -2916,6 +3016,21 @@ async function resolvedMergeArtifact<G extends GraphDef>(
       ...(plan.candidateDiagnostics === undefined ?
         {}
       : { diagnostics: plan.candidateDiagnostics }),
+      // Optional and omitted when empty: a merge that
+      // reconciled nothing produces a review object byte-identical to
+      // today's, so the plan's stored format version never moves.
+      ...(plan.identityReconciliations.length === 0 ?
+        {}
+      : {
+          identityReconciliations:
+            plan.identityReconciliations as unknown as readonly JsonValue[],
+        }),
+      ...(plan.identityConflicts.length === 0 ?
+        {}
+      : {
+          identityConflicts:
+            plan.identityConflicts as unknown as readonly JsonValue[],
+        }),
     },
     provenance: {
       includeInReport: options.provenance,
@@ -3464,6 +3579,8 @@ async function commitResolvedMerge<G extends GraphDef>(
       {}
     : { candidateDiagnostics: plan.candidateDiagnostics }),
     ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
+    identityReconciliations: plan.identityReconciliations,
+    identityConflicts: plan.identityConflicts,
   };
 }
 
@@ -4196,6 +4313,10 @@ function reportFromArtifact<G extends GraphDef>(
           .diagnostics as unknown as CandidateDiagnostics,
       }),
     ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
+    identityReconciliations: (artifact.review.identityReconciliations ??
+      []) as unknown as readonly IdentityReconciliation[],
+    identityConflicts: (artifact.review.identityConflicts ??
+      []) as unknown as readonly IdentityUnresolvedConflict[],
   };
 }
 

--- a/packages/typegraph/src/graph-merge/merge.ts
+++ b/packages/typegraph/src/graph-merge/merge.ts
@@ -105,11 +105,7 @@ import {
   translateMergeCommitError,
   UnsupportedMergePlanVersionError,
 } from "./errors";
-import type {
-  CandidateDiagnostic,
-  CandidateDiagnostics,
-  EntityRef,
-} from "./evidence";
+import type { CandidateDiagnostic, CandidateDiagnostics } from "./evidence";
 import { compareMatchEvidence } from "./evidence";
 import { unwrapMergeBranches } from "./ingestion-branch";
 import {
@@ -242,8 +238,6 @@ import type {
   Embedder,
   EntityResolution,
   GraphBranch,
-  IdentityReconciliation,
-  IdentityUnresolvedConflict,
   MergeBranch,
   MergedCounts,
   MergeIncrementalArgs as MergeIncrementalArguments,
@@ -939,10 +933,6 @@ export type MergePlan<G extends GraphDef> = Readonly<{
   // validation layers (the plan-time filter and the in-transaction freshness
   // guard) compare it to the target's row before the id is ended.
   identityRetractions: readonly IdentityTransferAssertion[];
-  /** Duplicate-assertion survivor picks the three-way classifier resolved. */
-  identityReconciliations: readonly IdentityReconciliation[];
-  /** Identity-assertion conflicts a resolving `onAssertionConflict` kept rather than refused. */
-  identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;
 
 /**
@@ -965,11 +955,7 @@ function buildInternalMergePlan<G extends GraphDef>(
   targetPeers: readonly Readonly<{ kind: string; id: string }>[],
   preferredBranchId?: BranchId,
 ): MergePlan<G> {
-  const identity = planIdentityChanges(
-    staging,
-    storedIdentityRowsById,
-    options.identity?.onAssertionConflict,
-  );
+  const identity = planIdentityChanges(staging, storedIdentityRowsById);
   const provenanceRecords: ProvenanceRecord[] = [];
   // The contributions already recorded, keyed by `contributionKey` — the sidecar
   // row's own identity, so a repeat is the same row written twice and never new
@@ -1647,93 +1633,7 @@ function buildInternalMergePlan<G extends GraphDef>(
       }),
     identityAssertions: identityRemap.assertions,
     identityRetractions: survivingRetractions,
-    identityReconciliations: identity.reconciliations.toSorted((left, right) =>
-      compareIdentityReportKeys(
-        identityReconciliationSortKey(left),
-        identityReconciliationSortKey(right),
-      ),
-    ),
-    identityConflicts: identity.unresolved.toSorted((left, right) =>
-      compareIdentityReportKeys(
-        identityUnresolvedConflictSortKey(left),
-        identityUnresolvedConflictSortKey(right),
-      ),
-    ),
   };
-}
-
-/**
- * Order-independent sort key: `semanticKey` then the endpoint pair for the
- * `assertion` shape (§4.1), degrading to whatever identifying fields the
- * other {@link IdentityUnresolvedConflict} kinds carry — never insertion
- * order, which would depend on which branch's diff happened to stage the
- * item first.
- */
-type IdentityReportSortKey = Readonly<{
-  semanticKey: string;
-  a: EntityRef;
-  b: EntityRef;
-}>;
-
-function identityReconciliationSortKey(
-  reconciliation: IdentityReconciliation,
-): IdentityReportSortKey {
-  return {
-    semanticKey: reconciliation.semanticKey,
-    a: reconciliation.a,
-    b: reconciliation.b,
-  };
-}
-
-const UNKEYED_ENTITY_REF: EntityRef = { kind: "", id: "" as EntityRef["id"] };
-
-function identityUnresolvedConflictSortKey(
-  conflict: IdentityUnresolvedConflict,
-): IdentityReportSortKey {
-  switch (conflict.kind) {
-    case "assertion": {
-      return {
-        semanticKey: conflict.semanticKey,
-        a: conflict.a,
-        b: conflict.b,
-      };
-    }
-    case "separation": {
-      return { semanticKey: conflict.kind, a: conflict.a, b: conflict.b };
-    }
-    case "uniqueness": {
-      return {
-        semanticKey: `${conflict.kind}|${conflict.constraintName}`,
-        a: conflict.members[0] ?? UNKEYED_ENTITY_REF,
-        b: conflict.members[1] ?? UNKEYED_ENTITY_REF,
-      };
-    }
-    case "provenance": {
-      return {
-        semanticKey: conflict.kind,
-        a: conflict.canonical,
-        b: UNKEYED_ENTITY_REF,
-      };
-    }
-  }
-}
-
-function compareIdentityReportKeys(
-  left: IdentityReportSortKey,
-  right: IdentityReportSortKey,
-): number {
-  const bySemanticKey = compareStrings(left.semanticKey, right.semanticKey);
-  if (bySemanticKey !== 0) return bySemanticKey;
-  const byA = compareMergeKeys(
-    mergeKey(left.a.kind, left.a.id),
-    mergeKey(right.a.kind, right.a.id),
-  );
-  return byA === 0 ?
-      compareMergeKeys(
-        mergeKey(left.b.kind, left.b.id),
-        mergeKey(right.b.kind, right.b.id),
-      )
-    : byA;
 }
 
 /**
@@ -3016,21 +2916,6 @@ async function resolvedMergeArtifact<G extends GraphDef>(
       ...(plan.candidateDiagnostics === undefined ?
         {}
       : { diagnostics: plan.candidateDiagnostics }),
-      // Optional and omitted when empty (plan-G2 §4.2): a merge that
-      // reconciled nothing produces a review object byte-identical to
-      // today's, so the plan's stored format version never moves.
-      ...(plan.identityReconciliations.length === 0 ?
-        {}
-      : {
-          identityReconciliations:
-            plan.identityReconciliations as unknown as readonly JsonValue[],
-        }),
-      ...(plan.identityConflicts.length === 0 ?
-        {}
-      : {
-          identityConflicts:
-            plan.identityConflicts as unknown as readonly JsonValue[],
-        }),
     },
     provenance: {
       includeInReport: options.provenance,
@@ -3579,8 +3464,6 @@ async function commitResolvedMerge<G extends GraphDef>(
       {}
     : { candidateDiagnostics: plan.candidateDiagnostics }),
     ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
-    identityReconciliations: plan.identityReconciliations,
-    identityConflicts: plan.identityConflicts,
   };
 }
 
@@ -4313,10 +4196,6 @@ function reportFromArtifact<G extends GraphDef>(
           .diagnostics as unknown as CandidateDiagnostics,
       }),
     ...(provenancePersisted === undefined ? {} : { provenancePersisted }),
-    identityReconciliations: (artifact.review.identityReconciliations ??
-      []) as unknown as readonly IdentityReconciliation[],
-    identityConflicts: (artifact.review.identityConflicts ??
-      []) as unknown as readonly IdentityUnresolvedConflict[],
   };
 }
 

--- a/packages/typegraph/src/graph-merge/options.ts
+++ b/packages/typegraph/src/graph-merge/options.ts
@@ -15,6 +15,7 @@
 import { z } from "zod";
 
 import { createDataKeyedBag } from "../utils/object";
+import { InvalidMergeOptionsError } from "./errors";
 import type { IdentityAssertionConflictPolicy } from "./identity-three-way";
 import type { GraphDef } from "./typegraph-internal";
 import type {
@@ -47,8 +48,6 @@ export const MERGE_OPTION_DEFAULTS = {
   identity: {
     pairing: "off",
     onAssertionConflict: "refuse",
-    onEdgeConflict: "repoint",
-    onUniquenessConflict: "refuse",
     onProvenanceConflict: "keepBoth",
   },
 } as const satisfies Readonly<{
@@ -62,8 +61,6 @@ export const MERGE_OPTION_DEFAULTS = {
   identity: Readonly<{
     pairing: "off";
     onAssertionConflict: "refuse";
-    onEdgeConflict: "repoint";
-    onUniquenessConflict: "refuse";
     onProvenanceConflict: "keepBoth";
   }>;
 }>;
@@ -104,12 +101,6 @@ const identityOptionsScalarSchema = z
     pairing: z
       .enum(["off", "candidate", "definitional"])
       .default(MERGE_OPTION_DEFAULTS.identity.pairing),
-    onEdgeConflict: z
-      .enum(["repoint", "flag"])
-      .default(MERGE_OPTION_DEFAULTS.identity.onEdgeConflict),
-    onUniquenessConflict: z
-      .enum(["refuse", "flag"])
-      .default(MERGE_OPTION_DEFAULTS.identity.onUniquenessConflict),
     onProvenanceConflict: z
       .enum(["keepBoth", "refuse"])
       .default(MERGE_OPTION_DEFAULTS.identity.onProvenanceConflict),
@@ -225,8 +216,9 @@ function validateIdentityAssertionConflictPolicy(
     typeof policy === "string" &&
     !identityAssertionConflictPolicySchema.safeParse(policy).success
   ) {
-    throw new Error(
+    throw new InvalidMergeOptionsError(
       `Invalid identity.onAssertionConflict "${policy}": expected "refuse", "assertWins", "retractWins", "flag", or a function.`,
+      { details: { option: "identity.onAssertionConflict", policy } },
     );
   }
   return policy;
@@ -247,29 +239,11 @@ function validateIdentityOptions(
   if (identity === undefined) return undefined;
   const { onAssertionConflict, ...scalarInput } = identity;
   const scalar = identityOptionsScalarSchema.parse(scalarInput);
-  // Accepted or refused, never ignored. Both `"flag"` arms mean "drop the
-  // identity PAIRING and keep the data", which needs a plan rebuild with the
-  // offending identity candidate edges removed — machinery this release does
-  // not have. Refusing the value is the honest contract: a caller who states it
-  // learns the merge cannot honor it, instead of receiving a plan that silently
-  // applied the default.
-  if (scalar.onEdgeConflict === "flag") {
-    throw new Error(
-      'identity.onEdgeConflict: "flag" is not implemented: dropping an identity pairing whose repoint collides requires rebuilding the plan without that pairing. Use "repoint" (the default), which applies the repoint and reports the property disagreement through onPropertyConflict.',
-    );
-  }
-  if (scalar.onUniquenessConflict === "flag") {
-    throw new Error(
-      'identity.onUniquenessConflict: "flag" is not implemented: dropping an identity pairing whose fusion violates a unique constraint requires rebuilding the plan without that pairing. Use "refuse" (the default), which surfaces the violation through the existing constraint-conflict error.',
-    );
-  }
   return {
     pairing: scalar.pairing,
     onAssertionConflict: validateIdentityAssertionConflictPolicy(
       onAssertionConflict ?? MERGE_OPTION_DEFAULTS.identity.onAssertionConflict,
     ),
-    onEdgeConflict: scalar.onEdgeConflict,
-    onUniquenessConflict: scalar.onUniquenessConflict,
     onProvenanceConflict: scalar.onProvenanceConflict,
   };
 }

--- a/packages/typegraph/src/graph-merge/options.ts
+++ b/packages/typegraph/src/graph-merge/options.ts
@@ -247,6 +247,22 @@ function validateIdentityOptions(
   if (identity === undefined) return undefined;
   const { onAssertionConflict, ...scalarInput } = identity;
   const scalar = identityOptionsScalarSchema.parse(scalarInput);
+  // Accepted or refused, never ignored. Both `"flag"` arms mean "drop the
+  // identity PAIRING and keep the data", which needs a plan rebuild with the
+  // offending identity candidate edges removed — machinery this release does
+  // not have. Refusing the value is the honest contract: a caller who states it
+  // learns the merge cannot honor it, instead of receiving a plan that silently
+  // applied the default.
+  if (scalar.onEdgeConflict === "flag") {
+    throw new Error(
+      'identity.onEdgeConflict: "flag" is not implemented: dropping an identity pairing whose repoint collides requires rebuilding the plan without that pairing. Use "repoint" (the default), which applies the repoint and reports the property disagreement through onPropertyConflict.',
+    );
+  }
+  if (scalar.onUniquenessConflict === "flag") {
+    throw new Error(
+      'identity.onUniquenessConflict: "flag" is not implemented: dropping an identity pairing whose fusion violates a unique constraint requires rebuilding the plan without that pairing. Use "refuse" (the default), which surfaces the violation through the existing constraint-conflict error.',
+    );
+  }
   return {
     pairing: scalar.pairing,
     onAssertionConflict: validateIdentityAssertionConflictPolicy(

--- a/packages/typegraph/src/graph-merge/options.ts
+++ b/packages/typegraph/src/graph-merge/options.ts
@@ -15,6 +15,7 @@
 import { z } from "zod";
 
 import { createDataKeyedBag } from "../utils/object";
+import type { IdentityAssertionConflictPolicy } from "./identity-three-way";
 import type { GraphDef } from "./typegraph-internal";
 import type {
   BranchId,
@@ -22,6 +23,7 @@ import type {
   ComparisonCeilingPolicy,
   DeleteModifyPolicy,
   Embedder,
+  IdentityReconciliationOptions,
   MergeOptions,
   PropertyConflictPolicy,
   ReconcileTypesMode,
@@ -42,6 +44,13 @@ export const MERGE_OPTION_DEFAULTS = {
   onComparisonCeiling: "error",
   provenance: true,
   persistProvenance: false,
+  identity: {
+    pairing: "off",
+    onAssertionConflict: "refuse",
+    onEdgeConflict: "repoint",
+    onUniquenessConflict: "refuse",
+    onProvenanceConflict: "keepBoth",
+  },
 } as const satisfies Readonly<{
   reconcileTypes: ReconcileTypesMode;
   onPropertyConflict: "flag";
@@ -50,6 +59,13 @@ export const MERGE_OPTION_DEFAULTS = {
   onComparisonCeiling: ComparisonCeilingPolicy;
   provenance: boolean;
   persistProvenance: boolean;
+  identity: Readonly<{
+    pairing: "off";
+    onAssertionConflict: "refuse";
+    onEdgeConflict: "repoint";
+    onUniquenessConflict: "refuse";
+    onProvenanceConflict: "keepBoth";
+  }>;
 }>;
 
 /**
@@ -64,6 +80,41 @@ const propertyConflictPolicySchema = z.enum([
   "lastWriteWins",
   "provenanceWeighted",
 ]);
+
+/**
+ * zod schema for the STRING arm of `identity.onAssertionConflict` (the
+ * function arm is not validatable by zod, exactly the `onPropertyConflict`
+ * precedent above).
+ */
+const identityAssertionConflictPolicySchema = z.enum([
+  "refuse",
+  "assertWins",
+  "retractWins",
+  "flag",
+]);
+
+/**
+ * zod schema for `identity`'s scalar surface, EXCLUDING `onAssertionConflict`
+ * (validated separately, like `onPropertyConflict`, since it admits a
+ * function arm). `.strict()` so a mistyped sub-option is refused rather than
+ * silently ignored.
+ */
+const identityOptionsScalarSchema = z
+  .object({
+    pairing: z
+      .enum(["off", "candidate", "definitional"])
+      .default(MERGE_OPTION_DEFAULTS.identity.pairing),
+    onEdgeConflict: z
+      .enum(["repoint", "flag"])
+      .default(MERGE_OPTION_DEFAULTS.identity.onEdgeConflict),
+    onUniquenessConflict: z
+      .enum(["refuse", "flag"])
+      .default(MERGE_OPTION_DEFAULTS.identity.onUniquenessConflict),
+    onProvenanceConflict: z
+      .enum(["keepBoth", "refuse"])
+      .default(MERGE_OPTION_DEFAULTS.identity.onProvenanceConflict),
+  })
+  .strict();
 
 /** zod schema for a single resolve config's scalar surface (the threshold). */
 const resolveConfigScalarSchema = z.object({
@@ -139,6 +190,8 @@ export type NormalizedMergeOptions<G extends GraphDef = GraphDef> = Readonly<{
   candidateDiagnostics?: CandidateDiagnosticsOptions;
   branchOrder?: readonly BranchId[];
   provenanceWeights?: ReadonlyMap<BranchId, number>;
+  /** Presence-preserving: absent unless the caller stated `identity`. */
+  identity?: IdentityReconciliationOptions;
 }>;
 
 /**
@@ -159,6 +212,50 @@ function validatePropertyConflictPolicy<G extends GraphDef>(
     );
   }
   return policy;
+}
+
+/**
+ * Validates the STRING arm of `identity.onAssertionConflict` (the function
+ * arm is not validatable by zod).
+ */
+function validateIdentityAssertionConflictPolicy(
+  policy: IdentityAssertionConflictPolicy,
+): IdentityAssertionConflictPolicy {
+  if (
+    typeof policy === "string" &&
+    !identityAssertionConflictPolicySchema.safeParse(policy).success
+  ) {
+    throw new Error(
+      `Invalid identity.onAssertionConflict "${policy}": expected "refuse", "assertWins", "retractWins", "flag", or a function.`,
+    );
+  }
+  return policy;
+}
+
+/**
+ * Validates and fully resolves `identity`, PRESENCE-PRESERVING: `undefined`
+ * in, `undefined` out — the compatibility hinge that keeps a review artifact
+ * captured before this option existed revalidating `compatible`
+ * (`reviewOptionEvidence` encodes only what `normalizeMergeOptions` emits).
+ * `{}` in still resolves every default and comes back fully populated: the
+ * caller STATED they want identity reconciliation, even with every field at
+ * its default.
+ */
+function validateIdentityOptions(
+  identity: IdentityReconciliationOptions | undefined,
+): IdentityReconciliationOptions | undefined {
+  if (identity === undefined) return undefined;
+  const { onAssertionConflict, ...scalarInput } = identity;
+  const scalar = identityOptionsScalarSchema.parse(scalarInput);
+  return {
+    pairing: scalar.pairing,
+    onAssertionConflict: validateIdentityAssertionConflictPolicy(
+      onAssertionConflict ?? MERGE_OPTION_DEFAULTS.identity.onAssertionConflict,
+    ),
+    onEdgeConflict: scalar.onEdgeConflict,
+    onUniquenessConflict: scalar.onUniquenessConflict,
+    onProvenanceConflict: scalar.onProvenanceConflict,
+  };
 }
 
 /**
@@ -280,6 +377,8 @@ export function normalizeMergeOptions<G extends GraphDef>(
       undefined
     : validateProvenanceWeights(options.provenanceWeights);
 
+  const identity = validateIdentityOptions(options.identity);
+
   // "provenanceWeighted" without weights would silently degrade to a
   // stable-branch-order (lastWriteWins) resolution and quietly commit a
   // different graph. Fail loudly instead so the misconfiguration is visible.
@@ -322,5 +421,6 @@ export function normalizeMergeOptions<G extends GraphDef>(
       {}
     : { branchOrder: options.branchOrder }),
     ...(provenanceWeights === undefined ? {} : { provenanceWeights }),
+    ...(identity === undefined ? {} : { identity }),
   };
 }

--- a/packages/typegraph/src/graph-merge/options.ts
+++ b/packages/typegraph/src/graph-merge/options.ts
@@ -44,13 +44,6 @@ export const MERGE_OPTION_DEFAULTS = {
   onComparisonCeiling: "error",
   provenance: true,
   persistProvenance: false,
-  identity: {
-    pairing: "off",
-    onAssertionConflict: "refuse",
-    onEdgeConflict: "repoint",
-    onUniquenessConflict: "refuse",
-    onProvenanceConflict: "keepBoth",
-  },
 } as const satisfies Readonly<{
   reconcileTypes: ReconcileTypesMode;
   onPropertyConflict: "flag";
@@ -59,13 +52,29 @@ export const MERGE_OPTION_DEFAULTS = {
   onComparisonCeiling: ComparisonCeilingPolicy;
   provenance: boolean;
   persistProvenance: boolean;
-  identity: Readonly<{
-    pairing: "off";
-    onAssertionConflict: "refuse";
-    onEdgeConflict: "repoint";
-    onUniquenessConflict: "refuse";
-    onProvenanceConflict: "keepBoth";
-  }>;
+}>;
+
+/**
+ * Frozen `identity` defaults — the one place `normalizeIdentityOptions`'s
+ * default spelling lives. Kept SEPARATE from {@link MERGE_OPTION_DEFAULTS}
+ * (rather than a member of it) because that constant is already publicly
+ * re-exported (`src/graph-merge/index.ts`): folding `identity` into it would
+ * move `etc/typegraph-graph-merge.api.md`, a public-surface change this PR
+ * must not make. PR-3 can fold this back into `MERGE_OPTION_DEFAULTS` in the
+ * same commit that exports `IdentityReconciliationOptions`.
+ */
+export const IDENTITY_OPTION_DEFAULTS = {
+  pairing: "off",
+  onAssertionConflict: "refuse",
+  onEdgeConflict: "repoint",
+  onUniquenessConflict: "refuse",
+  onProvenanceConflict: "keepBoth",
+} as const satisfies Readonly<{
+  pairing: "off";
+  onAssertionConflict: "refuse";
+  onEdgeConflict: "repoint";
+  onUniquenessConflict: "refuse";
+  onProvenanceConflict: "keepBoth";
 }>;
 
 /**
@@ -103,16 +112,16 @@ const identityOptionsScalarSchema = z
   .object({
     pairing: z
       .enum(["off", "candidate", "definitional"])
-      .default(MERGE_OPTION_DEFAULTS.identity.pairing),
+      .default(IDENTITY_OPTION_DEFAULTS.pairing),
     onEdgeConflict: z
       .enum(["repoint", "flag"])
-      .default(MERGE_OPTION_DEFAULTS.identity.onEdgeConflict),
+      .default(IDENTITY_OPTION_DEFAULTS.onEdgeConflict),
     onUniquenessConflict: z
       .enum(["refuse", "flag"])
-      .default(MERGE_OPTION_DEFAULTS.identity.onUniquenessConflict),
+      .default(IDENTITY_OPTION_DEFAULTS.onUniquenessConflict),
     onProvenanceConflict: z
       .enum(["keepBoth", "refuse"])
-      .default(MERGE_OPTION_DEFAULTS.identity.onProvenanceConflict),
+      .default(IDENTITY_OPTION_DEFAULTS.onProvenanceConflict),
   })
   .strict();
 
@@ -190,8 +199,9 @@ export type NormalizedMergeOptions<G extends GraphDef = GraphDef> = Readonly<{
   candidateDiagnostics?: CandidateDiagnosticsOptions;
   branchOrder?: readonly BranchId[];
   provenanceWeights?: ReadonlyMap<BranchId, number>;
-  /** Presence-preserving: absent unless the caller stated `identity`. */
-  identity?: IdentityReconciliationOptions;
+  // NOTE: `identity` is not a member here yet — see the matching note on
+  // `MergeOptions` (types.ts). `normalizeIdentityOptions` below is the
+  // presence-preserving normalizer PR-3 will wire in as this field.
 }>;
 
 /**
@@ -233,15 +243,23 @@ function validateIdentityAssertionConflictPolicy(
 }
 
 /**
- * Validates and fully resolves `identity`, PRESENCE-PRESERVING: `undefined`
- * in, `undefined` out — the compatibility hinge that keeps a review artifact
- * captured before this option existed revalidating `compatible`
+ * Validates and fully resolves an `identity` options bag, PRESENCE-PRESERVING:
+ * `undefined` in, `undefined` out — the compatibility hinge PR-3 needs to keep
+ * a review artifact captured before this option existed revalidating
+ * `compatible` once `normalizeMergeOptions` threads this in as a member
  * (`reviewOptionEvidence` encodes only what `normalizeMergeOptions` emits).
  * `{}` in still resolves every default and comes back fully populated: the
  * caller STATED they want identity reconciliation, even with every field at
  * its default.
+ *
+ * Deliberately NOT called from {@link normalizeMergeOptions} yet: `MergeOptions`
+ * is already publicly exported, so wiring this in changes
+ * `etc/typegraph-graph-merge.api.md` — a public-surface change this PR must
+ * not make (see the `MergeOptions`/`NormalizedMergeOptions` notes above).
+ * PR-3 calls this from `normalizeMergeOptions` once `identity` is a real
+ * `MergeOptions` member and `IdentityReconciliationOptions` ships as an export.
  */
-function validateIdentityOptions(
+export function normalizeIdentityOptions(
   identity: IdentityReconciliationOptions | undefined,
 ): IdentityReconciliationOptions | undefined {
   if (identity === undefined) return undefined;
@@ -250,7 +268,7 @@ function validateIdentityOptions(
   return {
     pairing: scalar.pairing,
     onAssertionConflict: validateIdentityAssertionConflictPolicy(
-      onAssertionConflict ?? MERGE_OPTION_DEFAULTS.identity.onAssertionConflict,
+      onAssertionConflict ?? IDENTITY_OPTION_DEFAULTS.onAssertionConflict,
     ),
     onEdgeConflict: scalar.onEdgeConflict,
     onUniquenessConflict: scalar.onUniquenessConflict,
@@ -377,8 +395,6 @@ export function normalizeMergeOptions<G extends GraphDef>(
       undefined
     : validateProvenanceWeights(options.provenanceWeights);
 
-  const identity = validateIdentityOptions(options.identity);
-
   // "provenanceWeighted" without weights would silently degrade to a
   // stable-branch-order (lastWriteWins) resolution and quietly commit a
   // different graph. Fail loudly instead so the misconfiguration is visible.
@@ -421,6 +437,5 @@ export function normalizeMergeOptions<G extends GraphDef>(
       {}
     : { branchOrder: options.branchOrder }),
     ...(provenanceWeights === undefined ? {} : { provenanceWeights }),
-    ...(identity === undefined ? {} : { identity }),
   };
 }

--- a/packages/typegraph/src/graph-merge/options.ts
+++ b/packages/typegraph/src/graph-merge/options.ts
@@ -44,6 +44,13 @@ export const MERGE_OPTION_DEFAULTS = {
   onComparisonCeiling: "error",
   provenance: true,
   persistProvenance: false,
+  identity: {
+    pairing: "off",
+    onAssertionConflict: "refuse",
+    onEdgeConflict: "repoint",
+    onUniquenessConflict: "refuse",
+    onProvenanceConflict: "keepBoth",
+  },
 } as const satisfies Readonly<{
   reconcileTypes: ReconcileTypesMode;
   onPropertyConflict: "flag";
@@ -52,29 +59,13 @@ export const MERGE_OPTION_DEFAULTS = {
   onComparisonCeiling: ComparisonCeilingPolicy;
   provenance: boolean;
   persistProvenance: boolean;
-}>;
-
-/**
- * Frozen `identity` defaults — the one place `normalizeIdentityOptions`'s
- * default spelling lives. Kept SEPARATE from {@link MERGE_OPTION_DEFAULTS}
- * (rather than a member of it) because that constant is already publicly
- * re-exported (`src/graph-merge/index.ts`): folding `identity` into it would
- * move `etc/typegraph-graph-merge.api.md`, a public-surface change this PR
- * must not make. PR-3 can fold this back into `MERGE_OPTION_DEFAULTS` in the
- * same commit that exports `IdentityReconciliationOptions`.
- */
-export const IDENTITY_OPTION_DEFAULTS = {
-  pairing: "off",
-  onAssertionConflict: "refuse",
-  onEdgeConflict: "repoint",
-  onUniquenessConflict: "refuse",
-  onProvenanceConflict: "keepBoth",
-} as const satisfies Readonly<{
-  pairing: "off";
-  onAssertionConflict: "refuse";
-  onEdgeConflict: "repoint";
-  onUniquenessConflict: "refuse";
-  onProvenanceConflict: "keepBoth";
+  identity: Readonly<{
+    pairing: "off";
+    onAssertionConflict: "refuse";
+    onEdgeConflict: "repoint";
+    onUniquenessConflict: "refuse";
+    onProvenanceConflict: "keepBoth";
+  }>;
 }>;
 
 /**
@@ -112,16 +103,16 @@ const identityOptionsScalarSchema = z
   .object({
     pairing: z
       .enum(["off", "candidate", "definitional"])
-      .default(IDENTITY_OPTION_DEFAULTS.pairing),
+      .default(MERGE_OPTION_DEFAULTS.identity.pairing),
     onEdgeConflict: z
       .enum(["repoint", "flag"])
-      .default(IDENTITY_OPTION_DEFAULTS.onEdgeConflict),
+      .default(MERGE_OPTION_DEFAULTS.identity.onEdgeConflict),
     onUniquenessConflict: z
       .enum(["refuse", "flag"])
-      .default(IDENTITY_OPTION_DEFAULTS.onUniquenessConflict),
+      .default(MERGE_OPTION_DEFAULTS.identity.onUniquenessConflict),
     onProvenanceConflict: z
       .enum(["keepBoth", "refuse"])
-      .default(IDENTITY_OPTION_DEFAULTS.onProvenanceConflict),
+      .default(MERGE_OPTION_DEFAULTS.identity.onProvenanceConflict),
   })
   .strict();
 
@@ -199,9 +190,8 @@ export type NormalizedMergeOptions<G extends GraphDef = GraphDef> = Readonly<{
   candidateDiagnostics?: CandidateDiagnosticsOptions;
   branchOrder?: readonly BranchId[];
   provenanceWeights?: ReadonlyMap<BranchId, number>;
-  // NOTE: `identity` is not a member here yet — see the matching note on
-  // `MergeOptions` (types.ts). `normalizeIdentityOptions` below is the
-  // presence-preserving normalizer PR-3 will wire in as this field.
+  /** Presence-preserving: absent unless the caller stated `identity`. */
+  identity?: IdentityReconciliationOptions;
 }>;
 
 /**
@@ -243,23 +233,15 @@ function validateIdentityAssertionConflictPolicy(
 }
 
 /**
- * Validates and fully resolves an `identity` options bag, PRESENCE-PRESERVING:
- * `undefined` in, `undefined` out — the compatibility hinge PR-3 needs to keep
- * a review artifact captured before this option existed revalidating
- * `compatible` once `normalizeMergeOptions` threads this in as a member
+ * Validates and fully resolves `identity`, PRESENCE-PRESERVING: `undefined`
+ * in, `undefined` out — the compatibility hinge that keeps a review artifact
+ * captured before this option existed revalidating `compatible`
  * (`reviewOptionEvidence` encodes only what `normalizeMergeOptions` emits).
  * `{}` in still resolves every default and comes back fully populated: the
  * caller STATED they want identity reconciliation, even with every field at
  * its default.
- *
- * Deliberately NOT called from {@link normalizeMergeOptions} yet: `MergeOptions`
- * is already publicly exported, so wiring this in changes
- * `etc/typegraph-graph-merge.api.md` — a public-surface change this PR must
- * not make (see the `MergeOptions`/`NormalizedMergeOptions` notes above).
- * PR-3 calls this from `normalizeMergeOptions` once `identity` is a real
- * `MergeOptions` member and `IdentityReconciliationOptions` ships as an export.
  */
-export function normalizeIdentityOptions(
+function validateIdentityOptions(
   identity: IdentityReconciliationOptions | undefined,
 ): IdentityReconciliationOptions | undefined {
   if (identity === undefined) return undefined;
@@ -268,7 +250,7 @@ export function normalizeIdentityOptions(
   return {
     pairing: scalar.pairing,
     onAssertionConflict: validateIdentityAssertionConflictPolicy(
-      onAssertionConflict ?? IDENTITY_OPTION_DEFAULTS.onAssertionConflict,
+      onAssertionConflict ?? MERGE_OPTION_DEFAULTS.identity.onAssertionConflict,
     ),
     onEdgeConflict: scalar.onEdgeConflict,
     onUniquenessConflict: scalar.onUniquenessConflict,
@@ -395,6 +377,8 @@ export function normalizeMergeOptions<G extends GraphDef>(
       undefined
     : validateProvenanceWeights(options.provenanceWeights);
 
+  const identity = validateIdentityOptions(options.identity);
+
   // "provenanceWeighted" without weights would silently degrade to a
   // stable-branch-order (lastWriteWins) resolution and quietly commit a
   // different graph. Fail loudly instead so the misconfiguration is visible.
@@ -437,5 +421,6 @@ export function normalizeMergeOptions<G extends GraphDef>(
       {}
     : { branchOrder: options.branchOrder }),
     ...(provenanceWeights === undefined ? {} : { provenanceWeights }),
+    ...(identity === undefined ? {} : { identity }),
   };
 }

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -236,6 +236,10 @@ export type MergePlanReview = Readonly<{
   warnings: readonly string[];
   compositionOrphans: readonly MergePlanCompositionOrphan[];
   diagnostics?: MergePlanDiagnostics | undefined;
+  /** Optional, omitted when empty — see plan-G2 §4.2's format-version note. */
+  identityReconciliations?: readonly JsonValue[] | undefined;
+  /** Optional, omitted when empty — see plan-G2 §4.2's format-version note. */
+  identityConflicts?: readonly JsonValue[] | undefined;
 }>;
 
 export type MergePlanProvenanceOptions = Readonly<{
@@ -564,6 +568,49 @@ const diagnosticsSchema = z
   })
   .strict();
 
+const identityReconciliationSchema = z
+  .object({
+    semanticKey: nonEmptyStringSchema,
+    a: mergePlanEntityRefSchema,
+    b: mergePlanEntityRefSchema,
+    relation: z.enum(["same", "different"]),
+    survivorAssertionId: nonEmptyStringSchema,
+    supersededAssertionIds: z.array(nonEmptyStringSchema),
+    rule: z.enum([
+      "earliest-valid-from",
+      "code-point-id",
+      "committed-id",
+      "policy",
+    ]),
+    policy: z.string().optional(),
+    branches: z.array(nonEmptyStringSchema),
+  })
+  .strict();
+
+/**
+ * Only the `"assertion"` arm is validated today — the sole
+ * {@link IdentityUnresolvedConflict} kind `planIdentityThreeWay` (identity-
+ * three-way.ts) actually produces. The `"separation"` / `"uniqueness"` /
+ * `"provenance"` arms are owed when their producers land (plan-G2 §2/§3).
+ */
+const identityUnresolvedConflictSchema = z
+  .object({
+    kind: z.literal("assertion"),
+    reason: z.enum([
+      "retract-reassert",
+      "opposing-relations",
+      "id-reuse",
+      "cross-kind-pairing",
+    ]),
+    semanticKey: nonEmptyStringSchema,
+    a: mergePlanEntityRefSchema,
+    b: mergePlanEntityRefSchema,
+    relation: z.enum(["same", "different"]),
+    assertionIds: z.array(nonEmptyStringSchema),
+    branches: z.array(nonEmptyStringSchema),
+  })
+  .strict();
+
 const mergePlanReviewSchema = z
   .object({
     resolutions: z.array(entityResolutionSchema),
@@ -670,6 +717,11 @@ const mergePlanReviewSchema = z
         .strict(),
     ),
     diagnostics: diagnosticsSchema.optional(),
+    // Optional and omitted when empty (the `diagnostics` precedent above): a
+    // merge that reconciled nothing produces a review object byte-identical
+    // to today's, so `MERGE_PLAN_FORMAT_VERSION` stays unchanged (plan-G2 §4.2).
+    identityReconciliations: z.array(identityReconciliationSchema).optional(),
+    identityConflicts: z.array(identityUnresolvedConflictSchema).optional(),
   })
   .strict();
 

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -196,7 +196,7 @@ export type MergePlanCandidateDiagnostic = Readonly<{
     | "retained"
     | Readonly<{
         kind: "excluded";
-        reason: "diameter" | "baseAmbiguity";
+        reason: "diameter" | "baseAmbiguity" | "separation";
       }>
     | undefined;
 }>;
@@ -566,7 +566,7 @@ const diagnosticsSchema = z
               z
                 .object({
                   kind: z.literal("excluded"),
-                  reason: z.enum(["diameter", "baseAmbiguity"]),
+                  reason: z.enum(["diameter", "baseAmbiguity", "separation"]),
                 })
                 .strict(),
             ])
@@ -642,13 +642,9 @@ const identityUnresolvedConflictSchema = z.discriminatedUnion("kind", [
       source: matchSourceSchema.optional(),
     })
     .strict(),
-  z
-    .object({
-      kind: z.literal("provenance"),
-      canonical: mergePlanEntityRefSchema,
-      contributions: z.array(identityProvenanceRecordSchema),
-    })
-    .strict(),
+  // No `"provenance"` arm: `onProvenanceConflict` has no reporting
+  // disposition that could ever place one on this array (see the matching
+  // note on `IdentityUnresolvedConflict` in types.ts).
 ]);
 
 const mergePlanReviewSchema = z

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -147,6 +147,11 @@ export type MergePlanMatchSource =
       kind: "custom";
       sourceId: string;
       metadata?: JsonValue | undefined;
+    }>
+  | Readonly<{
+      kind: "identity";
+      sourceId: string;
+      assertionIds: readonly string[];
     }>;
 
 export type MergePlanSimilarityStrategy =
@@ -477,6 +482,13 @@ const matchSourceSchema = z.discriminatedUnion("kind", [
       metadata: z.json().optional(),
     })
     .strict(),
+  z
+    .object({
+      kind: z.literal("identity"),
+      sourceId: nonEmptyStringSchema,
+      assertionIds: z.array(nonEmptyStringSchema),
+    })
+    .strict(),
 ]);
 
 const similarityStrategySchema = z.discriminatedUnion("kind", [
@@ -587,30 +599,65 @@ const identityReconciliationSchema = z
   })
   .strict();
 
-/**
- * Only the `"assertion"` arm is validated today — the sole
- * {@link IdentityUnresolvedConflict} kind `planIdentityThreeWay` (identity-
- * three-way.ts) actually produces. The `"separation"` / `"uniqueness"` /
- * `"provenance"` arms are produced by the separation veto, the uniqueness
- * drop and the provenance refusal respectively.
- */
-const identityUnresolvedConflictSchema = z
+const identityProvenanceRecordSchema = z
   .object({
-    kind: z.literal("assertion"),
-    reason: z.enum([
-      "retract-reassert",
-      "opposing-relations",
-      "id-reuse",
-      "cross-kind-pairing",
-    ]),
-    semanticKey: nonEmptyStringSchema,
-    a: mergePlanEntityRefSchema,
-    b: mergePlanEntityRefSchema,
-    relation: z.enum(["same", "different"]),
-    assertionIds: z.array(nonEmptyStringSchema),
-    branches: z.array(nonEmptyStringSchema),
+    role: z.enum(["node", "edge"]),
+    canonicalId: nonEmptyStringSchema,
+    canonicalKind: nonEmptyStringSchema,
+    branchId: nonEmptyStringSchema,
+    sourceId: nonEmptyStringSchema,
   })
   .strict();
+
+/**
+ * Every arm of the public `IdentityUnresolvedConflict` union, validated
+ * STRICTLY rather than as opaque JSON: an entry the merge could not have
+ * produced fails at parse, where the plan artifact is read, rather than at the
+ * point a consumer reaches into a field that is not there.
+ */
+const identityUnresolvedConflictSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("assertion"),
+      reason: z.enum([
+        "retract-reassert",
+        "opposing-relations",
+        "id-reuse",
+        "cross-kind-pairing",
+      ]),
+      semanticKey: nonEmptyStringSchema,
+      a: mergePlanEntityRefSchema,
+      b: mergePlanEntityRefSchema,
+      relation: z.enum(["same", "different"]),
+      assertionIds: z.array(nonEmptyStringSchema),
+      branches: z.array(nonEmptyStringSchema),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("separation"),
+      a: mergePlanEntityRefSchema,
+      b: mergePlanEntityRefSchema,
+      assertionIds: z.array(nonEmptyStringSchema),
+      source: matchSourceSchema.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("uniqueness"),
+      constraintName: nonEmptyStringSchema,
+      members: z.array(mergePlanEntityRefSchema),
+      assertionIds: z.array(nonEmptyStringSchema),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("provenance"),
+      canonical: mergePlanEntityRefSchema,
+      contributions: z.array(identityProvenanceRecordSchema),
+    })
+    .strict(),
+]);
 
 const mergePlanReviewSchema = z
   .object({
@@ -696,17 +743,7 @@ const mergePlanReviewSchema = z
         })
         .strict(),
     ),
-    provenanceRecords: z.array(
-      z
-        .object({
-          role: z.enum(["node", "edge"]),
-          canonicalId: nonEmptyStringSchema,
-          canonicalKind: nonEmptyStringSchema,
-          branchId: nonEmptyStringSchema,
-          sourceId: nonEmptyStringSchema,
-        })
-        .strict(),
-    ),
+    provenanceRecords: z.array(identityProvenanceRecordSchema),
     warnings: z.array(z.string()),
     compositionOrphans: z.array(
       z

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -236,10 +236,6 @@ export type MergePlanReview = Readonly<{
   warnings: readonly string[];
   compositionOrphans: readonly MergePlanCompositionOrphan[];
   diagnostics?: MergePlanDiagnostics | undefined;
-  /** Optional, omitted when empty — see plan-G2 §4.2's format-version note. */
-  identityReconciliations?: readonly JsonValue[] | undefined;
-  /** Optional, omitted when empty — see plan-G2 §4.2's format-version note. */
-  identityConflicts?: readonly JsonValue[] | undefined;
 }>;
 
 export type MergePlanProvenanceOptions = Readonly<{
@@ -568,49 +564,6 @@ const diagnosticsSchema = z
   })
   .strict();
 
-const identityReconciliationSchema = z
-  .object({
-    semanticKey: nonEmptyStringSchema,
-    a: mergePlanEntityRefSchema,
-    b: mergePlanEntityRefSchema,
-    relation: z.enum(["same", "different"]),
-    survivorAssertionId: nonEmptyStringSchema,
-    supersededAssertionIds: z.array(nonEmptyStringSchema),
-    rule: z.enum([
-      "earliest-valid-from",
-      "code-point-id",
-      "committed-id",
-      "policy",
-    ]),
-    policy: z.string().optional(),
-    branches: z.array(nonEmptyStringSchema),
-  })
-  .strict();
-
-/**
- * Only the `"assertion"` arm is validated today — the sole
- * {@link IdentityUnresolvedConflict} kind `planIdentityThreeWay` (identity-
- * three-way.ts) actually produces. The `"separation"` / `"uniqueness"` /
- * `"provenance"` arms are owed when their producers land (plan-G2 §2/§3).
- */
-const identityUnresolvedConflictSchema = z
-  .object({
-    kind: z.literal("assertion"),
-    reason: z.enum([
-      "retract-reassert",
-      "opposing-relations",
-      "id-reuse",
-      "cross-kind-pairing",
-    ]),
-    semanticKey: nonEmptyStringSchema,
-    a: mergePlanEntityRefSchema,
-    b: mergePlanEntityRefSchema,
-    relation: z.enum(["same", "different"]),
-    assertionIds: z.array(nonEmptyStringSchema),
-    branches: z.array(nonEmptyStringSchema),
-  })
-  .strict();
-
 const mergePlanReviewSchema = z
   .object({
     resolutions: z.array(entityResolutionSchema),
@@ -717,11 +670,6 @@ const mergePlanReviewSchema = z
         .strict(),
     ),
     diagnostics: diagnosticsSchema.optional(),
-    // Optional and omitted when empty (the `diagnostics` precedent above): a
-    // merge that reconciled nothing produces a review object byte-identical
-    // to today's, so `MERGE_PLAN_FORMAT_VERSION` stays unchanged (plan-G2 §4.2).
-    identityReconciliations: z.array(identityReconciliationSchema).optional(),
-    identityConflicts: z.array(identityUnresolvedConflictSchema).optional(),
   })
   .strict();
 

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -236,6 +236,10 @@ export type MergePlanReview = Readonly<{
   warnings: readonly string[];
   compositionOrphans: readonly MergePlanCompositionOrphan[];
   diagnostics?: MergePlanDiagnostics | undefined;
+  /** Optional, omitted when empty — see the review schema's format-version note. */
+  identityReconciliations?: readonly JsonValue[] | undefined;
+  /** Optional, omitted when empty — see the review schema's format-version note. */
+  identityConflicts?: readonly JsonValue[] | undefined;
 }>;
 
 export type MergePlanProvenanceOptions = Readonly<{
@@ -564,6 +568,50 @@ const diagnosticsSchema = z
   })
   .strict();
 
+const identityReconciliationSchema = z
+  .object({
+    semanticKey: nonEmptyStringSchema,
+    a: mergePlanEntityRefSchema,
+    b: mergePlanEntityRefSchema,
+    relation: z.enum(["same", "different"]),
+    survivorAssertionId: nonEmptyStringSchema,
+    supersededAssertionIds: z.array(nonEmptyStringSchema),
+    rule: z.enum([
+      "earliest-valid-from",
+      "code-point-id",
+      "committed-id",
+      "policy",
+    ]),
+    policy: z.string().optional(),
+    branches: z.array(nonEmptyStringSchema),
+  })
+  .strict();
+
+/**
+ * Only the `"assertion"` arm is validated today — the sole
+ * {@link IdentityUnresolvedConflict} kind `planIdentityThreeWay` (identity-
+ * three-way.ts) actually produces. The `"separation"` / `"uniqueness"` /
+ * `"provenance"` arms are produced by the separation veto, the uniqueness
+ * drop and the provenance refusal respectively.
+ */
+const identityUnresolvedConflictSchema = z
+  .object({
+    kind: z.literal("assertion"),
+    reason: z.enum([
+      "retract-reassert",
+      "opposing-relations",
+      "id-reuse",
+      "cross-kind-pairing",
+    ]),
+    semanticKey: nonEmptyStringSchema,
+    a: mergePlanEntityRefSchema,
+    b: mergePlanEntityRefSchema,
+    relation: z.enum(["same", "different"]),
+    assertionIds: z.array(nonEmptyStringSchema),
+    branches: z.array(nonEmptyStringSchema),
+  })
+  .strict();
+
 const mergePlanReviewSchema = z
   .object({
     resolutions: z.array(entityResolutionSchema),
@@ -670,6 +718,12 @@ const mergePlanReviewSchema = z
         .strict(),
     ),
     diagnostics: diagnosticsSchema.optional(),
+    // Optional and omitted when empty (the `diagnostics` precedent above): a
+    // merge that reconciled nothing produces a review object byte-identical
+    // to today's, so `MERGE_PLAN_FORMAT_VERSION` stays at 2 and every plan
+    // artifact serialized before identity reconciliation existed still parses.
+    identityReconciliations: z.array(identityReconciliationSchema).optional(),
+    identityConflicts: z.array(identityUnresolvedConflictSchema).optional(),
   })
   .strict();
 

--- a/packages/typegraph/src/graph-merge/plan-schema.ts
+++ b/packages/typegraph/src/graph-merge/plan-schema.ts
@@ -586,7 +586,7 @@ const identityReconciliationSchema = z
     a: mergePlanEntityRefSchema,
     b: mergePlanEntityRefSchema,
     relation: z.enum(["same", "different"]),
-    survivorAssertionId: nonEmptyStringSchema,
+    survivorAssertionId: nonEmptyStringSchema.optional(),
     supersededAssertionIds: z.array(nonEmptyStringSchema),
     rule: z.enum([
       "earliest-valid-from",
@@ -622,8 +622,8 @@ const identityUnresolvedConflictSchema = z.discriminatedUnion("kind", [
       reason: z.enum([
         "retract-reassert",
         "opposing-relations",
-        "id-reuse",
         "cross-kind-pairing",
+        "out-of-scope-pairing",
       ]),
       semanticKey: nonEmptyStringSchema,
       a: mergePlanEntityRefSchema,
@@ -640,14 +640,6 @@ const identityUnresolvedConflictSchema = z.discriminatedUnion("kind", [
       b: mergePlanEntityRefSchema,
       assertionIds: z.array(nonEmptyStringSchema),
       source: matchSourceSchema.optional(),
-    })
-    .strict(),
-  z
-    .object({
-      kind: z.literal("uniqueness"),
-      constraintName: nonEmptyStringSchema,
-      members: z.array(mergePlanEntityRefSchema),
-      assertionIds: z.array(nonEmptyStringSchema),
     })
     .strict(),
   z

--- a/packages/typegraph/src/graph-merge/sources.ts
+++ b/packages/typegraph/src/graph-merge/sources.ts
@@ -894,14 +894,28 @@ export const baseKeySource: CandidateSource = {
 export const identitySource: CandidateSource = {
   id: "identity",
   generate(scope) {
-    const { identity } = scope;
+    const { identity, nodes } = scope;
     if (identity === undefined || identity.assertions.length === 0) {
       return Promise.resolve({ pairs: [], forcedEdges: [], baseMembers: [] });
     }
-    const nodesByKey = new Map<MergeKey, Node<NodeType>>();
-    for (const members of scope.blocks.values()) {
-      for (const node of members) nodesByKey.set(mergeKeyOf(node), node);
+    if (nodes === undefined) {
+      throw new CandidateSourceError(
+        "identitySource requires the kind's staged nodes in the source scope.",
+        {
+          details: {
+            kind: scope.kind,
+            source: "identity",
+            sourceId: "identity",
+            operation: "generate",
+          },
+        },
+      );
     }
+    // The kind's staged NEW nodes directly, not the blocked buckets: an
+    // assertion pairs the entities it names, whatever blocking key they carry
+    // (a kind can be identity-paired with no `block` at all).
+    const nodesByKey = new Map<MergeKey, Node<NodeType>>();
+    for (const node of nodes) nodesByKey.set(mergeKeyOf(node), node);
     // One entry per ENDPOINT PAIR: several assertions can name the same pair
     // (a re-assertion under a fresh id, or two branches asserting it
     // independently), and the evidence records every one of them rather than

--- a/packages/typegraph/src/graph-merge/sources.ts
+++ b/packages/typegraph/src/graph-merge/sources.ts
@@ -58,6 +58,7 @@ import { FORCED_MATCH_SCORE } from "./scoring";
 import { fieldText } from "./similarity";
 import type {
   GraphDef,
+  IdentityTransferAssertion,
   JsonValue,
   Node,
   NodeId,
@@ -149,6 +150,25 @@ export type SourceScope = Readonly<{
    * neighbourhood instead of all-vs-all (the `keyless` source, §6.2). */
   keyless?: KeylessConfig;
   store?: BaseLookupStore;
+  /**
+   * The `same` identity assertions in scope for this kind, and how strongly
+   * they pair. Present only when the graph declares `identity` and the caller
+   * stated `identity.pairing` as something other than `"off"`; the field is a
+   * SCOPE fragment, not a backend handle.
+   */
+  identity?: IdentityPairingScope;
+}>;
+
+/**
+ * The identity slice of a {@link SourceScope}: every `same` assertion whose two
+ * endpoints are both staged new nodes of this kind, plus the strength the
+ * caller asked for. An assertion is a recall signal (`"candidate"`, scored
+ * against the kind's threshold) or a definition (`"definitional"`, a forced
+ * edge at {@link FORCED_MATCH_SCORE}) — never both.
+ */
+export type IdentityPairingScope = Readonly<{
+  pairing: "candidate" | "definitional";
+  assertions: readonly IdentityTransferAssertion[];
 }>;
 
 /**
@@ -838,6 +858,123 @@ export const baseKeySource: CandidateSource = {
         compareStrings(left.id, right.id),
       ),
     };
+  },
+};
+
+/**
+ * `identity` source — the IDENTITY-DRIVEN recall path. An explicit
+ * `store.identity.assertSame(a, b)` says the two nodes are one entity; this
+ * source is what lets a merge act on that, instead of only refusing the
+ * contradiction it would otherwise discover at commit.
+ *
+ * It reads `scope.identity.assertions` — the `same` assertions the CALLER
+ * already restricted to this kind, drawn from the same staging slices the
+ * three-way classifier reads, so the pairing source and the classifier can
+ * never disagree about which assertions exist. An assertion naming a node that
+ * is not a staged new node of this kind proposes nothing: recall can only
+ * propose over the nodes in scope.
+ *
+ * The strength is the caller's, not this module's:
+ *
+ *   - `"candidate"` emits a scored {@link CandidatePair}, so the assertion is
+ *     strong recall and the kind's threshold still decides. An assertion is
+ *     evidence, not proof.
+ *   - `"definitional"` emits a forced {@link CandidateEdge} at
+ *     {@link FORCED_MATCH_SCORE}, exactly as a shared unique value does — the
+ *     one place a `same` assertion consolidates two rows into one.
+ *
+ * NOT part of {@link CANDIDATE_SOURCES}: the source is constructed only when
+ * the graph declares `identity` and the caller stated a pairing mode, so a
+ * merge that never sets `identity` runs precisely the sources it always has.
+ *
+ * Determinism: assertions are visited in `(a, b, id)` order and each pair is
+ * canonicalized by {@link orderEndpoints}, so the emission order is a pure
+ * function of the assertion SET.
+ */
+export const identitySource: CandidateSource = {
+  id: "identity",
+  generate(scope) {
+    const { identity } = scope;
+    if (identity === undefined || identity.assertions.length === 0) {
+      return Promise.resolve({ pairs: [], forcedEdges: [], baseMembers: [] });
+    }
+    const nodesByKey = new Map<MergeKey, Node<NodeType>>();
+    for (const members of scope.blocks.values()) {
+      for (const node of members) nodesByKey.set(mergeKeyOf(node), node);
+    }
+    // One entry per ENDPOINT PAIR: several assertions can name the same pair
+    // (a re-assertion under a fresh id, or two branches asserting it
+    // independently), and the evidence records every one of them rather than
+    // proposing the pair twice.
+    const assertionIdsByPair = new Map<
+      string,
+      Readonly<{ left: Node<NodeType>; right: Node<NodeType>; ids: string[] }>
+    >();
+    const ordered = [...identity.assertions].sort((left, right) =>
+      compareStrings(
+        JSON.stringify([
+          left.a.kind,
+          left.a.id,
+          left.b.kind,
+          left.b.id,
+          left.id,
+        ]),
+        JSON.stringify([
+          right.a.kind,
+          right.a.id,
+          right.b.kind,
+          right.b.id,
+          right.id,
+        ]),
+      ),
+    );
+    for (const assertion of ordered) {
+      const left = nodesByKey.get(mergeKeyOf(assertion.a));
+      const right = nodesByKey.get(mergeKeyOf(assertion.b));
+      // Not in scope for this kind's candidate generation — the assertion
+      // names a committed node, a node of another kind, or one no branch
+      // staged. Recall proposes over the nodes it has.
+      if (left === undefined || right === undefined) continue;
+      // An assertion naming one node twice is a self-loop, never a pairing.
+      if (left.id === right.id && left.kind === right.kind) continue;
+      const { a, b } = orderEndpoints(left, right, []);
+      const pairKey = `${a}\u0000${b}`;
+      const existing = assertionIdsByPair.get(pairKey);
+      if (existing === undefined) {
+        assertionIdsByPair.set(pairKey, { left, right, ids: [assertion.id] });
+      } else {
+        existing.ids.push(assertion.id);
+      }
+    }
+
+    const pairs: CandidatePair[] = [];
+    const forcedEdges: CandidateEdge[] = [];
+    for (const { left, right, ids } of assertionIdsByPair.values()) {
+      const source: MatchSource = {
+        kind: "identity",
+        sourceId: "identity",
+        assertionIds: [...ids].sort((first, second) =>
+          compareStrings(first, second),
+        ),
+      };
+      if (identity.pairing === "candidate") {
+        pairs.push(orderEndpoints(left, right, [source]));
+        continue;
+      }
+      const { a, b } = orderEndpoints(left, right, []);
+      forcedEdges.push({
+        a,
+        b,
+        score: FORCED_MATCH_SCORE,
+        evidence: {
+          a: entityRef(a),
+          b: entityRef(b),
+          sources: [source],
+          decision: "definitional",
+        },
+      });
+    }
+    return Promise.resolve({ pairs, forcedEdges, baseMembers: [] });
   },
 };
 

--- a/packages/typegraph/src/graph-merge/sources.ts
+++ b/packages/typegraph/src/graph-merge/sources.ts
@@ -1,5 +1,6 @@
 import { createDataKeyedBag } from "../utils/object";
 import { requireDefined } from "../utils/presence";
+import { encodeTupleKey } from "../utils/tuple-key";
 /**
  * Candidate SOURCES (design §4 / §6.1) — the RECALL layer of candidate generation.
  *
@@ -926,14 +927,14 @@ export const identitySource: CandidateSource = {
     >();
     const ordered = [...identity.assertions].sort((left, right) =>
       compareStrings(
-        JSON.stringify([
+        encodeTupleKey([
           left.a.kind,
           left.a.id,
           left.b.kind,
           left.b.id,
           left.id,
         ]),
-        JSON.stringify([
+        encodeTupleKey([
           right.a.kind,
           right.a.id,
           right.b.kind,

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -39,6 +39,7 @@ export {
 } from "../errors";
 export {
   bulkIsSeparated,
+  hasLiveDifferentAssertions,
   IDENTITY_STORAGE_MISSING_CODE,
 } from "../identity/separation";
 export type { IdentityTransferAssertion } from "../identity/service";

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -37,7 +37,19 @@ export {
   TypeGraphError,
   type TypeGraphErrorOptions,
 } from "../errors";
+export {
+  bulkIsSeparated,
+  IDENTITY_STORAGE_MISSING_CODE,
+} from "../identity/separation";
 export type { IdentityTransferAssertion } from "../identity/service";
+export { currentClassKey } from "../identity/service-mutation";
+export {
+  refKey as identityReferenceKeyOf,
+  loadCurrentStructuralClasses,
+  loadSpanningDifferentAssertion,
+} from "../identity/service-read";
+export type { IdentityServiceContext } from "../identity/service-types";
+export type { PlainNodeRef } from "../identity/sql-target";
 export type {
   IdentityAssertionWriteFacade,
   IdentityFacade,

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -50,6 +50,7 @@ export {
 } from "../identity/service-read";
 export type { IdentityServiceContext } from "../identity/service-types";
 export type { PlainNodeRef } from "../identity/sql-target";
+export type { IdentityDecisionProvenance } from "../identity/transition-log";
 export type {
   IdentityAssertionWriteFacade,
   IdentityFacade,

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -41,6 +41,7 @@ export {
   bulkIsSeparated,
   hasLiveDifferentAssertions,
   IDENTITY_STORAGE_MISSING_CODE,
+  separationFactsKnownEmpty,
 } from "../identity/separation";
 export type { IdentityTransferAssertion } from "../identity/service";
 export { currentClassKey } from "../identity/service-mutation";

--- a/packages/typegraph/src/graph-merge/typegraph-internal.ts
+++ b/packages/typegraph/src/graph-merge/typegraph-internal.ts
@@ -48,12 +48,12 @@ export {
   loadCurrentStructuralClasses,
   loadSpanningDifferentAssertion,
 } from "../identity/service-read";
-export type { IdentityServiceContext } from "../identity/service-types";
 export type { PlainNodeRef } from "../identity/sql-target";
 export type { IdentityDecisionProvenance } from "../identity/transition-log";
 export type {
   IdentityAssertionWriteFacade,
   IdentityFacade,
+  IdentityRelation,
 } from "../identity/types";
 export { exportGraph, exportGraphStream } from "../interchange/export";
 export { importGraph, importGraphStream } from "../interchange/import";

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -371,21 +371,31 @@ export type IdentityReconciliationOptions = Readonly<{
   onAssertionConflict?: IdentityAssertionConflictPolicy;
   /**
    * How an identity-paired cluster's repointed edge collides with another.
-   * `"repoint"` (default) applies the repoint; `"flag"` keeps the edge and
-   * records a typed conflict.
+   * `"repoint"` (default) applies the repoint, reporting any property
+   * disagreement through {@link MergeOptions.onPropertyConflict}.
+   *
+   * `"flag"` — drop the pairing, keep both edges — is REFUSED with an
+   * invalid-option error rather than silently applying the default: dropping a
+   * pairing requires rebuilding the plan without the offending identity
+   * candidate edge, which this release does not do.
    */
   onEdgeConflict?: "repoint" | "flag";
   /**
-   * How a resolved write set that still violates a unique constraint after
-   * an identity pairing is dropped is handled. `"refuse"` (default) fails
-   * the merge with the existing constraint-conflict error; `"flag"` drops
-   * the pairing (never the constraint) and records a typed conflict.
+   * How a resolved write set that violates a unique constraint because an
+   * identity pairing fused two members is handled. `"refuse"` (default)
+   * surfaces the violation through the existing constraint-conflict error.
+   *
+   * `"flag"` — drop the pairing, never the constraint — is REFUSED with an
+   * invalid-option error rather than silently applying the default, for the
+   * same reason as {@link IdentityReconciliationOptions.onEdgeConflict}.
    */
   onUniquenessConflict?: "refuse" | "flag";
   /**
-   * How contradictory source attribution across identity-paired members is
-   * handled. `"keepBoth"` (default) keeps every contribution; `"refuse"`
-   * fails the merge.
+   * How contradictory source attribution across the members of a cluster an
+   * identity assertion FUSED is handled. `"keepBoth"` (default) keeps every
+   * contribution, exactly as the merge always has; `"refuse"` fails the plan
+   * with `GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT`, naming the canonical
+   * entity and the contributions that disagree.
    */
   onProvenanceConflict?: "keepBoth" | "refuse";
 }>;

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -370,27 +370,6 @@ export type IdentityReconciliationOptions = Readonly<{
    */
   onAssertionConflict?: IdentityAssertionConflictPolicy;
   /**
-   * How an identity-paired cluster's repointed edge collides with another.
-   * `"repoint"` (default) applies the repoint, reporting any property
-   * disagreement through {@link MergeOptions.onPropertyConflict}.
-   *
-   * `"flag"` — drop the pairing, keep both edges — is REFUSED with an
-   * invalid-option error rather than silently applying the default: dropping a
-   * pairing requires rebuilding the plan without the offending identity
-   * candidate edge, which this release does not do.
-   */
-  onEdgeConflict?: "repoint" | "flag";
-  /**
-   * How a resolved write set that violates a unique constraint because an
-   * identity pairing fused two members is handled. `"refuse"` (default)
-   * surfaces the violation through the existing constraint-conflict error.
-   *
-   * `"flag"` — drop the pairing, never the constraint — is REFUSED with an
-   * invalid-option error rather than silently applying the default, for the
-   * same reason as {@link IdentityReconciliationOptions.onEdgeConflict}.
-   */
-  onUniquenessConflict?: "refuse" | "flag";
-  /**
    * How contradictory source attribution across the members of a cluster an
    * identity assertion FUSED is handled. `"keepBoth"` (default) keeps every
    * contribution, exactly as the merge always has; `"refuse"` fails the plan
@@ -611,14 +590,17 @@ export type DroppedItem =
  *   while a DIFFERENT branch re-asserted it under a new id without retracting.
  * - `"opposing-relations"` — branches asserted BOTH `same` and `different` for
  *   one endpoint pair with overlapping validity windows.
- * - `"id-reuse"` — one assertion id was staged for two different identity
- *   truths. Never policy-resolvable: an id names one truth by construction, so
- *   there is no arbitration to offer — see {@link IdentityAssertionDecision}.
  * - `"cross-kind-pairing"` — a `same` assertion spans two different merge
  *   KINDS, so no per-kind candidate scope can express it as a pairing edge.
+ * - `"out-of-scope-pairing"` — a `same` assertion names at least one endpoint
+ *   that is not a staged new node of its kind (a committed target row, or a
+ *   node no branch staged), so no per-kind candidate scope contains it.
  */
 export type IdentityAssertionConflictReason =
-  "retract-reassert" | "opposing-relations" | "id-reuse" | "cross-kind-pairing";
+  | "retract-reassert"
+  | "opposing-relations"
+  | "cross-kind-pairing"
+  | "out-of-scope-pairing";
 
 /**
  * An identity-adjacent disagreement the merge could not resolve into a single
@@ -653,12 +635,6 @@ export type IdentityUnresolvedConflict =
       source?: MatchSource | undefined;
     }>
   | Readonly<{
-      kind: "uniqueness";
-      constraintName: string;
-      members: readonly EntityRef[];
-      assertionIds: readonly string[];
-    }>
-  | Readonly<{
       kind: "provenance";
       canonical: EntityRef;
       contributions: readonly ProvenanceRecord[];
@@ -677,9 +653,29 @@ export type IdentityReconciliation = Readonly<{
   a: EntityRef;
   b: EntityRef;
   relation: IdentityRelation;
-  survivorAssertionId: string;
+  /**
+   * The assertion id that governs the pair after the merge: the surviving
+   * assertion for a duplicate survivor pick or an assert-shaped policy
+   * resolution, and the ENDED base row's own id when a policy resolved the
+   * conflict by retracting. Absent only when the resolution kept nothing at
+   * all — a callback that retracts an opposing-relations conflict, where no
+   * assertion and no base row is left to name.
+   */
+  survivorAssertionId?: string | undefined;
   supersededAssertionIds: readonly string[];
+  /**
+   * WHICH rule chose the survivor. `"policy"` means the caller's
+   * `onAssertionConflict` arbitrated a conflict no rule could resolve, and
+   * {@link IdentityReconciliation.policy} names the arm it used.
+   */
   rule: "earliest-valid-from" | "code-point-id" | "committed-id" | "policy";
+  /**
+   * The `onAssertionConflict` arm that decided, present exactly when `rule` is
+   * `"policy"`: the policy string, or `"callback"` for a function policy
+   * (whose source is never recorded). This is what
+   * `IdentityDecisionProvenance.policy` is built from, so a merge that
+   * arbitrated nothing by policy records no policy string.
+   */
   policy?: string | undefined;
   branches: readonly BranchId[];
 }>;

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -493,15 +493,14 @@ export type MergeOptions<G extends GraphDef = GraphDef> = Readonly<{
    * validation refuses the merge rather than silently changing policy.
    */
   provenanceWeights?: ReadonlyMap<BranchId, number>;
-  // NOTE: `identity` (identity-driven candidate pairing / assertion-conflict
-  // arbitration, `IdentityReconciliationOptions`) is deliberately NOT a
-  // member here yet. `MergeOptions` is already publicly exported
-  // (`src/graph-merge/index.ts`), so adding a field to it changes
-  // `etc/typegraph-graph-merge.api.md` — a public-surface change this PR
-  // must not make (no changeset; PR-3 owns the release). `IdentityReconciliationOptions`
-  // and its normalization already exist (`options.ts`'s `normalizeIdentityOptions`)
-  // for direct testing; wiring this field onto `MergeOptions` is PR-3's job,
-  // alongside exporting the type and refreshing the API report.
+  /**
+   * Identity-driven candidate pairing and identity-assertion conflict
+   * arbitration. Omitted by default, which reproduces today's behavior
+   * byte-for-byte: no identity-driven pairing, and any identity-assertion
+   * conflict the classifier finds still fails the merge exactly as it always
+   * has. Stating this option on a graph declaring no `identity` is refused.
+   */
+  identity?: IdentityReconciliationOptions;
 }>;
 
 /**
@@ -839,4 +838,8 @@ export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
    * persistence was off or failed (a failure adds a {@link MergeReport.warnings}).
    */
   provenancePersisted?: Readonly<{ graphId: string; count: number }>;
+  /** Duplicate-assertion survivor picks the three-way classifier resolved. */
+  identityReconciliations: readonly IdentityReconciliation[];
+  /** Identity-assertion conflicts a resolving `onAssertionConflict` kept rather than refused. */
+  identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -20,6 +20,7 @@ import type {
   MatchEvidence,
   MatchSource,
 } from "./evidence";
+import type { IdentityAssertionConflictPolicy } from "./identity-three-way";
 import type {
   EdgeId,
   GetNodeType,
@@ -337,6 +338,59 @@ export type CandidateDiagnosticsOptions = Readonly<{
 }>;
 
 /**
+ * How the merge folds identity assertions (`store.identity.assertSame` /
+ * `assertDifferent`) into candidate pairing, and how it arbitrates the
+ * identity-assertion conflicts a three-way classification against the staged
+ * base slice cannot resolve by rule alone.
+ *
+ * Every field defaults to today's behavior: `pairing: "off"` recalls no
+ * candidates from identity assertions at all, and `onAssertionConflict:
+ * "refuse"` fails the merge on the same two shapes it always has (branches
+ * asserting opposing relations for one pair, or a retract/reassert race) — a
+ * merge that never sets `identity` behaves byte-for-byte as it does today.
+ */
+export type IdentityReconciliationOptions = Readonly<{
+  /**
+   * `"off"` (default): identity assertions recall no candidates.
+   * `"candidate"`: each `same` assertion emits a scored candidate pair,
+   * subject to the kind's threshold — strong recall, not proof.
+   * `"definitional"`: each `same` assertion forces a fused candidate edge,
+   * merging its endpoints regardless of similarity score.
+   */
+  pairing?: "off" | "candidate" | "definitional";
+  /**
+   * How to arbitrate a `same`/`different` opposing-relations collision or a
+   * retract/reassert race the classifier cannot resolve by rule alone.
+   * `"refuse"` (default) fails the merge, byte-identical to today.
+   * `"assertWins"` / `"retractWins"` resolve a retract/reassert race
+   * specifically (refused as an invalid option against any OTHER conflict
+   * shape, which has no assert/retract axis to decide). `"flag"` keeps base
+   * truth and records an {@link IdentityUnresolvedConflict}. A function
+   * receives the fully-populated conflict and returns the decision itself.
+   */
+  onAssertionConflict?: IdentityAssertionConflictPolicy;
+  /**
+   * How an identity-paired cluster's repointed edge collides with another.
+   * `"repoint"` (default) applies the repoint; `"flag"` keeps the edge and
+   * records a typed conflict.
+   */
+  onEdgeConflict?: "repoint" | "flag";
+  /**
+   * How a resolved write set that still violates a unique constraint after
+   * an identity pairing is dropped is handled. `"refuse"` (default) fails
+   * the merge with the existing constraint-conflict error; `"flag"` drops
+   * the pairing (never the constraint) and records a typed conflict.
+   */
+  onUniquenessConflict?: "refuse" | "flag";
+  /**
+   * How contradictory source attribution across identity-paired members is
+   * handled. `"keepBoth"` (default) keeps every contribution; `"refuse"`
+   * fails the merge.
+   */
+  onProvenanceConflict?: "keepBoth" | "refuse";
+}>;
+
+/**
  * Ontology type-reconciliation mode. `"off"` is a no-op (default); `"ontology"`
  * collapses compatible types to the most-specific via the public subClassOf
  * closure (T2a / T10).
@@ -439,6 +493,14 @@ export type MergeOptions<G extends GraphDef = GraphDef> = Readonly<{
    * validation refuses the merge rather than silently changing policy.
    */
   provenanceWeights?: ReadonlyMap<BranchId, number>;
+  /**
+   * Identity-driven candidate pairing and identity-assertion conflict
+   * arbitration. Omitted by default, which reproduces today's behavior
+   * byte-for-byte: no identity-driven pairing, and any identity-assertion
+   * conflict the classifier finds still fails the merge exactly as it always
+   * has. Stating this option on a graph declaring no `identity` is refused.
+   */
+  identity?: IdentityReconciliationOptions;
 }>;
 
 /**

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -493,14 +493,15 @@ export type MergeOptions<G extends GraphDef = GraphDef> = Readonly<{
    * validation refuses the merge rather than silently changing policy.
    */
   provenanceWeights?: ReadonlyMap<BranchId, number>;
-  /**
-   * Identity-driven candidate pairing and identity-assertion conflict
-   * arbitration. Omitted by default, which reproduces today's behavior
-   * byte-for-byte: no identity-driven pairing, and any identity-assertion
-   * conflict the classifier finds still fails the merge exactly as it always
-   * has. Stating this option on a graph declaring no `identity` is refused.
-   */
-  identity?: IdentityReconciliationOptions;
+  // NOTE: `identity` (identity-driven candidate pairing / assertion-conflict
+  // arbitration, `IdentityReconciliationOptions`) is deliberately NOT a
+  // member here yet. `MergeOptions` is already publicly exported
+  // (`src/graph-merge/index.ts`), so adding a field to it changes
+  // `etc/typegraph-graph-merge.api.md` — a public-surface change this PR
+  // must not make (no changeset; PR-3 owns the release). `IdentityReconciliationOptions`
+  // and its normalization already exist (`options.ts`'s `normalizeIdentityOptions`)
+  // for direct testing; wiring this field onto `MergeOptions` is PR-3's job,
+  // alongside exporting the type and refreshing the API report.
 }>;
 
 /**

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -12,8 +12,14 @@
  * runtime merge logic.
  */
 
+import type { IdentityRelation } from "../identity/types";
 import type { IngestionImportTarget } from "../interchange/ingestion-import-target";
-import type { CandidateDiagnostics, MatchEvidence } from "./evidence";
+import type {
+  CandidateDiagnostics,
+  EntityRef,
+  MatchEvidence,
+  MatchSource,
+} from "./evidence";
 import type {
   EdgeId,
   GetNodeType,
@@ -524,6 +530,81 @@ export type DroppedItem =
   | Readonly<{ kind: "node"; id: NodeId<NodeType>; reason: string }>
   | Readonly<{ kind: "edge"; id: EdgeId; reason: string }>
   | Readonly<{ kind: "identity"; id: string; reason: string }>;
+
+/**
+ * WHY an identity assertion pair could not be arbitrated by rule: the shape of
+ * the disagreement, not the policy consulted about it.
+ *
+ * - `"retract-reassert"` — one branch retracted the pair's committed truth
+ *   while a DIFFERENT branch re-asserted it under a new id without retracting.
+ * - `"opposing-relations"` — branches asserted BOTH `same` and `different` for
+ *   one endpoint pair with overlapping validity windows.
+ * - `"id-reuse"` — one assertion id was staged for two different identity
+ *   truths. Never policy-resolvable: an id names one truth by construction, so
+ *   there is no arbitration to offer — see {@link IdentityAssertionDecision}.
+ * - `"cross-kind-pairing"` — a `same` assertion spans two different merge
+ *   KINDS, so no per-kind candidate scope can express it as a pairing edge.
+ */
+export type IdentityAssertionConflictReason =
+  "retract-reassert" | "opposing-relations" | "id-reuse" | "cross-kind-pairing";
+
+/**
+ * An identity-adjacent disagreement the merge could not resolve into a single
+ * write, recorded on {@link MergeReport.identityConflicts} instead of silently
+ * dropped. A plan carrying one is still APPLICABLE — `"flag"` means "keep the
+ * base truth, keep the data, tell the caller", exactly the posture `"flag"`
+ * already has for delete/modify ({@link DeleteModifyPolicy}). Only `"refuse"`
+ * fails the plan.
+ */
+export type IdentityUnresolvedConflict =
+  | Readonly<{
+      kind: "assertion";
+      reason: IdentityAssertionConflictReason;
+      semanticKey: string;
+      a: EntityRef;
+      b: EntityRef;
+      relation: IdentityRelation;
+      assertionIds: readonly string[];
+      branches: readonly BranchId[];
+    }>
+  | Readonly<{
+      kind: "separation";
+      a: EntityRef;
+      b: EntityRef;
+      assertionIds: readonly string[];
+      source: MatchSource;
+    }>
+  | Readonly<{
+      kind: "uniqueness";
+      constraintName: string;
+      members: readonly EntityRef[];
+      assertionIds: readonly string[];
+    }>
+  | Readonly<{
+      kind: "provenance";
+      canonical: EntityRef;
+      contributions: readonly ProvenanceRecord[];
+    }>;
+
+/**
+ * Visibility into a duplicate-assertion arbitration the merge already applied:
+ * two or more branches asserted the SAME semantic identity claim under
+ * DIFFERENT assertion ids, one survivor was chosen, and the rest were dropped
+ * (see {@link DroppedItem}). Recorded on
+ * {@link MergeReport.identityReconciliations} so the choice is visible rather
+ * than only inferable from the drop reasons.
+ */
+export type IdentityReconciliation = Readonly<{
+  semanticKey: string;
+  a: EntityRef;
+  b: EntityRef;
+  relation: IdentityRelation;
+  survivorAssertionId: string;
+  supersededAssertionIds: readonly string[];
+  rule: "earliest-valid-from" | "code-point-id" | "committed-id" | "policy";
+  policy?: string | undefined;
+  branches: readonly BranchId[];
+}>;
 
 /**
  * The {@link ValidityEndResolution.precedence} of an entry the INCREMENTAL TARGET

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -838,8 +838,4 @@ export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
    * persistence was off or failed (a failure adds a {@link MergeReport.warnings}).
    */
   provenancePersisted?: Readonly<{ graphId: string; count: number }>;
-  /** Duplicate-assertion survivor picks the three-way classifier resolved. */
-  identityReconciliations: readonly IdentityReconciliation[];
-  /** Identity-assertion conflicts a resolving `onAssertionConflict` kept rather than refused. */
-  identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -633,12 +633,13 @@ export type IdentityUnresolvedConflict =
        * source cannot make this a crash.
        */
       source?: MatchSource | undefined;
-    }>
-  | Readonly<{
-      kind: "provenance";
-      canonical: EntityRef;
-      contributions: readonly ProvenanceRecord[];
     }>;
+// No `"provenance"` arm: `onProvenanceConflict` has exactly two dispositions
+// (`"keepBoth"`, which reports nothing, and `"refuse"`, which throws) and no
+// resolving/"flag" disposition that could ever place one on
+// `MergeReport.identityConflicts` or a plan artifact — see
+// `assertIdentityProvenanceAgreement` in merge.ts, the arm's only producer,
+// which builds this shape solely for a THROWN error's `details.conflict`.
 
 /**
  * Visibility into a duplicate-assertion arbitration the merge already applied:

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -634,7 +634,13 @@ export type IdentityUnresolvedConflict =
       a: EntityRef;
       b: EntityRef;
       assertionIds: readonly string[];
-      source: MatchSource;
+      /**
+       * The recall path that proposed the vetoed match. Absent only for a
+       * candidate edge carrying no attribution at all, which no shipped source
+       * produces — modelled as optional rather than asserted so a future
+       * source cannot make this a crash.
+       */
+      source?: MatchSource | undefined;
     }>
   | Readonly<{
       kind: "uniqueness";

--- a/packages/typegraph/src/graph-merge/types.ts
+++ b/packages/typegraph/src/graph-merge/types.ts
@@ -838,4 +838,8 @@ export type MergeReport<G extends GraphDef = GraphDef> = Readonly<{
    * persistence was off or failed (a failure adds a {@link MergeReport.warnings}).
    */
   provenancePersisted?: Readonly<{ graphId: string; count: number }>;
+  /** Duplicate-assertion survivor picks the three-way classifier resolved. */
+  identityReconciliations: readonly IdentityReconciliation[];
+  /** Identity-assertion conflicts a resolving `onAssertionConflict` kept rather than refused. */
+  identityConflicts: readonly IdentityUnresolvedConflict[];
 }>;

--- a/packages/typegraph/src/identity/index.ts
+++ b/packages/typegraph/src/identity/index.ts
@@ -1,4 +1,5 @@
 export { rebuildIdentityClosure } from "./rebuild";
+export type { IdentityDecisionProvenance } from "./transition-log";
 export type {
   IdentityAssertion,
   IdentityAssertionId,

--- a/packages/typegraph/src/identity/separation.ts
+++ b/packages/typegraph/src/identity/separation.ts
@@ -67,6 +67,16 @@ import { type IdentityAssertionStorageRow } from "./storage-types";
 const MAX_SEPARATION_INSERT_CHUNK_SIZE = 100;
 
 /**
+ * The one code every "this graph's derived identity storage is not readable"
+ * refusal carries — an absent relation and a never-filled one are the same fact
+ * for an operator, with the same remedy. Named so a consumer that must
+ * recognize the refusal (graph-merge's separation veto, which re-raises it as
+ * an invalid-option refusal when a merge stated `identity.pairing`) matches the
+ * value rather than re-spelling the string.
+ */
+export const IDENTITY_STORAGE_MISSING_CODE = "IDENTITY_STORAGE_MISSING";
+
+/**
  * The PERSISTED encoding of an identity class key.
  *
  * Deliberately its own function rather than a reuse of the service's in-memory
@@ -499,7 +509,7 @@ function separationUnreadableError(
   return new ConfigurationError(
     "Operational Identity could not read the materialized separation relation.",
     {
-      code: "IDENTITY_STORAGE_MISSING",
+      code: IDENTITY_STORAGE_MISSING_CODE,
       graphId,
       tables: [schema.tables.identitySeparation],
     },
@@ -528,7 +538,7 @@ function separationUnfilledError(
   return new ConfigurationError(
     "Operational Identity found the separation relation present but never filled for this graph.",
     {
-      code: "IDENTITY_STORAGE_MISSING",
+      code: IDENTITY_STORAGE_MISSING_CODE,
       graphId,
       reason: "unfilled",
       tables: [schema.tables.identitySeparation],

--- a/packages/typegraph/src/identity/separation.ts
+++ b/packages/typegraph/src/identity/separation.ts
@@ -668,7 +668,7 @@ async function hasSeparationRows(
  * a database whose closure is corrupt, which `validateIdentity()` reports and
  * which the CHECK still refuses at the next fusing write.
  */
-async function hasLiveDifferentAssertions(
+export async function hasLiveDifferentAssertions(
   target: IdentityTarget,
   schema: SqlSchema,
   graphId: string,

--- a/packages/typegraph/src/identity/separation.ts
+++ b/packages/typegraph/src/identity/separation.ts
@@ -387,6 +387,27 @@ function separationReadinessProven(
   return provenSeparationReadiness.get(registry)?.has(graphId) === true;
 }
 
+/**
+ * The public read of {@link separationReadinessProven}, for a caller that
+ * wants to SKIP its own "has this graph anything to separate" round trip
+ * rather than decide readiness itself.
+ *
+ * `graph-merge/identity-pairing.ts`'s plan-time capture asks the identical
+ * per-(registry, graphId) question `hasLiveDifferentAssertions` answers here —
+ * before this seam existed, it asked it with its own direct call, paying the
+ * round trip again even when an earlier `assertSame`/`assertDifferent` on the
+ * same Store handle had already proven it. One owner, two readers: this
+ * function never writes the memo — only {@link bulkIsSeparated}'s own
+ * zero-rows branch does that, so "true" here always traces back to a real
+ * probe this module ran itself.
+ */
+export function separationFactsKnownEmpty(
+  registry: KindRegistry,
+  graphId: string,
+): boolean {
+  return separationReadinessProven(registry, graphId);
+}
+
 function proveSeparationReadiness(
   registry: KindRegistry,
   graphId: string,

--- a/packages/typegraph/src/identity/separation.ts
+++ b/packages/typegraph/src/identity/separation.ts
@@ -198,13 +198,17 @@ type RawSeparationRow = Readonly<{
 }>;
 
 /**
- * Whether the relation records two CURRENT classes as separated.
+ * Whether the relation records each of `pairs` as CURRENT classes separated —
+ * the batch generalization of the single-pair probe.
  *
- * One primary-key probe against `(graph_id, class_key_low, class_key_high)`,
- * standing in for resolving both classes' `different` assertions out of the
- * ledger and scanning them for one that spans the pair. Callers pass the class
- * keys in any order; putting them in the relation's `low < high` order is this
- * module's business, since it is the same ordering the writer applies.
+ * ONE round trip per bind-budget chunk of DISTINCT non-trivial pairs, standing
+ * in for resolving every pair's two identity classes' `different` assertions
+ * out of the ledger and scanning them for one that spans the pair. Callers
+ * pass each pair's class keys in any order; putting them in the relation's
+ * `low < high` order is this module's business, since it is the same ordering
+ * the writer applies. A pair naming one class twice is never separated from
+ * itself — `low = high` is what the relation's CHECK exists to reject — and is
+ * answered `false` without a round trip.
  *
  * Valid only for a current-mode read: the relation projects CURRENT assertions
  * onto CURRENT classes, so a valid-time or recorded coordinate has to
@@ -221,18 +225,88 @@ type RawSeparationRow = Readonly<{
  * "not separated" — {@link separationRebuildRequired} is what keeps it loud
  * until the handle is reopened (the reopen runs the fill).
  *
- * WHAT IT COSTS. The pair lookup and "does this graph have ANY row" travel in
- * ONE statement — a second seek on the same primary key, in the same round
- * trip — so a graph that uses separations pays nothing beyond that seek and the
- * ledger is not read at all. The ledger probe runs only when the graph has NO
- * separation rows AND the pair missed, which is also the only state where a
- * "false" could be an unfilled relation rather than an absent separation. Both
- * callers reach here having already resolved two identity classes through the
- * closure (a recursive CTE each), so the bounded `LIMIT 1` this adds in that
- * state is small against what the answer already cost.
+ * WHAT IT COSTS. The batch lookup and "does this graph have ANY row" travel in
+ * ONE statement per chunk — a `LEFT JOIN` onto the same primary-key seek, in
+ * the same round trip — so a graph that uses separations pays nothing beyond
+ * that seek, chunked to the bind budget, and the ledger is not read at all.
+ * Arity one costs exactly the statement the single-pair probe always has: one
+ * chunk, one round trip. The ledger probe runs at most ONCE PER CALL — it is a
+ * fact about the graph, not about any one pair — and only when every chunk's
+ * graph-rows flag came back empty, which is also the only state where a
+ * "false" could be an unfilled relation rather than an absent separation.
  *
  * @throws {ConfigurationError} `IDENTITY_STORAGE_MISSING` when the relation the
  * probe reads does not exist, or exists without this graph's fill.
+ */
+export async function bulkIsSeparated(
+  target: IdentityTarget,
+  schema: SqlSchema,
+  graphId: string,
+  pairs: readonly Readonly<{ first: string; second: string }>[],
+  registry: KindRegistry,
+): Promise<readonly boolean[]> {
+  if (pairs.length === 0) return [];
+  // A class is never separated from itself: `low = high` is what the
+  // relation's CHECK exists to reject, so a trivial pair is answered without a
+  // round trip and never joins the batch below.
+  const ordered = pairs.map((pair) => orderedPair(pair.first, pair.second));
+  const uniqueNonTrivial = new Map<string, SeparationPair>();
+  for (const pair of ordered) {
+    if (pair.low === pair.high) continue;
+    uniqueNonTrivial.set(pairKey(pair), pair);
+  }
+  if (uniqueNonTrivial.size === 0) {
+    return ordered.map(() => false);
+  }
+
+  const chunkSize = identityChunkSize(target, {
+    fixedParameters: SEPARATION_PROBE_FIXED_PARAMETERS,
+    maxItems: MAX_REFERENCE_CHUNK_SIZE,
+    parametersPerItem: 2,
+  });
+  const separated = new Set<string>();
+  let graphHasRows = false;
+  for (const pairChunk of chunk([...uniqueNonTrivial.values()], chunkSize)) {
+    const probe = await probeSeparationPairs(
+      target,
+      schema,
+      graphId,
+      pairChunk,
+    );
+    graphHasRows ||= probe.graphHasRows;
+    for (const key of probe.separatedPairs) separated.add(key);
+  }
+  // The fast path, unchanged: rows exist for this graph, so the relation is
+  // not in the unfilled state and the ledger is not read at all.
+  const anyUnresolved = [...uniqueNonTrivial.keys()].some(
+    (key) => !separated.has(key),
+  );
+  if (
+    !graphHasRows &&
+    anyUnresolved &&
+    !separationReadinessProven(registry, graphId)
+  ) {
+    // Zero rows is not an exceptional state: it is the STEADY state of every
+    // graph that holds only `same` assertions, so this is the path whose cost
+    // decides whether the guard is affordable. The proof runs at most once per
+    // Store handle, and once per call here regardless of how many pairs it
+    // covers — the fact it settles is about the graph, not any one pair.
+    if (await hasLiveDifferentAssertions(target, schema, graphId, registry)) {
+      throw separationUnfilledError(graphId, schema);
+    }
+    proveSeparationReadiness(registry, graphId);
+  }
+  return ordered.map(
+    (pair) => pair.low !== pair.high && separated.has(pairKey(pair)),
+  );
+}
+
+/**
+ * Whether the relation records two CURRENT classes as separated.
+ *
+ * @throws {ConfigurationError} `IDENTITY_STORAGE_MISSING` when the relation the
+ * probe reads does not exist, or exists without this graph's fill.
+ * @see {@link bulkIsSeparated}, the arity-N owner this reduces to.
  */
 export async function isSeparated(
   target: IdentityTarget,
@@ -242,31 +316,14 @@ export async function isSeparated(
   secondClassKey: string,
   registry: KindRegistry,
 ): Promise<boolean> {
-  // A class is never separated from itself: `low = high` is what the relation's
-  // CHECK exists to reject, so the probe is a guaranteed miss and the round
-  // trip buys nothing.
-  if (firstClassKey === secondClassKey) return false;
-  const probe = await probeSeparationPair(
+  const [result] = await bulkIsSeparated(
     target,
     schema,
     graphId,
-    orderedPair(firstClassKey, secondClassKey),
+    [{ first: firstClassKey, second: secondClassKey }],
+    registry,
   );
-  if (probe.pairSeparated) return true;
-  // The fast path, unchanged: rows exist for this graph, so the relation is not
-  // in the unfilled state and the ledger is not read at all. This statement is
-  // exactly the one the guard inherited — no proof rides along, no kind binds.
-  if (probe.graphHasRows) return false;
-  // Zero rows is not an exceptional state: it is the STEADY state of every
-  // graph that holds only `same` assertions, so this is the path whose cost
-  // decides whether the guard is affordable. The proof runs at most once per
-  // Store handle.
-  if (separationReadinessProven(registry, graphId)) return false;
-  if (await hasLiveDifferentAssertions(target, schema, graphId, registry)) {
-    throw separationUnfilledError(graphId, schema);
-  }
-  proveSeparationReadiness(registry, graphId);
-  return false;
+  return result ?? false;
 }
 
 /**
@@ -329,14 +386,21 @@ function proveSeparationReadiness(
   provenSeparationReadiness.set(registry, proven);
 }
 
-/** What one probe of the relation establishes about a pair AND its graph. */
-type SeparationProbe = Readonly<{
-  pairSeparated: boolean;
+/** What one probe of the relation establishes about a chunk of pairs AND its graph. */
+type BulkSeparationProbe = Readonly<{
+  /** `pairKey`-encoded pairs the relation records as separated. */
+  separatedPairs: ReadonlySet<string>;
   graphHasRows: boolean;
 }>;
 
 /**
- * The pair lookup and "does this graph hold ANY row", in one statement.
+ * Fixed binds in {@link probeSeparationPairs}'s statement: `graph_id`, bound
+ * once in the graph-rows subquery and once in the matched-pairs subquery.
+ */
+const SEPARATION_PROBE_FIXED_PARAMETERS = 2;
+
+/**
+ * The batch pair lookup and "does this graph hold ANY row", in one statement.
  *
  * The readiness proof deliberately does NOT ride along here. Folding it in as a
  * `CASE`-guarded scalar subquery was measured and rejected: it made the
@@ -346,37 +410,55 @@ type SeparationProbe = Readonly<{
  * plan to prepare — while the graphs that DO hold rows would have paid the same
  * binds for a subquery whose arm is never taken. Cheap on paper, not on the
  * engine.
+ *
+ * The two subqueries are joined rather than left as independent scalars so
+ * arity N stays ONE round trip: the graph-rows scalar is always exactly one
+ * row, `LEFT JOIN`ed to however many of the chunk's pairs the relation
+ * actually holds (zero or more), which at arity one degenerates to exactly the
+ * single combined row the original probe returned.
  */
-async function probeSeparationPair(
+async function probeSeparationPairs(
   target: IdentityTarget,
   schema: SqlSchema,
   graphId: string,
-  pair: SeparationPair,
-): Promise<SeparationProbe> {
+  pairChunk: readonly SeparationPair[],
+): Promise<BulkSeparationProbe> {
   try {
+    const conditions = pairChunk.map(
+      (pair) =>
+        sql`(class_key_low = ${pair.low} AND class_key_high = ${pair.high})`,
+    );
     const rows = await target.execute<Readonly<Record<string, unknown>>>(
       asCompiledRowsSql(sql`
-        SELECT
-          (
-            SELECT COUNT(*) FROM ${schema.identitySeparationTable}
+        SELECT graph_probe.graph_rows AS graph_rows,
+               matched.class_key_low AS class_key_low,
+               matched.class_key_high AS class_key_high
+        FROM (
+          SELECT COUNT(*) AS graph_rows FROM (
+            SELECT 1 AS present FROM ${schema.identitySeparationTable}
             WHERE graph_id = ${graphId}
-              AND class_key_low = ${pair.low}
-              AND class_key_high = ${pair.high}
-          ) AS pair_rows,
-          (
-            SELECT COUNT(*) FROM (
-              SELECT 1 AS present FROM ${schema.identitySeparationTable}
-              WHERE graph_id = ${graphId}
-              LIMIT 1
-            ) graph_probe
-          ) AS graph_rows
+            LIMIT 1
+          ) graph_present
+        ) graph_probe
+        LEFT JOIN (
+          SELECT class_key_low, class_key_high
+          FROM ${schema.identitySeparationTable}
+          WHERE graph_id = ${graphId}
+            AND (${sql.join(conditions, sql` OR `)})
+        ) matched ON 1 = 1
       `),
     );
-    const row = rows[0];
-    return {
-      graphHasRows: countOf(row, "graph_rows") > 0,
-      pairSeparated: countOf(row, "pair_rows") > 0,
-    };
+    const separatedPairs = new Set<string>();
+    let graphHasRows = false;
+    for (const row of rows) {
+      if (countOf(row, "graph_rows") > 0) graphHasRows = true;
+      const low = row["class_key_low"];
+      const high = row["class_key_high"];
+      if (typeof low === "string" && typeof high === "string") {
+        separatedPairs.add(pairKey({ low, high }));
+      }
+    }
+    return { graphHasRows, separatedPairs };
   } catch (error) {
     // Never degrade to "not separated": a caller that cannot read the relation
     // has no basis for an answer, and the wrong answer here is the one that

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -115,6 +115,10 @@ export {
   type IdentityAssertionId,
   type IdentityAssertionResult,
   type IdentityAssertionWriteFacade,
+  // The governing decision a merge attaches to the identity transitions it
+  // causes — named on `StoreRuntime.applyIdentityMergeAtTarget`, so a backend
+  // or store author implementing the port needs it by name.
+  type IdentityDecisionProvenance,
   type IdentityFacade,
   type IdentityNode,
   type IdentityNodeReference,

--- a/packages/typegraph/src/store/runtime-port.ts
+++ b/packages/typegraph/src/store/runtime-port.ts
@@ -24,6 +24,7 @@ import {
   type NodeType,
 } from "../core/types";
 import { type IdentityServiceContext } from "../identity/service-types";
+import { type IdentityDecisionProvenance } from "../identity/transition-log";
 import { type IdentityReadFacade } from "../identity/types";
 import { type InitialQueryBuilder } from "../query/builder";
 import { typeGraphGlobalSymbol } from "../utils/global-symbol";
@@ -350,6 +351,12 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
     }>[],
     mode: "state" | "archival",
   ) => Promise<Readonly<{ created: number; skipped: number }>>;
+  /**
+   * `decision` is the governing merge decision, when the apply runs under one:
+   * every identity transition the call causes carries it, so a fold a merged
+   * node create triggered is attributed to the merge rather than filed as an
+   * anonymous `fold`. `undefined` for an apply with no governing decision.
+   */
   applyIdentityMergeAtTarget: (
     target: GraphBackend | TransactionBackend,
     retractions: readonly Readonly<{
@@ -370,6 +377,7 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
       validTo?: string | undefined;
       endedBy?: Readonly<{ kind: string; id: string }> | undefined;
     }>[],
+    decision?: IdentityDecisionProvenance,
   ) => Promise<Readonly<{ created: number; retracted: number }>>;
   /**
    * Proves the identity classes of `seeds` carry no contradiction in the state

--- a/packages/typegraph/src/store/store.ts
+++ b/packages/typegraph/src/store/store.ts
@@ -166,6 +166,7 @@ import {
   validateIdentityForContext,
 } from "../identity/service";
 import { type IdentityTarget } from "../identity/sql-target";
+import { type IdentityDecisionProvenance } from "../identity/transition-log";
 import type {
   IdentityFacade,
   IdentityNode,
@@ -1392,8 +1393,13 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
         this.foldImportedIdentityNodes(target, references),
       importIdentityAssertionsAtTarget: (target, assertions, mode) =>
         this.importIdentityAssertionsAtTarget(target, assertions, mode),
-      applyIdentityMergeAtTarget: (target, retractions, assertions) =>
-        this.applyIdentityMergeAtTarget(target, retractions, assertions),
+      applyIdentityMergeAtTarget: (target, retractions, assertions, decision) =>
+        this.applyIdentityMergeAtTarget(
+          target,
+          retractions,
+          assertions,
+          decision,
+        ),
       assertIdentityClassesConsistentAtTarget: (target, seeds) =>
         this.assertIdentityClassesConsistentAtTarget(target, seeds),
     };
@@ -1699,6 +1705,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
     target: GraphBackend | TransactionBackend,
     retractions: readonly IdentityTransferAssertion[],
     assertions: readonly IdentityTransferAssertion[],
+    decision?: IdentityDecisionProvenance,
   ): Promise<Readonly<{ created: number; retracted: number }>> {
     if (retractions.length === 0 && assertions.length === 0) {
       return Promise.resolve({ created: 0, retracted: 0 });
@@ -1713,6 +1720,7 @@ class StoreImplementation<G extends GraphDef, TNativeTransaction = unknown> {
       this.#identityContext(target),
       retractions,
       assertions,
+      decision,
     );
   }
 

--- a/packages/typegraph/tests/graph-merge/commit.test.ts
+++ b/packages/typegraph/tests/graph-merge/commit.test.ts
@@ -86,6 +86,8 @@ function emptyPlan(): MergePlan<CareGraph> {
     warnings: [],
     identityAssertions: [],
     identityRetractions: [],
+    identityReconciliations: [],
+    identityConflicts: [],
     canonicalOf: new Map(),
   };
 }

--- a/packages/typegraph/tests/graph-merge/commit.test.ts
+++ b/packages/typegraph/tests/graph-merge/commit.test.ts
@@ -86,8 +86,6 @@ function emptyPlan(): MergePlan<CareGraph> {
     warnings: [],
     identityAssertions: [],
     identityRetractions: [],
-    identityReconciliations: [],
-    identityConflicts: [],
     canonicalOf: new Map(),
   };
 }

--- a/packages/typegraph/tests/graph-merge/identity-commit-closure.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-commit-closure.test.ts
@@ -103,8 +103,6 @@ function emptyFoldPlan(): MergePlan<FoldGraph> {
     warnings: [],
     identityAssertions: [],
     identityRetractions: [],
-    identityReconciliations: [],
-    identityConflicts: [],
     canonicalOf: new Map(),
   };
 }
@@ -329,8 +327,6 @@ describe("affectedIdentityClassSeeds", () => {
     canonicalEntities: [],
     identityAssertions: [],
     identityRetractions: [],
-    identityReconciliations: [],
-    identityConflicts: [],
     nodeDeletions: new Map<string, string>(),
     retypeMap: new Map<string, string>(),
     canonicalOf: new Map<string, string>(),

--- a/packages/typegraph/tests/graph-merge/identity-commit-closure.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-commit-closure.test.ts
@@ -103,6 +103,8 @@ function emptyFoldPlan(): MergePlan<FoldGraph> {
     warnings: [],
     identityAssertions: [],
     identityRetractions: [],
+    identityReconciliations: [],
+    identityConflicts: [],
     canonicalOf: new Map(),
   };
 }
@@ -327,6 +329,8 @@ describe("affectedIdentityClassSeeds", () => {
     canonicalEntities: [],
     identityAssertions: [],
     identityRetractions: [],
+    identityReconciliations: [],
+    identityConflicts: [],
     nodeDeletions: new Map<string, string>(),
     retypeMap: new Map<string, string>(),
     canonicalOf: new Map<string, string>(),

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -17,6 +17,8 @@ import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
 import { createLocalSqliteBackend } from "../../src/backend/sqlite/local";
 import {
   captureCandidateWriteSetTarget,
+  isOk,
+  merge,
   planCandidateWriteSetReview,
   revalidateCandidateWriteSetReview,
   unwrap,
@@ -113,19 +115,38 @@ describe("§3.3 refusal matrix — identity option validation", () => {
     ).toThrow();
   });
 
-  // Applied or refused, never ignored: both `"flag"` arms mean "drop the
-  // identity pairing", which needs a plan rebuild this release does not do.
-  // Accepting them and silently applying the default would be the API lying.
-  it("refuses onEdgeConflict: flag, naming what is missing", () => {
+  // The two deferred knobs (`onEdgeConflict`, `onUniquenessConflict`) are not
+  // part of the option at all this release: an option whose only accepted
+  // value is its default is dead surface. `.strict()` refuses them exactly as
+  // it refuses a typo, so a caller who states one is told rather than served a
+  // plan that ignored it.
+  it("refuses the deferred onEdgeConflict knob", () => {
     expect(() =>
-      normalizeMergeOptions({ identity: { onEdgeConflict: "flag" } }),
-    ).toThrow(/onEdgeConflict/);
+      // @ts-expect-error deferred: not part of this release's option
+      normalizeMergeOptions({ identity: { onEdgeConflict: "repoint" } }),
+    ).toThrow();
   });
 
-  it("refuses onUniquenessConflict: flag, naming what is missing", () => {
+  it("refuses the deferred onUniquenessConflict knob", () => {
     expect(() =>
-      normalizeMergeOptions({ identity: { onUniquenessConflict: "flag" } }),
-    ).toThrow(/onUniquenessConflict/);
+      // @ts-expect-error deferred: not part of this release's option
+      normalizeMergeOptions({ identity: { onUniquenessConflict: "refuse" } }),
+    ).toThrow();
+  });
+
+  it("a refused identity option carries details.option through tryNormalize", async () => {
+    const { backend } = createLocalSqliteBackend();
+    disposers.push(() => backend.close());
+    const [store] = await createStoreWithSchema(reviewGraph, backend, {
+      history: true,
+    });
+    const result = await merge(store, [], {
+      // @ts-expect-error deliberately invalid enum value
+      identity: { onAssertionConflict: "yolo" },
+    });
+    if (isOk(result)) throw new Error("expected an invalid-options refusal");
+    expect(result.error.code).toBe("GRAPH_MERGE_INVALID_OPTIONS");
+    expect(result.error.details["option"]).toBe("identity.onAssertionConflict");
   });
 
   it("accepts every arm it does honor", () => {
@@ -133,16 +154,12 @@ describe("§3.3 refusal matrix — identity option validation", () => {
       identity: {
         pairing: "definitional",
         onAssertionConflict: "flag",
-        onEdgeConflict: "repoint",
-        onUniquenessConflict: "refuse",
         onProvenanceConflict: "refuse",
       },
     });
     expect(normalized.identity).toEqual({
       pairing: "definitional",
       onAssertionConflict: "flag",
-      onEdgeConflict: "repoint",
-      onUniquenessConflict: "refuse",
       onProvenanceConflict: "refuse",
     });
   });

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -1,95 +1,100 @@
 /**
- * The `identity` merge-options normalizer (design §4.2 / plan-G2 §3):
+ * The `identity` merge-options bag (design §4.2 / plan-G2 §3): normalization
  * defaults, the `.strict()` scalar validation, the `onAssertionConflict`
  * function/string split, and — the compatibility hinge (§3.2) — that
- * normalization is PRESENCE-PRESERVING (`undefined` in, `undefined` out; `{}`
- * in resolves every default), so a review artifact captured before this
- * option existed will keep revalidating `compatible` once PR-3 wires it in.
- *
- * `normalizeIdentityOptions` is deliberately NOT yet called from
- * `normalizeMergeOptions`/`MergeOptions` (see the notes in `options.ts` and
- * `types.ts`): `MergeOptions` is already publicly exported, so attaching a
- * member to it moves `etc/typegraph-graph-merge.api.md`, a public-surface
- * change this internal PR must not make. This suite exercises the
- * normalizer directly — exactly the shape PR-3's wiring will preserve.
+ * `normalizeMergeOptions` emits the field ONLY when the caller stated
+ * `identity`, so a review artifact captured before this option existed keeps
+ * revalidating `compatible`.
  */
 import { describe, expect, it } from "vitest";
 
 import {
-  IDENTITY_OPTION_DEFAULTS,
-  normalizeIdentityOptions,
+  MERGE_OPTION_DEFAULTS,
+  normalizeMergeOptions,
 } from "../../src/graph-merge/options";
+import { reviewOptionEvidence } from "../../src/graph-merge/review-evidence";
 
 describe("T7 — presence-preserving normalization", () => {
-  it("returns undefined for undefined input", () => {
-    expect(normalizeIdentityOptions(undefined)).toBeUndefined();
+  it("omits `identity` entirely when the caller never stated it", () => {
+    const normalized = normalizeMergeOptions({});
+    expect("identity" in normalized).toBe(false);
   });
 
-  it("fully resolves every default once the caller states `{}`", () => {
-    expect(normalizeIdentityOptions({})).toEqual(IDENTITY_OPTION_DEFAULTS);
+  it("fully resolves `identity` once the caller states it, even as `{}`", () => {
+    const normalized = normalizeMergeOptions({ identity: {} });
+    expect(normalized.identity).toEqual(MERGE_OPTION_DEFAULTS.identity);
   });
 
-  it("mutation check: defaulting `undefined` to the resolved bag breaks presence-preservation", () => {
-    // Simulates the regression this test guards against: a normalizer that
-    // falls back to the defaulted bag instead of passing `undefined` through
-    // would make `identity-free` options revalidate as "identity present"
-    // once PR-3 wires this into `reviewOptionEvidence`.
-    const wronglyDefaulted =
-      normalizeIdentityOptions(undefined) ?? IDENTITY_OPTION_DEFAULTS;
-    expect(wronglyDefaulted).toEqual(IDENTITY_OPTION_DEFAULTS);
-    // ...which is exactly why the real normalizer must return `undefined`
-    // here, not the defaulted bag itself.
-    expect(normalizeIdentityOptions(undefined)).toBeUndefined();
+  it("an identity-free options bag's review evidence is unaffected by the new field existing", () => {
+    // The digest an old review artifact was captured against, and the digest
+    // a caller who never heard of `identity` produces today, must be
+    // IDENTICAL — otherwise every stored review artifact from before this
+    // release would revalidate `changed` for no stated reason.
+    const withoutIdentityField = reviewOptionEvidence({});
+    const jsonString = JSON.stringify(withoutIdentityField);
+    expect(jsonString.includes('"identity"')).toBe(false);
+  });
+
+  it("mutation check: emitting the defaulted bag unconditionally breaks presence-preservation", () => {
+    // Simulates the regression this test guards against directly against the
+    // normalizer, without needing to re-run the whole suite under a patched
+    // build: an unconditional emission is exactly `{ ...normalizeMergeOptions({}), identity: MERGE_OPTION_DEFAULTS.identity }`.
+    const wronglyUnconditional = {
+      ...normalizeMergeOptions({}),
+      identity: MERGE_OPTION_DEFAULTS.identity,
+    };
+    expect("identity" in wronglyUnconditional).toBe(true);
+    // ...which is exactly what the real (correct) normalizer must NOT do.
+    expect("identity" in normalizeMergeOptions({})).toBe(false);
   });
 });
 
-describe("T6 (normalizer layer) — every stated policy resolves distinctly", () => {
-  it("two different onAssertionConflict policies normalize to different bags", () => {
-    const assertWins = normalizeIdentityOptions({
-      pairing: "candidate",
-      onAssertionConflict: "assertWins",
+describe("T6 (options layer) — policy is part of the review evidence", () => {
+  it("two different onAssertionConflict policies encode to different evidence", () => {
+    const assertWinsEvidence = reviewOptionEvidence({
+      identity: { pairing: "candidate", onAssertionConflict: "assertWins" },
     });
-    const retractWins = normalizeIdentityOptions({
-      pairing: "candidate",
-      onAssertionConflict: "retractWins",
+    const retractWinsEvidence = reviewOptionEvidence({
+      identity: { pairing: "candidate", onAssertionConflict: "retractWins" },
     });
-    expect(assertWins).not.toEqual(retractWins);
+    expect(assertWinsEvidence).not.toEqual(retractWinsEvidence);
   });
 
-  it("a function policy passes through unchanged", () => {
-    const policy = (): { kind: "unresolved" } => ({ kind: "unresolved" });
-    const normalized = normalizeIdentityOptions({
-      pairing: "candidate",
-      onAssertionConflict: policy,
+  it("a function policy encodes as a callback marker, not its source", () => {
+    const evidence = reviewOptionEvidence({
+      identity: {
+        pairing: "candidate",
+        onAssertionConflict: () => ({ kind: "unresolved" as const }),
+      },
     });
-    expect(normalized?.onAssertionConflict).toBe(policy);
+    expect(JSON.stringify(evidence)).toContain('"callback"');
   });
 });
 
 describe("§3.3 refusal matrix — identity option validation", () => {
   it("refuses an unrecognized identity sub-option (typo)", () => {
     expect(() =>
-      normalizeIdentityOptions({
+      normalizeMergeOptions({
         // @ts-expect-error deliberately malformed to prove `.strict()` catches it
-        pairign: "candidate",
+        identity: { pairign: "candidate" },
       }),
     ).toThrow();
   });
 
   it("refuses an unrecognized onAssertionConflict string", () => {
     expect(() =>
-      normalizeIdentityOptions({
+      normalizeMergeOptions({
         // @ts-expect-error deliberately invalid enum value
-        onAssertionConflict: "yolo",
+        identity: { onAssertionConflict: "yolo" },
       }),
     ).toThrow(/onAssertionConflict/);
   });
 
   it("refuses an unrecognized pairing mode", () => {
     expect(() =>
-      normalizeIdentityOptions({
+      normalizeMergeOptions({
         // @ts-expect-error deliberately invalid enum value
-        pairing: "everything",
+        identity: { pairing: "everything" },
       }),
     ).toThrow();
   });

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -1,0 +1,101 @@
+/**
+ * The `identity` merge-options bag (design §4.2 / plan-G2 §3): normalization
+ * defaults, the `.strict()` scalar validation, the `onAssertionConflict`
+ * function/string split, and — the compatibility hinge (§3.2) — that
+ * `normalizeMergeOptions` emits the field ONLY when the caller stated
+ * `identity`, so a review artifact captured before this option existed keeps
+ * revalidating `compatible`.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  MERGE_OPTION_DEFAULTS,
+  normalizeMergeOptions,
+} from "../../src/graph-merge/options";
+import { reviewOptionEvidence } from "../../src/graph-merge/review-evidence";
+
+describe("T7 — presence-preserving normalization", () => {
+  it("omits `identity` entirely when the caller never stated it", () => {
+    const normalized = normalizeMergeOptions({});
+    expect("identity" in normalized).toBe(false);
+  });
+
+  it("fully resolves `identity` once the caller states it, even as `{}`", () => {
+    const normalized = normalizeMergeOptions({ identity: {} });
+    expect(normalized.identity).toEqual(MERGE_OPTION_DEFAULTS.identity);
+  });
+
+  it("an identity-free options bag's review evidence is unaffected by the new field existing", () => {
+    // The digest an old review artifact was captured against, and the digest
+    // a caller who never heard of `identity` produces today, must be
+    // IDENTICAL — otherwise every stored review artifact from before this
+    // release would revalidate `changed` for no stated reason.
+    const withoutIdentityField = reviewOptionEvidence({});
+    const jsonString = JSON.stringify(withoutIdentityField);
+    expect(jsonString.includes('"identity"')).toBe(false);
+  });
+
+  it("mutation check: emitting the defaulted bag unconditionally breaks presence-preservation", () => {
+    // Simulates the regression this test guards against directly against the
+    // normalizer, without needing to re-run the whole suite under a patched
+    // build: an unconditional emission is exactly `{ ...normalizeMergeOptions({}), identity: MERGE_OPTION_DEFAULTS.identity }`.
+    const wronglyUnconditional = {
+      ...normalizeMergeOptions({}),
+      identity: MERGE_OPTION_DEFAULTS.identity,
+    };
+    expect("identity" in wronglyUnconditional).toBe(true);
+    // ...which is exactly what the real (correct) normalizer must NOT do.
+    expect("identity" in normalizeMergeOptions({})).toBe(false);
+  });
+});
+
+describe("T6 (options layer) — policy is part of the review evidence", () => {
+  it("two different onAssertionConflict policies encode to different evidence", () => {
+    const assertWinsEvidence = reviewOptionEvidence({
+      identity: { pairing: "candidate", onAssertionConflict: "assertWins" },
+    });
+    const retractWinsEvidence = reviewOptionEvidence({
+      identity: { pairing: "candidate", onAssertionConflict: "retractWins" },
+    });
+    expect(assertWinsEvidence).not.toEqual(retractWinsEvidence);
+  });
+
+  it("a function policy encodes as a callback marker, not its source", () => {
+    const evidence = reviewOptionEvidence({
+      identity: {
+        pairing: "candidate",
+        onAssertionConflict: () => ({ kind: "unresolved" as const }),
+      },
+    });
+    expect(JSON.stringify(evidence)).toContain('"callback"');
+  });
+});
+
+describe("§3.3 refusal matrix — identity option validation", () => {
+  it("refuses an unrecognized identity sub-option (typo)", () => {
+    expect(() =>
+      normalizeMergeOptions({
+        // @ts-expect-error deliberately malformed to prove `.strict()` catches it
+        identity: { pairign: "candidate" },
+      }),
+    ).toThrow();
+  });
+
+  it("refuses an unrecognized onAssertionConflict string", () => {
+    expect(() =>
+      normalizeMergeOptions({
+        // @ts-expect-error deliberately invalid enum value
+        identity: { onAssertionConflict: "yolo" },
+      }),
+    ).toThrow(/onAssertionConflict/);
+  });
+
+  it("refuses an unrecognized pairing mode", () => {
+    expect(() =>
+      normalizeMergeOptions({
+        // @ts-expect-error deliberately invalid enum value
+        identity: { pairing: "everything" },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -1,18 +1,32 @@
 /**
- * The `identity` merge-options bag (design §4.2 / plan-G2 §3): normalization
- * defaults, the `.strict()` scalar validation, the `onAssertionConflict`
- * function/string split, and — the compatibility hinge (§3.2) — that
- * `normalizeMergeOptions` emits the field ONLY when the caller stated
+ * The `identity` merge-options bag: normalization defaults, the `.strict()`
+ * scalar validation, the `onAssertionConflict` function/string split, the
+ * refusal of every value the merge cannot honor, and — the compatibility hinge
+ * — that `normalizeMergeOptions` emits the field ONLY when the caller stated
  * `identity`, so a review artifact captured before this option existed keeps
  * revalidating `compatible`.
+ *
+ * The governed-merge promise runs through here: `reviewOptionEvidence` encodes
+ * what `normalizeMergeOptions` emits, so a policy inside the bag is inside the
+ * review digest, and an applier that changed it is refused.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 
+import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
+import { createLocalSqliteBackend } from "../../src/backend/sqlite/local";
+import {
+  captureCandidateWriteSetTarget,
+  planCandidateWriteSetReview,
+  revalidateCandidateWriteSetReview,
+  unwrap,
+} from "../../src/graph-merge";
 import {
   MERGE_OPTION_DEFAULTS,
   normalizeMergeOptions,
 } from "../../src/graph-merge/options";
 import { reviewOptionEvidence } from "../../src/graph-merge/review-evidence";
+import type { IdentityReconciliationOptions } from "../../src/graph-merge/types";
 
 describe("T7 — presence-preserving normalization", () => {
   it("omits `identity` entirely when the caller never stated it", () => {
@@ -97,5 +111,128 @@ describe("§3.3 refusal matrix — identity option validation", () => {
         identity: { pairing: "everything" },
       }),
     ).toThrow();
+  });
+
+  // Applied or refused, never ignored: both `"flag"` arms mean "drop the
+  // identity pairing", which needs a plan rebuild this release does not do.
+  // Accepting them and silently applying the default would be the API lying.
+  it("refuses onEdgeConflict: flag, naming what is missing", () => {
+    expect(() =>
+      normalizeMergeOptions({ identity: { onEdgeConflict: "flag" } }),
+    ).toThrow(/onEdgeConflict/);
+  });
+
+  it("refuses onUniquenessConflict: flag, naming what is missing", () => {
+    expect(() =>
+      normalizeMergeOptions({ identity: { onUniquenessConflict: "flag" } }),
+    ).toThrow(/onUniquenessConflict/);
+  });
+
+  it("accepts every arm it does honor", () => {
+    const normalized = normalizeMergeOptions({
+      identity: {
+        pairing: "definitional",
+        onAssertionConflict: "flag",
+        onEdgeConflict: "repoint",
+        onUniquenessConflict: "refuse",
+        onProvenanceConflict: "refuse",
+      },
+    });
+    expect(normalized.identity).toEqual({
+      pairing: "definitional",
+      onAssertionConflict: "flag",
+      onEdgeConflict: "repoint",
+      onUniquenessConflict: "refuse",
+      onProvenanceConflict: "refuse",
+    });
+  });
+});
+
+const ReviewItem = defineNode("Item", {
+  schema: z.object({ name: z.string() }),
+});
+const reviewGraph = defineGraph({
+  id: "identity_options_review",
+  nodes: { Item: { type: ReviewItem } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+const REVIEW_POLICY = { id: "identity-review-policy", context: {} } as const;
+
+const disposers: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const dispose of disposers.splice(0)) await dispose();
+});
+
+async function reviewArgs(identity: IdentityReconciliationOptions | undefined) {
+  const { backend } = createLocalSqliteBackend();
+  disposers.push(() => backend.close());
+  const [target] = await createStoreWithSchema(reviewGraph, backend, {
+    history: true,
+  });
+  return {
+    target,
+    makeBackend: async () => createLocalSqliteBackend().backend,
+    writeSet: {
+      formatVersion: 1 as const,
+      sourceId: "source",
+      target: await captureCandidateWriteSetTarget(target),
+      nodes: [
+        {
+          kind: "Item",
+          id: "candidate",
+          properties: { name: "New" },
+          validFrom: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      edges: [],
+    },
+    policy: REVIEW_POLICY,
+    ...(identity === undefined ? {} : { options: { identity } }),
+  };
+}
+
+describe("T6 — the identity policy is inside the review digest", () => {
+  it("revalidating an approved plan under a DIFFERENT assertion policy reports changed", async () => {
+    const planned = await reviewArgs({ onAssertionConflict: "assertWins" });
+    const review = unwrap(await planCandidateWriteSetReview(planned));
+    // Same write set, same target, same reviewer — only the policy moved.
+    const applying = await reviewArgs({ onAssertionConflict: "retractWins" });
+    const revalidated = unwrap(
+      await revalidateCandidateWriteSetReview({
+        ...applying,
+        target: planned.target,
+        review: JSON.parse(JSON.stringify(review)),
+      }),
+    );
+    expect(revalidated.status).toBe("changed");
+  });
+
+  it("revalidating under the SAME policy stays compatible", async () => {
+    const planned = await reviewArgs({ onAssertionConflict: "assertWins" });
+    const review = unwrap(await planCandidateWriteSetReview(planned));
+    const applying = await reviewArgs({ onAssertionConflict: "assertWins" });
+    const revalidated = unwrap(
+      await revalidateCandidateWriteSetReview({
+        ...applying,
+        target: planned.target,
+        review: JSON.parse(JSON.stringify(review)),
+      }),
+    );
+    expect(revalidated.status).toBe("compatible");
+  });
+
+  it("T7 at the artifact layer: an identity-free review stays compatible against identity-free options", async () => {
+    const planned = await reviewArgs(undefined);
+    const review = unwrap(await planCandidateWriteSetReview(planned));
+    const applying = await reviewArgs(undefined);
+    const revalidated = unwrap(
+      await revalidateCandidateWriteSetReview({
+        ...applying,
+        target: planned.target,
+        review: JSON.parse(JSON.stringify(review)),
+      }),
+    );
+    expect(revalidated.status).toBe("compatible");
   });
 });

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -267,7 +267,7 @@ describe("T6 — the identity policy is inside the review digest", () => {
     // sides being computed by the current code would make this test unable to
     // fail — an unconditional `identity` emission would move both together.
     const stored = {
-      ...JSON.parse(JSON.stringify(review)),
+      ...(JSON.parse(JSON.stringify(review)) as typeof review),
       options: PRE_RELEASE_OPTION_EVIDENCE,
     };
     const applying = await reviewArgs(undefined);

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -1,100 +1,95 @@
 /**
- * The `identity` merge-options bag (design §4.2 / plan-G2 §3): normalization
+ * The `identity` merge-options normalizer (design §4.2 / plan-G2 §3):
  * defaults, the `.strict()` scalar validation, the `onAssertionConflict`
  * function/string split, and — the compatibility hinge (§3.2) — that
- * `normalizeMergeOptions` emits the field ONLY when the caller stated
- * `identity`, so a review artifact captured before this option existed keeps
- * revalidating `compatible`.
+ * normalization is PRESENCE-PRESERVING (`undefined` in, `undefined` out; `{}`
+ * in resolves every default), so a review artifact captured before this
+ * option existed will keep revalidating `compatible` once PR-3 wires it in.
+ *
+ * `normalizeIdentityOptions` is deliberately NOT yet called from
+ * `normalizeMergeOptions`/`MergeOptions` (see the notes in `options.ts` and
+ * `types.ts`): `MergeOptions` is already publicly exported, so attaching a
+ * member to it moves `etc/typegraph-graph-merge.api.md`, a public-surface
+ * change this internal PR must not make. This suite exercises the
+ * normalizer directly — exactly the shape PR-3's wiring will preserve.
  */
 import { describe, expect, it } from "vitest";
 
 import {
-  MERGE_OPTION_DEFAULTS,
-  normalizeMergeOptions,
+  IDENTITY_OPTION_DEFAULTS,
+  normalizeIdentityOptions,
 } from "../../src/graph-merge/options";
-import { reviewOptionEvidence } from "../../src/graph-merge/review-evidence";
 
 describe("T7 — presence-preserving normalization", () => {
-  it("omits `identity` entirely when the caller never stated it", () => {
-    const normalized = normalizeMergeOptions({});
-    expect("identity" in normalized).toBe(false);
+  it("returns undefined for undefined input", () => {
+    expect(normalizeIdentityOptions(undefined)).toBeUndefined();
   });
 
-  it("fully resolves `identity` once the caller states it, even as `{}`", () => {
-    const normalized = normalizeMergeOptions({ identity: {} });
-    expect(normalized.identity).toEqual(MERGE_OPTION_DEFAULTS.identity);
+  it("fully resolves every default once the caller states `{}`", () => {
+    expect(normalizeIdentityOptions({})).toEqual(IDENTITY_OPTION_DEFAULTS);
   });
 
-  it("an identity-free options bag's review evidence is unaffected by the new field existing", () => {
-    // The digest an old review artifact was captured against, and the digest
-    // a caller who never heard of `identity` produces today, must be
-    // IDENTICAL — otherwise every stored review artifact from before this
-    // release would revalidate `changed` for no stated reason.
-    const withoutIdentityField = reviewOptionEvidence({});
-    const jsonString = JSON.stringify(withoutIdentityField);
-    expect(jsonString.includes('"identity"')).toBe(false);
-  });
-
-  it("mutation check: emitting the defaulted bag unconditionally breaks presence-preservation", () => {
-    // Simulates the regression this test guards against directly against the
-    // normalizer, without needing to re-run the whole suite under a patched
-    // build: an unconditional emission is exactly `{ ...normalizeMergeOptions({}), identity: MERGE_OPTION_DEFAULTS.identity }`.
-    const wronglyUnconditional = {
-      ...normalizeMergeOptions({}),
-      identity: MERGE_OPTION_DEFAULTS.identity,
-    };
-    expect("identity" in wronglyUnconditional).toBe(true);
-    // ...which is exactly what the real (correct) normalizer must NOT do.
-    expect("identity" in normalizeMergeOptions({})).toBe(false);
+  it("mutation check: defaulting `undefined` to the resolved bag breaks presence-preservation", () => {
+    // Simulates the regression this test guards against: a normalizer that
+    // falls back to the defaulted bag instead of passing `undefined` through
+    // would make `identity-free` options revalidate as "identity present"
+    // once PR-3 wires this into `reviewOptionEvidence`.
+    const wronglyDefaulted =
+      normalizeIdentityOptions(undefined) ?? IDENTITY_OPTION_DEFAULTS;
+    expect(wronglyDefaulted).toEqual(IDENTITY_OPTION_DEFAULTS);
+    // ...which is exactly why the real normalizer must return `undefined`
+    // here, not the defaulted bag itself.
+    expect(normalizeIdentityOptions(undefined)).toBeUndefined();
   });
 });
 
-describe("T6 (options layer) — policy is part of the review evidence", () => {
-  it("two different onAssertionConflict policies encode to different evidence", () => {
-    const assertWinsEvidence = reviewOptionEvidence({
-      identity: { pairing: "candidate", onAssertionConflict: "assertWins" },
+describe("T6 (normalizer layer) — every stated policy resolves distinctly", () => {
+  it("two different onAssertionConflict policies normalize to different bags", () => {
+    const assertWins = normalizeIdentityOptions({
+      pairing: "candidate",
+      onAssertionConflict: "assertWins",
     });
-    const retractWinsEvidence = reviewOptionEvidence({
-      identity: { pairing: "candidate", onAssertionConflict: "retractWins" },
+    const retractWins = normalizeIdentityOptions({
+      pairing: "candidate",
+      onAssertionConflict: "retractWins",
     });
-    expect(assertWinsEvidence).not.toEqual(retractWinsEvidence);
+    expect(assertWins).not.toEqual(retractWins);
   });
 
-  it("a function policy encodes as a callback marker, not its source", () => {
-    const evidence = reviewOptionEvidence({
-      identity: {
-        pairing: "candidate",
-        onAssertionConflict: () => ({ kind: "unresolved" as const }),
-      },
+  it("a function policy passes through unchanged", () => {
+    const policy = (): { kind: "unresolved" } => ({ kind: "unresolved" });
+    const normalized = normalizeIdentityOptions({
+      pairing: "candidate",
+      onAssertionConflict: policy,
     });
-    expect(JSON.stringify(evidence)).toContain('"callback"');
+    expect(normalized?.onAssertionConflict).toBe(policy);
   });
 });
 
 describe("§3.3 refusal matrix — identity option validation", () => {
   it("refuses an unrecognized identity sub-option (typo)", () => {
     expect(() =>
-      normalizeMergeOptions({
+      normalizeIdentityOptions({
         // @ts-expect-error deliberately malformed to prove `.strict()` catches it
-        identity: { pairign: "candidate" },
+        pairign: "candidate",
       }),
     ).toThrow();
   });
 
   it("refuses an unrecognized onAssertionConflict string", () => {
     expect(() =>
-      normalizeMergeOptions({
+      normalizeIdentityOptions({
         // @ts-expect-error deliberately invalid enum value
-        identity: { onAssertionConflict: "yolo" },
+        onAssertionConflict: "yolo",
       }),
     ).toThrow(/onAssertionConflict/);
   });
 
   it("refuses an unrecognized pairing mode", () => {
     expect(() =>
-      normalizeMergeOptions({
+      normalizeIdentityOptions({
         // @ts-expect-error deliberately invalid enum value
-        identity: { pairing: "everything" },
+        pairing: "everything",
       }),
     ).toThrow();
   });

--- a/packages/typegraph/tests/graph-merge/identity-options.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-options.test.ts
@@ -16,10 +16,13 @@ import { z } from "zod";
 import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
 import { createLocalSqliteBackend } from "../../src/backend/sqlite/local";
 import {
+  branch,
   captureCandidateWriteSetTarget,
   isOk,
   merge,
+  MERGE_PLAN_FORMAT_VERSION,
   planCandidateWriteSetReview,
+  planMerge,
   revalidateCandidateWriteSetReview,
   unwrap,
 } from "../../src/graph-merge";
@@ -28,7 +31,29 @@ import {
   normalizeMergeOptions,
 } from "../../src/graph-merge/options";
 import { reviewOptionEvidence } from "../../src/graph-merge/review-evidence";
-import type { IdentityReconciliationOptions } from "../../src/graph-merge/types";
+import {
+  asBranchId,
+  type IdentityReconciliationOptions,
+} from "../../src/graph-merge/types";
+
+/**
+ * The option evidence a caller who never heard of `identity` produced BEFORE
+ * this release — copied literally, not recomputed. A review artifact stored
+ * against this must keep revalidating `compatible`.
+ */
+const PRE_RELEASE_OPTION_EVIDENCE = [
+  "object",
+  [
+    ["onBasePropertyConflict", ["literal", "flag"]],
+    ["onComparisonCeiling", ["literal", "error"]],
+    ["onDeleteModifyConflict", ["literal", "flag"]],
+    ["onPropertyConflict", ["literal", "flag"]],
+    ["persistProvenance", ["literal", false]],
+    ["provenance", ["literal", true]],
+    ["reconcileTypes", ["literal", "off"]],
+    ["resolve", ["object", []]],
+  ],
+] as const;
 
 describe("T7 — presence-preserving normalization", () => {
   it("omits `identity` entirely when the caller never stated it", () => {
@@ -51,17 +76,12 @@ describe("T7 — presence-preserving normalization", () => {
     expect(jsonString.includes('"identity"')).toBe(false);
   });
 
-  it("mutation check: emitting the defaulted bag unconditionally breaks presence-preservation", () => {
-    // Simulates the regression this test guards against directly against the
-    // normalizer, without needing to re-run the whole suite under a patched
-    // build: an unconditional emission is exactly `{ ...normalizeMergeOptions({}), identity: MERGE_OPTION_DEFAULTS.identity }`.
-    const wronglyUnconditional = {
-      ...normalizeMergeOptions({}),
-      identity: MERGE_OPTION_DEFAULTS.identity,
-    };
-    expect("identity" in wronglyUnconditional).toBe(true);
-    // ...which is exactly what the real (correct) normalizer must NOT do.
-    expect("identity" in normalizeMergeOptions({})).toBe(false);
+  it("an identity-free bag encodes to the FROZEN pre-release evidence, field for field", () => {
+    // Not "the same as what the normalizer produces" — a literal copy of the
+    // evidence this release inherited. Anything the normalizer starts emitting
+    // for an identity-free caller fails here, which is what makes every stored
+    // review artifact's compatibility a guarantee rather than a coincidence.
+    expect(reviewOptionEvidence({})).toEqual(PRE_RELEASE_OPTION_EVIDENCE);
   });
 });
 
@@ -239,17 +259,57 @@ describe("T6 — the identity policy is inside the review digest", () => {
     expect(revalidated.status).toBe("compatible");
   });
 
-  it("T7 at the artifact layer: an identity-free review stays compatible against identity-free options", async () => {
+  it("T7 at the artifact layer: a review captured BEFORE this release still revalidates compatible", async () => {
     const planned = await reviewArgs(undefined);
     const review = unwrap(await planCandidateWriteSetReview(planned));
+    // The stored artifact is a PRE-RELEASE one: its option evidence is the
+    // frozen literal, not whatever today's normalizer happens to emit. Both
+    // sides being computed by the current code would make this test unable to
+    // fail — an unconditional `identity` emission would move both together.
+    const stored = {
+      ...JSON.parse(JSON.stringify(review)),
+      options: PRE_RELEASE_OPTION_EVIDENCE,
+    };
     const applying = await reviewArgs(undefined);
     const revalidated = unwrap(
       await revalidateCandidateWriteSetReview({
         ...applying,
         target: planned.target,
-        review: JSON.parse(JSON.stringify(review)),
+        review: stored,
       }),
     );
     expect(revalidated.status).toBe("compatible");
+  });
+
+  it("T7 — the identity review arms are additive: the plan format version stays 2", async () => {
+    const { backend } = createLocalSqliteBackend();
+    disposers.push(() => backend.close());
+    const [target] = await createStoreWithSchema(reviewGraph, backend, {
+      history: true,
+    });
+    await target.nodes.Item.create({ name: "Kept" }, { id: "kept" });
+    const source = unwrap(
+      await branch(target, async () => createLocalSqliteBackend().backend, {
+        id: asBranchId("branch-a"),
+      }),
+    );
+    await source.store.nodes.Item.create({ name: "Fresh" }, { id: "fresh" });
+    await source.store.identity.assertSame(
+      { kind: "Item", id: "kept" },
+      { kind: "Item", id: "fresh" },
+    );
+    disposers.push(() => source.close());
+
+    const artifact = unwrap(
+      await planMerge(target, [source], {
+        branchOrder: [asBranchId("branch-a")],
+        identity: { pairing: "definitional" },
+      }),
+    );
+    expect(MERGE_PLAN_FORMAT_VERSION).toBe(2);
+    expect(artifact.formatVersion).toBe(MERGE_PLAN_FORMAT_VERSION);
+    // Present only when non-empty, so an identity-free plan's review object is
+    // byte-identical to a pre-release one at the same format version.
+    expect(artifact.review.identityConflicts).toBeDefined();
   });
 });

--- a/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
@@ -152,16 +152,20 @@ describe.each(backendMatrix())(
     }
 
     /**
-     * T3 — a FORCED candidate edge whose endpoints the ledger holds apart is
-     * refused at PLAN time.
+     * T3 — a DEFINITIONAL pairing that SURVIVES the base and diameter guards
+     * is refused at PLAN time.
      *
-     * The target holds `alpha` and `beta` and separates them. A branch created
-     * its own `beta` carrying `alpha`'s unique email, so the shared unique
-     * value is a DEFINITIONAL claim that `beta` and `alpha` are one entity —
-     * against a ledger that says they are not.
+     * Both branches recreate `alpha` and `beta`, which the TARGET already holds
+     * apart, and one of them asserts they are the same entity. The two staged
+     * assertions collide, and a policy that resolves the collision in favour
+     * of `same` still cannot fuse them: resolving the collision changes what
+     * the merge ASSERTS, not what the target currently HOLDS. Under
+     * `pairing: "definitional"` the surviving assertion forces a fused edge
+     * between two staged nodes — no base member is involved, so no guard
+     * severs it and the cluster really would collapse two separated classes.
      */
-    it("refuses a forced candidate edge whose endpoints are class-lifted different", async () => {
-      const forkPoint = await makeStore();
+    it("refuses a definitional pairing that survives the guards", async () => {
+      const forkPoint = await makeSimilarityStore();
       const target = unwrap(
         await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
       ).store;
@@ -182,8 +186,16 @@ describe.each(backendMatrix())(
         await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
       );
       await source.store.nodes.Person.create(
-        { name: "Beta", email: "alpha@example.test" },
+        { name: "Alpha", email: "alpha@example.test" },
+        { id: "alpha" },
+      );
+      await source.store.nodes.Person.create(
+        { name: "Beta", email: "beta@example.test" },
         { id: "beta" },
+      );
+      await source.store.identity.assertSame(
+        { kind: "Person", id: "alpha" },
+        { kind: "Person", id: "beta" },
       );
 
       const before = await livePersonIds(target);
@@ -193,15 +205,25 @@ describe.each(backendMatrix())(
         branches: [source],
         options: {
           branchOrder: [BRANCH_A],
-          resolve: { Person: FORCED_ONLY_RESOLVE },
+          identity: {
+            pairing: "definitional",
+            onAssertionConflict: (conflict) => {
+              const same = conflict.asserted.find(
+                (staged) => staged.assertion.relation === "same",
+              );
+              return same === undefined ?
+                  { kind: "unresolved" }
+                : { kind: "assert", assertionId: same.assertion.id };
+            },
+          },
         },
       });
 
       if (isOk(result)) throw new Error("expected a separation refusal");
       expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
-      // The load-bearing half: the code AND the phase. Without the
-      // candidate-edge veto the merge reaches the commit and dies on the
-      // separation relation's CHECK under a different code.
+      // The load-bearing half: the code AND the phase. Without the veto the
+      // merge reaches the commit and dies on the separation relation's CHECK
+      // under a different code.
       expect(result.error.code).toBe(
         "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
       );
@@ -213,8 +235,69 @@ describe.each(backendMatrix())(
       // The refusal names the assertion that separated them, not just that
       // something did.
       expect(result.error.details["assertionIds"]).toHaveLength(1);
+      // The EDGE-level diagnosis, not the cluster-level one: a surviving
+      // definitional claim is refused naming the source that proposed it.
+      expect(result.error.details["sources"]).toEqual([
+        expect.objectContaining({ kind: "identity" }),
+      ]);
+      expect(result.error.details["cluster"]).toBeUndefined();
       // The target is byte-unchanged: a plan-time refusal writes nothing.
       expect(await livePersonIds(target)).toEqual(before);
+    });
+
+    /**
+     * The counterpart, and the reason the definitional refusal runs AFTER the
+     * guards: a forced BASE pairing between two committed entities is severed
+     * by the component base guard, so it never fuses anything. Refusing it up
+     * front would fail a merge that is harmless — this fixture merges cleanly
+     * and leaves both entities, and their separation, intact.
+     */
+    it("does not refuse a forced base pairing the base guard already severed", async () => {
+      const forkPoint = await makeStore();
+      const target = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
+      ).store;
+      await target.nodes.Person.create(
+        { name: "Alpha", email: "alpha@example.test" },
+        { id: "alpha" },
+      );
+      await target.nodes.Person.create(
+        { name: "Beta", email: "beta@example.test" },
+        { id: "beta" },
+      );
+      await target.identity.assertDifferent(
+        { kind: "Person", id: "alpha" },
+        { kind: "Person", id: "beta" },
+      );
+
+      const source = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      );
+      // Shares `alpha`'s unique email, so a base source forces the pairing.
+      await source.store.nodes.Person.create(
+        { name: "Beta", email: "alpha@example.test" },
+        { id: "beta" },
+      );
+
+      const result = await mergeIncremental({
+        forkPoint,
+        target,
+        branches: [source],
+        options: {
+          branchOrder: [BRANCH_A],
+          resolve: { Person: FORCED_ONLY_RESOLVE },
+        },
+      });
+
+      if (isErr(result)) throw result.error;
+      expect(result.data.resolutions).toEqual([]);
+      expect(await livePersonIds(target)).toEqual(["alpha", "beta"]);
+      expect(
+        await target.identity.areDifferent(
+          { kind: "Person", id: "alpha" },
+          { kind: "Person", id: "beta" },
+        ),
+      ).toBe(true);
     });
 
     /**
@@ -327,6 +410,61 @@ describe.each(backendMatrix())(
     });
 
     /**
+     * `pairing: "candidate"` is RECALL, not proof: the assertion proposes the
+     * pair and the kind's own threshold still decides. The pair must therefore
+     * travel the ordinary scored pipeline — blocking puts the two nodes in
+     * different buckets, so no other source proposes them and the identity
+     * source is the only recall path under test.
+     */
+    it("candidate pairing proposes a SCORED pair the kind's threshold still decides", async () => {
+      async function mergeWith(
+        identity: { pairing: "candidate" } | undefined,
+        threshold: number,
+      ): Promise<readonly string[]> {
+        const store = await makeStore();
+        const source = unwrap(
+          await branch(store, () => makeBackend(), { id: BRANCH_A }),
+        );
+        await source.store.nodes.Person.create(
+          { name: "Ada", email: "a2@example.test" },
+          { id: "a2" },
+        );
+        await source.store.nodes.Person.create(
+          { name: "Ada", email: "b2@example.test" },
+          { id: "b2" },
+        );
+        await source.store.identity.assertSame(
+          { kind: "Person", id: "a2" },
+          { kind: "Person", id: "b2" },
+        );
+        const result = await merge(store, [source], {
+          branchOrder: [BRANCH_A],
+          resolve: {
+            Person: {
+              // One bucket per node: no other source can propose the pair.
+              block: (node) => node.id as string,
+              threshold,
+              similarity: { kind: "custom", score: () => 0.6 },
+            },
+          },
+          ...(identity === undefined ? {} : { identity }),
+        });
+        if (isErr(result)) throw result.error;
+        return livePersonIds(store);
+      }
+
+      // Scored 0.6: above a 0.5 threshold the identity-recalled pair merges.
+      expect(await mergeWith({ pairing: "candidate" }, 0.5)).toEqual(["a2"]);
+      // Same recall, same score, higher bar — the threshold still decides.
+      expect(await mergeWith({ pairing: "candidate" }, 0.9)).toEqual([
+        "a2",
+        "b2",
+      ]);
+      // Without the pairing option nothing proposes the pair at all.
+      expect(await mergeWith(undefined, 0.5)).toEqual(["a2", "b2"]);
+    });
+
+    /**
      * A cross-kind `same` assertion cannot be expressed as a per-kind pairing
      * edge — `orderEndpoints` keys on `(kind, id)` and a source scope is built
      * per kind. It is reported as a typed conflict rather than skipped, so a
@@ -372,11 +510,12 @@ describe.each(backendMatrix())(
 
     /**
      * The veto is on even with `pairing` absent, because a `different`
-     * assertion is an integrity fact and not a recall heuristic. Same fixture
-     * as the transitive case, no `identity` option stated at all.
+     * assertion is an integrity fact and not a recall heuristic. A SCORED
+     * match is recall, so the ledger's veto drops the proposal, reports it,
+     * and the merge continues — the plan is still applicable.
      */
-    it("vetoes without any identity option stated", async () => {
-      const forkPoint = await makeStore();
+    it("drops and reports a scored match the ledger holds apart, with no identity option stated", async () => {
+      const forkPoint = await makeSimilarityStore();
       const target = unwrap(
         await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
       ).store;
@@ -396,8 +535,8 @@ describe.each(backendMatrix())(
         await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
       );
       await source.store.nodes.Person.create(
-        { name: "beta", email: "alpha@example.test" },
-        { id: "beta" },
+        { name: "delta", email: "delta@example.test" },
+        { id: "delta" },
       );
 
       const result = await mergeIncremental({
@@ -406,13 +545,46 @@ describe.each(backendMatrix())(
         branches: [source],
         options: {
           branchOrder: [BRANCH_A],
-          resolve: { Person: FORCED_ONLY_RESOLVE },
+          resolve: {
+            Person: {
+              ...ONE_BUCKET,
+              threshold: 0.5,
+              similarity: {
+                kind: "custom",
+                // Only the separated pair scores: nothing else may fuse, so
+                // the drop is observable on its own.
+                score: (left, right) => {
+                  const ids = [
+                    left.id as string,
+                    right.id as string,
+                  ].toSorted();
+                  return ids[0] === "alpha" && ids[1] === "beta" ? 1 : 0;
+                },
+              },
+            },
+          },
         },
       });
-      if (isOk(result)) throw new Error("expected a separation refusal");
-      expect(result.error.code).toBe(
-        "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
+
+      if (isErr(result)) throw result.error;
+      const separations = result.data.identityConflicts.filter(
+        (conflict) => conflict.kind === "separation",
       );
+      expect(separations).toHaveLength(1);
+      expect(separations[0]).toMatchObject({
+        kind: "separation",
+        a: { kind: "Person", id: "alpha" },
+        b: { kind: "Person", id: "beta" },
+      });
+      expect(separations[0]?.assertionIds).toHaveLength(1);
+      // Reported, not fatal: the merge lands and the separation stands.
+      expect(await livePersonIds(target)).toEqual(["alpha", "beta", "delta"]);
+      expect(
+        await target.identity.areDifferent(
+          { kind: "Person", id: "alpha" },
+          { kind: "Person", id: "beta" },
+        ),
+      ).toBe(true);
     });
   },
 );

--- a/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
@@ -465,6 +465,73 @@ describe.each(backendMatrix())(
     });
 
     /**
+     * `onProvenanceConflict: "refuse"` — for a caller whose source attribution
+     * is a correctness invariant rather than a record. Only a cluster an
+     * identity assertion FUSED is judged: two members contributed under
+     * different source ids disagree, and the plan fails naming the canonical
+     * entity and the contributions.
+     */
+    it("refuses an identity-paired entity whose members disagree on provenance", async () => {
+      const store = await makeStore();
+      const source = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "Ada", email: "a3@example.test" },
+        { id: "a3" },
+      );
+      await source.store.nodes.Person.create(
+        { name: "Ada", email: "b3@example.test" },
+        { id: "b3" },
+      );
+      await source.store.identity.assertSame(
+        { kind: "Person", id: "a3" },
+        { kind: "Person", id: "b3" },
+      );
+
+      const result = await merge(store, [source], {
+        branchOrder: [BRANCH_A],
+        identity: { pairing: "definitional", onProvenanceConflict: "refuse" },
+      });
+      if (isOk(result)) throw new Error("expected a provenance refusal");
+      expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
+      expect(result.error.code).toBe(
+        "GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT",
+      );
+      expect(result.error.details["conflict"]).toMatchObject({
+        kind: "provenance",
+        canonical: { kind: "Person", id: "a3" },
+      });
+      // Nothing was written: the refusal is a plan-time one.
+      expect(await livePersonIds(store)).toEqual([]);
+
+      // The DEFAULT keeps every contribution and merges the same fixture, so
+      // the refusal is the policy's doing and not the pairing's.
+      const keeping = await makeStore();
+      const keepingSource = unwrap(
+        await branch(keeping, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await keepingSource.store.nodes.Person.create(
+        { name: "Ada", email: "a3@example.test" },
+        { id: "a3" },
+      );
+      await keepingSource.store.nodes.Person.create(
+        { name: "Ada", email: "b3@example.test" },
+        { id: "b3" },
+      );
+      await keepingSource.store.identity.assertSame(
+        { kind: "Person", id: "a3" },
+        { kind: "Person", id: "b3" },
+      );
+      const kept = await merge(keeping, [keepingSource], {
+        branchOrder: [BRANCH_A],
+        identity: { pairing: "definitional" },
+      });
+      if (isErr(kept)) throw kept.error;
+      expect(await livePersonIds(keeping)).toEqual(["a3"]);
+    });
+
+    /**
      * A cross-kind `same` assertion cannot be expressed as a per-kind pairing
      * edge — `orderEndpoints` keys on `(kind, id)` and a source scope is built
      * per kind. It is reported as a typed conflict rather than skipped, so a
@@ -506,6 +573,54 @@ describe.each(backendMatrix())(
       });
       // Reported, not fatal: both nodes still merge as themselves.
       expect(await livePersonIds(store)).toEqual(["p1"]);
+    });
+
+    /**
+     * A `same` assertion whose endpoints are not both staged new nodes of the
+     * kind cannot be expressed as a pairing edge either — candidate generation
+     * proposes over the nodes in scope. It is reported for the same reason the
+     * cross-kind case is: a stated `pairing` that cannot be applied must be
+     * visibly refused, never silently skipped.
+     */
+    it("reports a same assertion whose endpoint is not a staged new node", async () => {
+      const store = await makeStore();
+      // Committed on the TARGET before the branch forks, so it is base truth
+      // and never a staged new node.
+      await store.nodes.Person.create(
+        { name: "Ada", email: "committed@example.test" },
+        { id: "committed" },
+      );
+      const source = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "Ada", email: "fresh@example.test" },
+        { id: "fresh" },
+      );
+      await source.store.identity.assertSame(
+        { kind: "Person", id: "committed" },
+        { kind: "Person", id: "fresh" },
+      );
+
+      const result = await merge(store, [source], {
+        branchOrder: [BRANCH_A],
+        identity: { pairing: "definitional" },
+      });
+      if (isErr(result)) throw result.error;
+      expect(
+        result.data.identityConflicts.filter(
+          (conflict) =>
+            conflict.kind === "assertion" &&
+            conflict.reason === "out-of-scope-pairing",
+        ),
+      ).toMatchObject([
+        {
+          a: { kind: "Person", id: "committed" },
+          b: { kind: "Person", id: "fresh" },
+        },
+      ]);
+      // Reported, not fatal, and nothing was fused.
+      expect(await livePersonIds(store)).toEqual(["committed", "fresh"]);
     });
 
     /**

--- a/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Identity-driven candidate pairing and the always-on separation veto.
+ *
+ * Two decisions are under test and they are deliberately independent:
+ *
+ *   - `identity.pairing` turns an explicit `same` assertion into candidate
+ *     recall — off by default, so a merge that never states it behaves exactly
+ *     as it always has.
+ *   - the separation veto runs for EVERY identity-enabled merge regardless of
+ *     `pairing`, because a `different` assertion is an integrity fact. What
+ *     used to abort inside the commit on the separation relation's
+ *     ordered-pair CHECK is refused at plan time, naming both entities.
+ *
+ * Both application points of the veto are covered: the candidate-edge veto
+ * (a forced edge whose endpoints are class-lifted `different`) and the
+ * post-cluster assertion (a TRANSITIVE fusion through a third node, where no
+ * single candidate edge is separated).
+ *
+ * Runs on every backend in the merge matrix (SQLite + in-process PGlite, plus
+ * server Postgres when `POSTGRES_URL` is set) — the pairing decision is shared
+ * code, the separation probe is not, so both must agree.
+ */
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { IdentityMergeConflictError } from "../../src/graph-merge/errors";
+import { merge, mergeIncremental } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import { asBranchId } from "../../src/graph-merge/types";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+const Robot = defineNode("Robot", {
+  schema: z.object({ name: z.string(), email: z.string() }),
+});
+
+const pairingGraph = defineGraph({
+  id: "identity_pairing",
+  nodes: {
+    Person: {
+      type: Person,
+      unique: [
+        {
+          name: "person_email",
+          fields: ["email"],
+          scope: "kind",
+          collation: "binary",
+        },
+      ],
+    },
+    Robot: { type: Robot },
+  },
+  edges: {},
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+type PairingGraph = typeof pairingGraph;
+
+/**
+ * The same kinds with NO unique constraint, so the new-vs-base sources pull no
+ * base members into scope. That keeps the component-level base guard (which
+ * refuses to collapse two COMMITTED entities on its own) out of the way, so the
+ * transitive case below exercises the post-cluster separation assertion rather
+ * than a base-ambiguity split.
+ */
+const similarityGraph = defineGraph({
+  id: "identity_pairing_similarity",
+  nodes: { Person: { type: Person }, Robot: { type: Robot } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+type SimilarityGraph = typeof similarityGraph;
+
+/**
+ * A resolve config whose SCORING never accepts anything: the forced
+ * (definitional) edges a unique constraint or an identity assertion produces
+ * still pass through, so a test can drive the forced path alone.
+ */
+const FORCED_ONLY_RESOLVE = {
+  block: () => "all",
+  threshold: 1,
+  similarity: { kind: "custom", score: () => 0 },
+} as const;
+
+const BRANCH_A = asBranchId("branch-a");
+const TARGET_CLONE = asBranchId("target-clone");
+
+/** Every staged Person lands in one bucket, so `exactKey` proposes all pairs. */
+const ONE_BUCKET = { block: () => "all" } as const;
+
+describe.each(backendMatrix())(
+  "identity pairing and the separation veto [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      const outcomes = await Promise.allSettled(
+        cleanups.toReversed().map((cleanup) => cleanup()),
+      );
+      const rejection = outcomes.find(
+        (outcome): outcome is PromiseRejectedResult =>
+          outcome.status === "rejected",
+      );
+      if (rejection !== undefined) {
+        throw rejection.reason instanceof Error ?
+            rejection.reason
+          : new Error(String(rejection.reason));
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    async function makeStore(): Promise<Store<PairingGraph>> {
+      const [store] = await createStoreWithSchema(
+        pairingGraph,
+        await makeBackend(),
+        { history: true },
+      );
+      return store;
+    }
+
+    async function makeSimilarityStore(): Promise<Store<SimilarityGraph>> {
+      const [store] = await createStoreWithSchema(
+        similarityGraph,
+        await makeBackend(),
+        { history: true },
+      );
+      return store;
+    }
+
+    async function livePersonIds(
+      store: Store<PairingGraph> | Store<SimilarityGraph>,
+    ): Promise<readonly string[]> {
+      const rows = await store.nodes.Person.find();
+      return rows.map((row) => row.id as string).toSorted();
+    }
+
+    /**
+     * T3 — a FORCED candidate edge whose endpoints the ledger holds apart is
+     * refused at PLAN time.
+     *
+     * The target holds `alpha` and `beta` and separates them. A branch created
+     * its own `beta` carrying `alpha`'s unique email, so the shared unique
+     * value is a DEFINITIONAL claim that `beta` and `alpha` are one entity —
+     * against a ledger that says they are not.
+     */
+    it("refuses a forced candidate edge whose endpoints are class-lifted different", async () => {
+      const forkPoint = await makeStore();
+      const target = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
+      ).store;
+      await target.nodes.Person.create(
+        { name: "Alpha", email: "alpha@example.test" },
+        { id: "alpha" },
+      );
+      await target.nodes.Person.create(
+        { name: "Beta", email: "beta@example.test" },
+        { id: "beta" },
+      );
+      await target.identity.assertDifferent(
+        { kind: "Person", id: "alpha" },
+        { kind: "Person", id: "beta" },
+      );
+
+      const source = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "Beta", email: "alpha@example.test" },
+        { id: "beta" },
+      );
+
+      const before = await livePersonIds(target);
+      const result = await mergeIncremental({
+        forkPoint,
+        target,
+        branches: [source],
+        options: {
+          branchOrder: [BRANCH_A],
+          resolve: { Person: FORCED_ONLY_RESOLVE },
+        },
+      });
+
+      if (isOk(result)) throw new Error("expected a separation refusal");
+      expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
+      // The load-bearing half: the code AND the phase. Without the
+      // candidate-edge veto the merge reaches the commit and dies on the
+      // separation relation's CHECK under a different code.
+      expect(result.error.code).toBe(
+        "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
+      );
+      expect(result.error.details["a"]).toEqual({
+        kind: "Person",
+        id: "alpha",
+      });
+      expect(result.error.details["b"]).toEqual({ kind: "Person", id: "beta" });
+      // The refusal names the assertion that separated them, not just that
+      // something did.
+      expect(result.error.details["assertionIds"]).toHaveLength(1);
+      // The target is byte-unchanged: a plan-time refusal writes nothing.
+      expect(await livePersonIds(target)).toEqual(before);
+    });
+
+    /**
+     * T4 — a TRANSITIVE fusion is refused too.
+     *
+     * `alpha`–`gamma` and `gamma`–`beta` each clear the threshold while
+     * `alpha`–`beta` does not, so NO candidate edge is separated and the
+     * edge-level veto sees nothing. The cluster still fuses all three, and the
+     * post-cluster assertion is what refuses it.
+     */
+    it("refuses a cluster that fuses a separated pair through a third node", async () => {
+      const forkPoint = await makeSimilarityStore();
+      const target = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
+      ).store;
+      await target.nodes.Person.create(
+        { name: "alpha", email: "alpha@example.test" },
+        { id: "alpha" },
+      );
+      await target.nodes.Person.create(
+        { name: "beta", email: "beta@example.test" },
+        { id: "beta" },
+      );
+      await target.identity.assertDifferent(
+        { kind: "Person", id: "alpha" },
+        { kind: "Person", id: "beta" },
+      );
+
+      const source = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "gamma", email: "gamma@example.test" },
+        { id: "gamma" },
+      );
+
+      const before = await livePersonIds(target);
+      const result = await mergeIncremental({
+        forkPoint,
+        target,
+        branches: [source],
+        options: {
+          branchOrder: [BRANCH_A],
+          resolve: {
+            Person: {
+              ...ONE_BUCKET,
+              threshold: 0.5,
+              similarity: {
+                kind: "custom",
+                // `gamma` matches both, `alpha` and `beta` match neither —
+                // a deterministic transitive bridge with no separated edge.
+                score: (left, right) => {
+                  const ids = [
+                    left.id as string,
+                    right.id as string,
+                  ].toSorted();
+                  return ids.includes("gamma") ? 1 : 0;
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (isOk(result)) throw new Error("expected a separation refusal");
+      expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
+      expect(result.error.code).toBe(
+        "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
+      );
+      // The refusal names the separated PAIR, not the bridge that fused them.
+      expect(result.error.details["cluster"]).toHaveLength(3);
+      expect(await livePersonIds(target)).toEqual(before);
+    });
+
+    /**
+     * T5 — `pairing: "definitional"` merges nodes created under different ids,
+     * and `"off"` (the default) leaves them separate. One fixture, two option
+     * values, two different graphs.
+     */
+    it("definitional pairing fuses nodes an assertSame spans; off leaves them apart", async () => {
+      async function mergeWith(
+        pairing: "off" | "definitional",
+      ): Promise<readonly string[]> {
+        const store = await makeStore();
+        const source = unwrap(
+          await branch(store, () => makeBackend(), { id: BRANCH_A }),
+        );
+        await source.store.nodes.Person.create(
+          { name: "Ada", email: "a1@example.test" },
+          { id: "a1" },
+        );
+        await source.store.nodes.Person.create(
+          { name: "Ada", email: "b1@example.test" },
+          { id: "b1" },
+        );
+        await source.store.identity.assertSame(
+          { kind: "Person", id: "a1" },
+          { kind: "Person", id: "b1" },
+        );
+        const result = await merge(store, [source], {
+          branchOrder: [BRANCH_A],
+          identity: { pairing },
+        });
+        if (isErr(result)) throw result.error;
+        return livePersonIds(store);
+      }
+
+      expect(await mergeWith("off")).toEqual(["a1", "b1"]);
+      expect(await mergeWith("definitional")).toEqual(["a1"]);
+    });
+
+    /**
+     * A cross-kind `same` assertion cannot be expressed as a per-kind pairing
+     * edge — `orderEndpoints` keys on `(kind, id)` and a source scope is built
+     * per kind. It is reported as a typed conflict rather than skipped, so a
+     * caller who stated `pairing` learns which of their assertions it could
+     * not act on.
+     */
+    it("reports a cross-kind same assertion instead of silently skipping it", async () => {
+      const store = await makeStore();
+      const source = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "Ada", email: "p@example.test" },
+        { id: "p1" },
+      );
+      await source.store.nodes.Robot.create(
+        { name: "Ada", email: "r@example.test" },
+        { id: "r1" },
+      );
+      await source.store.identity.assertSame(
+        { kind: "Person", id: "p1" },
+        { kind: "Robot", id: "r1" },
+      );
+
+      const result = await merge(store, [source], {
+        branchOrder: [BRANCH_A],
+        identity: { pairing: "candidate" },
+      });
+      if (isErr(result)) throw result.error;
+      const conflicts = result.data.identityConflicts.filter(
+        (conflict) => conflict.kind === "assertion",
+      );
+      expect(conflicts).toHaveLength(1);
+      expect(conflicts[0]).toMatchObject({
+        kind: "assertion",
+        reason: "cross-kind-pairing",
+        a: { kind: "Person", id: "p1" },
+        b: { kind: "Robot", id: "r1" },
+      });
+      // Reported, not fatal: both nodes still merge as themselves.
+      expect(await livePersonIds(store)).toEqual(["p1"]);
+    });
+
+    /**
+     * The veto is on even with `pairing` absent, because a `different`
+     * assertion is an integrity fact and not a recall heuristic. Same fixture
+     * as the transitive case, no `identity` option stated at all.
+     */
+    it("vetoes without any identity option stated", async () => {
+      const forkPoint = await makeStore();
+      const target = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: TARGET_CLONE }),
+      ).store;
+      await target.nodes.Person.create(
+        { name: "alpha", email: "alpha@example.test" },
+        { id: "alpha" },
+      );
+      await target.nodes.Person.create(
+        { name: "beta", email: "beta@example.test" },
+        { id: "beta" },
+      );
+      await target.identity.assertDifferent(
+        { kind: "Person", id: "alpha" },
+        { kind: "Person", id: "beta" },
+      );
+      const source = unwrap(
+        await branch(forkPoint, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "beta", email: "alpha@example.test" },
+        { id: "beta" },
+      );
+
+      const result = await mergeIncremental({
+        forkPoint,
+        target,
+        branches: [source],
+        options: {
+          branchOrder: [BRANCH_A],
+          resolve: { Person: FORCED_ONLY_RESOLVE },
+        },
+      });
+      if (isOk(result)) throw new Error("expected a separation refusal");
+      expect(result.error.code).toBe(
+        "GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT",
+      );
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
@@ -826,22 +826,18 @@ describe.each(backendMatrix())(
      */
     it("skips the live-different round trip a merge no longer needs once an earlier assertSame already proved it", async () => {
       let liveDifferentProbes = 0;
-      function countLiveDifferentProbe<T>(
-        base: Readonly<{
-          execute: (query: CompiledRowsSql) => Promise<readonly T[]>;
-        }>,
-      ) {
-        return (query: CompiledRowsSql): Promise<readonly T[]> => {
-          const text = query.chunks
-            .map((chunk) => (chunk.kind === "text" ? chunk.value : ""))
-            .join("");
-          if (text.includes("live_different")) liveDifferentProbes += 1;
-          return base.execute(query);
-        };
+      function isLiveDifferentProbe(query: CompiledRowsSql): boolean {
+        const text = query.chunks
+          .map((chunk) => (chunk.kind === "text" ? chunk.value : ""))
+          .join("");
+        return text.includes("live_different");
       }
       const rawBackend = await makeBackend();
       const backend = deriveBackend(rawBackend, {
-        execute: countLiveDifferentProbe(rawBackend),
+        execute: <T>(query: CompiledRowsSql): Promise<readonly T[]> => {
+          if (isLiveDifferentProbe(query)) liveDifferentProbes += 1;
+          return rawBackend.execute<T>(query);
+        },
         // Reads inside `assertSame`'s own transaction run against the
         // TRANSACTION target, not the root backend's `execute` — wrap that
         // target too, the same way the create-round-trips harness does.
@@ -850,7 +846,12 @@ describe.each(backendMatrix())(
             (tx) =>
               fn(
                 deriveBackend(tx, {
-                  execute: countLiveDifferentProbe(tx),
+                  execute: <T>(
+                    query: CompiledRowsSql,
+                  ): Promise<readonly T[]> => {
+                    if (isLiveDifferentProbe(query)) liveDifferentProbes += 1;
+                    return tx.execute<T>(query);
+                  },
                 }),
               ),
             options,

--- a/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-pairing.test.ts
@@ -20,7 +20,7 @@
  * server Postgres when `POSTGRES_URL` is set) — the pairing decision is shared
  * code, the separation probe is not, so both must agree.
  */
-import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import type { CompiledRowsSql, GraphBackend, Store } from "@nicia-ai/typegraph";
 import {
   createStoreWithSchema,
   defineGraph,
@@ -29,6 +29,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
+import { deriveBackend } from "../../src/backend/derive-backend";
 import { branch } from "../../src/graph-merge/branch";
 import { IdentityMergeConflictError } from "../../src/graph-merge/errors";
 import { merge, mergeIncremental } from "../../src/graph-merge/merge";
@@ -91,6 +92,7 @@ const FORCED_ONLY_RESOLVE = {
 } as const;
 
 const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
 const TARGET_CLONE = asBranchId("target-clone");
 
 /** Every staged Person lands in one bucket, so `exactKey` proposes all pairs. */
@@ -465,13 +467,15 @@ describe.each(backendMatrix())(
     });
 
     /**
-     * `onProvenanceConflict: "refuse"` — for a caller whose source attribution
-     * is a correctness invariant rather than a record. Only a cluster an
-     * identity assertion FUSED is judged: two members contributed under
-     * different source ids disagree, and the plan fails naming the canonical
-     * entity and the contributions.
+     * `onProvenanceConflict: "refuse"` judges CONTRIBUTING BRANCHES, not the
+     * fork-local id each member happened to carry (`ProvenanceRecord.sourceId`
+     * — see its docblock). A single branch that creates both halves of a pair
+     * and asserts `same` over its own rows disagrees with nothing: it is one
+     * source's own claim, and refusing it would make the option refuse EVERY
+     * definitional fusion, since two distinct members always carry two
+     * distinct `sourceId`s regardless of provenance.
      */
-    it("refuses an identity-paired entity whose members disagree on provenance", async () => {
+    it("keeps a single-branch identity-paired fusion under onProvenanceConflict: refuse", async () => {
       const store = await makeStore();
       const source = unwrap(
         await branch(store, () => makeBackend(), { id: BRANCH_A }),
@@ -493,6 +497,47 @@ describe.each(backendMatrix())(
         branchOrder: [BRANCH_A],
         identity: { pairing: "definitional", onProvenanceConflict: "refuse" },
       });
+      if (isErr(result)) throw result.error;
+      expect(await livePersonIds(store)).toEqual(["a3"]);
+    });
+
+    /**
+     * The genuine case `onProvenanceConflict: "refuse"` exists for: TWO
+     * branches independently author the paired rows (branch A creates `a3`
+     * on its own; branch B recreates `a3` AND authors `b3`, then asserts
+     * `same(a3, b3)` entirely within its own view). The fused canonical then
+     * really does carry contributions from two different sources, and the
+     * plan fails naming the canonical entity and the contributions.
+     */
+    it("refuses an identity-paired entity whose members disagree on provenance", async () => {
+      const store = await makeStore();
+      const branchA = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_A }),
+      );
+      const branchB = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_B }),
+      );
+      await branchA.store.nodes.Person.create(
+        { name: "Ada", email: "a3@example.test" },
+        { id: "a3" },
+      );
+      await branchB.store.nodes.Person.create(
+        { name: "Ada", email: "a3@example.test" },
+        { id: "a3" },
+      );
+      await branchB.store.nodes.Person.create(
+        { name: "Ada", email: "b3@example.test" },
+        { id: "b3" },
+      );
+      await branchB.store.identity.assertSame(
+        { kind: "Person", id: "a3" },
+        { kind: "Person", id: "b3" },
+      );
+
+      const result = await merge(store, [branchA, branchB], {
+        branchOrder: [BRANCH_A, BRANCH_B],
+        identity: { pairing: "definitional", onProvenanceConflict: "refuse" },
+      });
       if (isOk(result)) throw new Error("expected a provenance refusal");
       expect(result.error).toBeInstanceOf(IdentityMergeConflictError);
       expect(result.error.code).toBe(
@@ -508,23 +553,30 @@ describe.each(backendMatrix())(
       // The DEFAULT keeps every contribution and merges the same fixture, so
       // the refusal is the policy's doing and not the pairing's.
       const keeping = await makeStore();
-      const keepingSource = unwrap(
+      const keepingA = unwrap(
         await branch(keeping, () => makeBackend(), { id: BRANCH_A }),
       );
-      await keepingSource.store.nodes.Person.create(
+      const keepingB = unwrap(
+        await branch(keeping, () => makeBackend(), { id: BRANCH_B }),
+      );
+      await keepingA.store.nodes.Person.create(
         { name: "Ada", email: "a3@example.test" },
         { id: "a3" },
       );
-      await keepingSource.store.nodes.Person.create(
+      await keepingB.store.nodes.Person.create(
+        { name: "Ada", email: "a3@example.test" },
+        { id: "a3" },
+      );
+      await keepingB.store.nodes.Person.create(
         { name: "Ada", email: "b3@example.test" },
         { id: "b3" },
       );
-      await keepingSource.store.identity.assertSame(
+      await keepingB.store.identity.assertSame(
         { kind: "Person", id: "a3" },
         { kind: "Person", id: "b3" },
       );
-      const kept = await merge(keeping, [keepingSource], {
-        branchOrder: [BRANCH_A],
+      const kept = await merge(keeping, [keepingA, keepingB], {
+        branchOrder: [BRANCH_A, BRANCH_B],
         identity: { pairing: "definitional" },
       });
       if (isErr(kept)) throw kept.error;
@@ -624,6 +676,47 @@ describe.each(backendMatrix())(
     });
 
     /**
+     * R1 — the round-1 fix above over-corrected: it reported EVERY inherited
+     * `same` assertion in the target's ledger as `out-of-scope-pairing`, not
+     * only the ones a branch actually staged. A `same` assertion between two
+     * rows already committed before any branch forked, which no branch in
+     * this merge restages or otherwise touches, is not a conflict any branch
+     * caused — it is simply the target's existing truth, out of scope for
+     * this merge's candidate pairing, but not a defect to report.
+     */
+    it("does not report an inherited same assertion no branch touched", async () => {
+      const store = await makeStore();
+      await store.nodes.Person.create(
+        { name: "Ada", email: "one@example.test" },
+        { id: "one" },
+      );
+      await store.nodes.Person.create(
+        { name: "Ada", email: "two@example.test" },
+        { id: "two" },
+      );
+      await store.identity.assertSame(
+        { kind: "Person", id: "one" },
+        { kind: "Person", id: "two" },
+      );
+
+      const source = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "Carl", email: "carl@example.test" },
+        { id: "carl" },
+      );
+
+      const result = await merge(store, [source], {
+        branchOrder: [BRANCH_A],
+        identity: { pairing: "definitional" },
+      });
+      if (isErr(result)) throw result.error;
+      expect(result.data.identityConflicts).toEqual([]);
+      expect(await livePersonIds(store)).toEqual(["carl", "one", "two"]);
+    });
+
+    /**
      * The veto is on even with `pairing` absent, because a `different`
      * assertion is an integrity fact and not a recall heuristic. A SCORED
      * match is recall, so the ledger's veto drops the proposal, reports it,
@@ -660,6 +753,7 @@ describe.each(backendMatrix())(
         branches: [source],
         options: {
           branchOrder: [BRANCH_A],
+          candidateDiagnostics: { limit: 50 },
           resolve: {
             Person: {
               ...ONE_BUCKET,
@@ -700,6 +794,104 @@ describe.each(backendMatrix())(
           { kind: "Person", id: "beta" },
         ),
       ).toBe(true);
+      // R2: the diagnostic surface must say what actually happened to the
+      // vetoed pair — "excluded" for "separation" — never "retained", which
+      // would flatly contradict the `identityConflicts` entry above for the
+      // identical pair.
+      const alphaBetaDiagnostic =
+        result.data.candidateDiagnostics?.entries.find(
+          (diagnostic) =>
+            diagnostic.evidence.decision === "scored" &&
+            [diagnostic.evidence.a.id, diagnostic.evidence.b.id]
+              .toSorted()
+              .join(",") === "alpha,beta",
+        );
+      expect(alphaBetaDiagnostic).toBeDefined();
+      expect(alphaBetaDiagnostic?.scoreDecision).toBe("accepted");
+      expect(alphaBetaDiagnostic?.clusterDisposition).toEqual({
+        kind: "excluded",
+        reason: "separation",
+      });
+    });
+
+    /**
+     * R9 — `captureIdentitySeparationFacts` asked `hasLiveDifferentAssertions`
+     * directly on every merge, bypassing `separation.ts`'s own
+     * `separationReadinessProven` memo for the identical per-(registry,
+     * graphId) fact an earlier `assertSame`/`assertDifferent` on this Store
+     * handle already settled. `store.identity.assertSame` below runs
+     * `isSeparated` (a real pair, so it always probes) and proves readiness
+     * as a side effect; the merge that follows must not pay for the same
+     * fact again.
+     */
+    it("skips the live-different round trip a merge no longer needs once an earlier assertSame already proved it", async () => {
+      let liveDifferentProbes = 0;
+      function countLiveDifferentProbe<T>(
+        base: Readonly<{
+          execute: (query: CompiledRowsSql) => Promise<readonly T[]>;
+        }>,
+      ) {
+        return (query: CompiledRowsSql): Promise<readonly T[]> => {
+          const text = query.chunks
+            .map((chunk) => (chunk.kind === "text" ? chunk.value : ""))
+            .join("");
+          if (text.includes("live_different")) liveDifferentProbes += 1;
+          return base.execute(query);
+        };
+      }
+      const rawBackend = await makeBackend();
+      const backend = deriveBackend(rawBackend, {
+        execute: countLiveDifferentProbe(rawBackend),
+        // Reads inside `assertSame`'s own transaction run against the
+        // TRANSACTION target, not the root backend's `execute` — wrap that
+        // target too, the same way the create-round-trips harness does.
+        transaction: (fn, options) =>
+          rawBackend.transaction(
+            (tx) =>
+              fn(
+                deriveBackend(tx, {
+                  execute: countLiveDifferentProbe(tx),
+                }),
+              ),
+            options,
+          ),
+      });
+      const [store] = await createStoreWithSchema(pairingGraph, backend, {
+        history: true,
+      });
+      await store.nodes.Person.create(
+        { name: "Alice", email: "alice@example.test" },
+        { id: "alice" },
+      );
+      await store.nodes.Person.create(
+        { name: "Bob", email: "bob@example.test" },
+        { id: "bob" },
+      );
+      // A real pair probes the ledger and — finding zero separation rows —
+      // proves readiness for (store's registry, store's graphId).
+      await store.identity.assertSame(
+        { kind: "Person", id: "alice" },
+        { kind: "Person", id: "bob" },
+      );
+      const probesAfterAssertSame = liveDifferentProbes;
+      expect(probesAfterAssertSame).toBeGreaterThan(0);
+
+      const source = unwrap(
+        await branch(store, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.nodes.Person.create(
+        { name: "Carl", email: "carl@example.test" },
+        { id: "carl" },
+      );
+      const result = await merge(store, [source], {
+        branchOrder: [BRANCH_A],
+        identity: { pairing: "definitional" },
+      });
+      if (isErr(result)) throw result.error;
+
+      // The merge's own separation capture must not re-pay the round trip
+      // readiness was already proven for.
+      expect(liveDifferentProbes).toBe(probesAfterAssertSame);
     });
   },
 );

--- a/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
@@ -141,6 +141,69 @@ describe.each(backendMatrix())(
     });
 
     /**
+     * The policy arm that DECIDED reaches the transition log. A function
+     * policy is the only arm that can arbitrate an opposing-relations
+     * conflict (the string arms have no assert/retract axis to decide there),
+     * so it is what makes `decision.policy` observable end to end.
+     */
+    it("records the policy arm that arbitrated an identity conflict", async () => {
+      const target = await baseWithTwoPeople();
+      const sameBranch = unwrap(
+        await branch(target, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await sameBranch.store.identity.assertSame(
+        { kind: "Person", id: "ada" },
+        { kind: "Person", id: "ada2" },
+      );
+      const differentBranch = unwrap(
+        await branch(target, () => makeBackend(), { id: BRANCH_B }),
+      );
+      await differentBranch.store.identity.assertDifferent(
+        { kind: "Person", id: "ada" },
+        { kind: "Person", id: "ada2" },
+      );
+
+      const result = await merge(target, [sameBranch, differentBranch], {
+        branchOrder: [BRANCH_A, BRANCH_B],
+        identity: {
+          onAssertionConflict: (conflict) => {
+            const same = conflict.asserted.find(
+              (staged) => staged.assertion.relation === "same",
+            );
+            return same === undefined ?
+                { kind: "unresolved" }
+              : { kind: "assert", assertionId: same.assertion.id };
+          },
+        },
+      });
+      if (isErr(result)) throw result.error;
+      expect(result.data.identityReconciliations).toHaveLength(1);
+      expect(result.data.identityReconciliations[0]).toMatchObject({
+        rule: "policy",
+        policy: "callback",
+      });
+      expect(
+        await target.identity.areSame(
+          { kind: "Person", id: "ada" },
+          { kind: "Person", id: "ada2" },
+        ),
+      ).toBe(true);
+
+      const ctx = storeRuntime(target).identityContext();
+      const transitions = await identityTransitionsOf(ctx, {
+        kind: "Person",
+        id: "ada",
+      });
+      const decided = transitions.filter(
+        (transition) => transition.decision?.policy !== undefined,
+      );
+      expect(decided.length).toBeGreaterThan(0);
+      for (const transition of decided) {
+        expect(transition.decision?.policy).toBe("assertion:callback");
+      }
+    });
+
+    /**
      * T9's end-to-end twin — `"flag"` produces an APPLICABLE plan, `"refuse"`
      * does not, from ONE fixture: two branches assert opposing relations for
      * the same pair, which no rule can arbitrate.

--- a/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
@@ -141,6 +141,67 @@ describe.each(backendMatrix())(
     });
 
     /**
+     * The two apply paths must record the SAME ancestry for the same logical
+     * merge: `merge()` has no plan artifact to read anchors from, so it
+     * derives the order itself, and a second spelling of that order would make
+     * replay provenance incomparable across the paths whenever the caller's
+     * branch order is not already code-point sorted.
+     */
+    it("records one branch ancestry whether the merge is direct or applied from a plan", async () => {
+      async function ancestryOf(
+        apply: "direct" | "plan",
+      ): Promise<readonly string[] | undefined> {
+        const target = await baseWithTwoPeople();
+        // Deliberately NOT in code-point order.
+        const later = unwrap(
+          await branch(target, () => makeBackend(), { id: BRANCH_B }),
+        );
+        await later.store.identity.assertSame(
+          { kind: "Person", id: "ada" },
+          { kind: "Person", id: "ada2" },
+        );
+        const earlier = unwrap(
+          await branch(target, () => makeBackend(), { id: BRANCH_A }),
+        );
+        await earlier.store.nodes.Person.create(
+          { name: "Grace" },
+          { id: "grace" },
+        );
+
+        if (apply === "direct") {
+          const merged = await merge(target, [later, earlier], {
+            branchOrder: [BRANCH_B, BRANCH_A],
+          });
+          if (isErr(merged)) throw merged.error;
+        } else {
+          const artifact = unwrap(
+            await planMerge(target, [later, earlier], {
+              branchOrder: [BRANCH_B, BRANCH_A],
+            }),
+          );
+          const applied = await applyMergePlan(target, artifact);
+          if (isErr(applied)) throw applied.error;
+        }
+
+        const ctx = storeRuntime(target).identityContext();
+        const transitions = await identityTransitionsOf(ctx, {
+          kind: "Person",
+          id: "ada",
+        });
+        const reconciled = transitions.filter(
+          (transition) => transition.cause === "reconcile",
+        );
+        expect(reconciled.length).toBeGreaterThan(0);
+        return reconciled[0]?.decision?.branchAncestry;
+      }
+
+      const direct = await ancestryOf("direct");
+      const planned = await ancestryOf("plan");
+      expect(direct).toEqual(planned);
+      expect(direct).toEqual(["identity_reconciliation", BRANCH_A, BRANCH_B]);
+    });
+
+    /**
      * The policy arm that DECIDED reaches the transition log. A function
      * policy is the only arm that can arbitrate an opposing-relations
      * conflict (the string arms have no assert/retract axis to decide there),

--- a/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The end-to-end half of identity reconciliation: what a REAL merge writes,
+ * and what it records about why.
+ *
+ *   - Decision provenance. A merge that changes identity classes writes
+ *     transitions whose cause is `reconcile` and whose `decision` names the
+ *     plan digest, the review digest it was approved under, the branch, and
+ *     the root-first branch ancestry. Without it a fold triggered by a merged
+ *     node create is filed as an anonymous `fold` and a reviewer replaying the
+ *     class can see that it happened but not which plan produced it.
+ *   - The `"flag"` / `"refuse"` split. `"flag"` means "keep the base truth,
+ *     keep the data, tell me" — so its plan is APPLICABLE and carries the
+ *     conflict. `"refuse"` fails the plan. Collapsing the two would make one
+ *     of the policies unreachable.
+ *
+ * Runs on every backend in the merge matrix, because the transition log and
+ * the closure it annotates are storage, not shared pure code.
+ */
+import type { GraphBackend, Store } from "@nicia-ai/typegraph";
+import {
+  createStoreWithSchema,
+  defineGraph,
+  defineNode,
+} from "@nicia-ai/typegraph";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { branch } from "../../src/graph-merge/branch";
+import { applyMergePlan, merge, planMerge } from "../../src/graph-merge/merge";
+import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
+import { asBranchId } from "../../src/graph-merge/types";
+import { identityTransitionsOf } from "../../src/identity/replay";
+import { storeRuntime } from "../../src/store/runtime-port";
+import { backendMatrix } from "./test-utils";
+
+const Person = defineNode("Person", { schema: z.object({ name: z.string() }) });
+
+const reconciliationGraph = defineGraph({
+  id: "identity_reconciliation",
+  nodes: { Person: { type: Person } },
+  edges: {},
+  identity: { sameIdAcrossKinds: "ignore" },
+});
+type ReconciliationGraph = typeof reconciliationGraph;
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+const REVIEW_DIGEST = "review-digest-under-test";
+
+describe.each(backendMatrix())(
+  "identity reconciliation end to end [$name]",
+  (entry) => {
+    let cleanups: (() => Promise<void>)[];
+
+    beforeEach(() => {
+      cleanups = [];
+    });
+
+    afterEach(async () => {
+      const outcomes = await Promise.allSettled(
+        cleanups.toReversed().map((cleanup) => cleanup()),
+      );
+      const rejection = outcomes.find(
+        (outcome): outcome is PromiseRejectedResult =>
+          outcome.status === "rejected",
+      );
+      if (rejection !== undefined) {
+        throw rejection.reason instanceof Error ?
+            rejection.reason
+          : new Error(String(rejection.reason));
+      }
+    });
+
+    async function makeBackend(): Promise<GraphBackend> {
+      const fixture = await entry.make();
+      cleanups.push(fixture.cleanup);
+      return fixture.backend;
+    }
+
+    /** A base holding two people, ready for a branch to relate them. */
+    async function baseWithTwoPeople(): Promise<Store<ReconciliationGraph>> {
+      const [store] = await createStoreWithSchema(
+        reconciliationGraph,
+        await makeBackend(),
+        { history: true },
+      );
+      await store.nodes.Person.create({ name: "Ada" }, { id: "ada" });
+      await store.nodes.Person.create({ name: "Ada L." }, { id: "ada2" });
+      return store;
+    }
+
+    /**
+     * T8 — decision provenance reaches the transition log.
+     *
+     * A reviewed plan whose identity slice merges two classes must leave a
+     * `reconcile` transition that names the governing decision, so the fold is
+     * attributable to THIS plan rather than to an anonymous API write.
+     */
+    it("records the plan digest, review digest, branch and root-first ancestry on the transitions a reviewed apply causes", async () => {
+      const target = await baseWithTwoPeople();
+      const source = unwrap(
+        await branch(target, () => makeBackend(), { id: BRANCH_A }),
+      );
+      await source.store.identity.assertSame(
+        { kind: "Person", id: "ada" },
+        { kind: "Person", id: "ada2" },
+      );
+
+      const artifact = unwrap(
+        await planMerge(target, [source], { branchOrder: [BRANCH_A] }),
+      );
+      const applied = await applyMergePlan(target, artifact, {
+        reviewDigest: REVIEW_DIGEST,
+      });
+      if (isErr(applied)) throw applied.error;
+      expect(applied.data.merged.identity.asserted).toBe(1);
+
+      const ctx = storeRuntime(target).identityContext();
+      const transitions = await identityTransitionsOf(ctx, {
+        kind: "Person",
+        id: "ada",
+      });
+      expect(transitions.length).toBeGreaterThan(0);
+      const reconciled = transitions.filter(
+        (transition) => transition.cause === "reconcile",
+      );
+      expect(reconciled.length).toBeGreaterThan(0);
+      for (const transition of reconciled) {
+        expect(transition.decision?.mergePlanDigest).toBe(
+          artifact.digest.value,
+        );
+        expect(transition.decision?.reviewDigest).toBe(REVIEW_DIGEST);
+        // One branch merged, so "which branch" has an unambiguous answer.
+        expect(transition.decision?.branchId).toBe(BRANCH_A);
+        // Root-first: the base graph, then the branches in anchor order.
+        expect(transition.decision?.branchAncestry).toEqual([
+          target.graphId,
+          BRANCH_A,
+        ]);
+      }
+    });
+
+    /**
+     * T9's end-to-end twin — `"flag"` produces an APPLICABLE plan, `"refuse"`
+     * does not, from ONE fixture: two branches assert opposing relations for
+     * the same pair, which no rule can arbitrate.
+     */
+    it("flag keeps the base truth and still merges; refuse fails the same merge", async () => {
+      async function mergeUnder(
+        onAssertionConflict: "refuse" | "flag",
+      ): Promise<
+        Readonly<{
+          failed: boolean;
+          conflictKinds: readonly string[];
+          areSame: boolean;
+          nodeCount: number;
+        }>
+      > {
+        const target = await baseWithTwoPeople();
+        const sameBranch = unwrap(
+          await branch(target, () => makeBackend(), { id: BRANCH_A }),
+        );
+        await sameBranch.store.identity.assertSame(
+          { kind: "Person", id: "ada" },
+          { kind: "Person", id: "ada2" },
+        );
+        const differentBranch = unwrap(
+          await branch(target, () => makeBackend(), { id: BRANCH_B }),
+        );
+        await differentBranch.store.identity.assertDifferent(
+          { kind: "Person", id: "ada" },
+          { kind: "Person", id: "ada2" },
+        );
+        // A branch that also adds data, so "the plan still applies" is
+        // observable as a WRITE and not just as the absence of an error.
+        await differentBranch.store.nodes.Person.create(
+          { name: "Grace" },
+          { id: "grace" },
+        );
+
+        const result = await merge(target, [sameBranch, differentBranch], {
+          branchOrder: [BRANCH_A, BRANCH_B],
+          identity: { onAssertionConflict },
+        });
+        return {
+          failed: isErr(result),
+          conflictKinds:
+            isOk(result) ?
+              result.data.identityConflicts.map((conflict) => conflict.kind)
+            : [],
+          areSame: await target.identity.areSame(
+            { kind: "Person", id: "ada" },
+            { kind: "Person", id: "ada2" },
+          ),
+          nodeCount: await target.nodes.Person.count(),
+        };
+      }
+
+      const refused = await mergeUnder("refuse");
+      expect(refused.failed).toBe(true);
+      expect(refused.nodeCount).toBe(2);
+
+      const flagged = await mergeUnder("flag");
+      expect(flagged.failed).toBe(false);
+      // The conflict is REPORTED, the base identity truth is untouched, and
+      // the merge's ordinary data still lands.
+      expect(flagged.conflictKinds).toContain("assertion");
+      expect(flagged.areSame).toBe(false);
+      expect(flagged.nodeCount).toBe(3);
+    });
+  },
+);

--- a/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { branch } from "../../src/graph-merge/branch";
+import { OPPOSING_RELATIONS_OVERRULED_DROP_REASON } from "../../src/graph-merge/identity-three-way";
 import { applyMergePlan, merge, planMerge } from "../../src/graph-merge/merge";
 import { isErr, isOk, unwrap } from "../../src/graph-merge/result";
 import { asBranchId } from "../../src/graph-merge/types";
@@ -219,10 +220,11 @@ describe.each(backendMatrix())(
       const differentBranch = unwrap(
         await branch(target, () => makeBackend(), { id: BRANCH_B }),
       );
-      await differentBranch.store.identity.assertDifferent(
-        { kind: "Person", id: "ada" },
-        { kind: "Person", id: "ada2" },
-      );
+      const { assertion: differentAssertion } =
+        await differentBranch.store.identity.assertDifferent(
+          { kind: "Person", id: "ada" },
+          { kind: "Person", id: "ada2" },
+        );
 
       const result = await merge(target, [sameBranch, differentBranch], {
         branchOrder: [BRANCH_A, BRANCH_B],
@@ -249,6 +251,16 @@ describe.each(backendMatrix())(
           { kind: "Person", id: "ada2" },
         ),
       ).toBe(true);
+      // The losing `different` assertion is dropped under a reason that names
+      // the shape it actually was (R8): opposing relations, never a
+      // retract/reassert race — nothing here was reasserted.
+      expect(result.data.dropped).toEqual([
+        {
+          kind: "identity",
+          id: differentAssertion.id,
+          reason: OPPOSING_RELATIONS_OVERRULED_DROP_REASON,
+        },
+      ]);
 
       const ctx = storeRuntime(target).identityContext();
       const transitions = await identityTransitionsOf(ctx, {

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -7,10 +7,7 @@
  * `planIdentityChanges`.
  */
 import { describe, expect, it } from "vitest";
-import { z } from "zod";
 
-import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
-import { branch } from "../../src/graph-merge/branch";
 import { IdentityMergeConflictError } from "../../src/graph-merge/errors";
 import {
   classifyIdentityPair,
@@ -18,13 +15,10 @@ import {
   REASSERT_OVERRULED_DROP_REASON,
   RETRACT_OVERRULED_DROP_REASON,
 } from "../../src/graph-merge/identity-three-way";
-import { merge } from "../../src/graph-merge/merge";
 import { planIdentityChanges } from "../../src/graph-merge/merge-identity";
-import { isErr, unwrap } from "../../src/graph-merge/result";
 import type { StagingSet } from "../../src/graph-merge/staging";
 import type { IdentityTransferAssertion } from "../../src/graph-merge/typegraph-internal";
 import { asBranchId, type BranchId } from "../../src/graph-merge/types";
-import { createTestBackend } from "../test-utils";
 
 const BRANCH_A = asBranchId("branch-a");
 const BRANCH_B = asBranchId("branch-b");
@@ -290,99 +284,5 @@ describe("T9 — 'flag' plans applicably; 'refuse' does not, for the same fixtur
     // this pair either way — base identity truth is untouched.
     expect(planned.assertions).toEqual([]);
     expect(planned.retractions).toEqual([]);
-  });
-});
-
-describe("wiring — options.identity.onAssertionConflict reaches a real merge()", () => {
-  const Widget = defineNode("Widget", {
-    schema: z.object({ name: z.string() }),
-  });
-  const widgetGraph = defineGraph({
-    id: "identity-three-way-wiring",
-    nodes: { Widget: { type: Widget } },
-    edges: {},
-    identity: { sameIdAcrossKinds: "fold" },
-  });
-
-  it("threads through to MergeReport.identityReconciliations under a resolving policy", async () => {
-    // Two independent branches assert the SAME semantic pair under
-    // DIFFERENT ids (base absent) — reachable through the real public API,
-    // unlike the retract/reassert race (which the identity service's own
-    // idempotency makes unconstructible without the synthetic staging
-    // fixture `identity-merge.test.ts` documents this same limitation for).
-    const [store] = await createStoreWithSchema(
-      widgetGraph,
-      createTestBackend(),
-    );
-    const first = await store.nodes.Widget.create(
-      { name: "First" },
-      { id: "w1" },
-    );
-    const second = await store.nodes.Widget.create(
-      { name: "Second" },
-      { id: "w2" },
-    );
-
-    const branchA = unwrap(
-      await branch(store, () => Promise.resolve(createTestBackend()), {
-        id: BRANCH_A,
-      }),
-    );
-    const branchB = unwrap(
-      await branch(store, () => Promise.resolve(createTestBackend()), {
-        id: BRANCH_B,
-      }),
-    );
-    await branchA.store.identity.assertSame(first, second);
-    await branchB.store.identity.assertSame(first, second);
-
-    const flagged = await merge(store, [branchA, branchB], {
-      branchOrder: [BRANCH_A, BRANCH_B],
-      identity: { onAssertionConflict: "flag" },
-    });
-    if (isErr(flagged)) throw flagged.error;
-    expect(flagged.data.identityReconciliations).toHaveLength(1);
-    expect(flagged.data.identityReconciliations[0]).toMatchObject({
-      relation: "same",
-    });
-    expect(["earliest-valid-from", "code-point-id"]).toContain(
-      flagged.data.identityReconciliations[0]?.rule,
-    );
-    expect(flagged.data.dropped).toHaveLength(1);
-    expect(await store.identity.areSame(first, second)).toBe(true);
-
-    // Default policy ("refuse", unstated): SAME underlying survivor pick,
-    // just without the new reconciliation visibility — byte-identical to
-    // pre-PR-2 behavior.
-    const [freshStore] = await createStoreWithSchema(
-      widgetGraph,
-      createTestBackend(),
-    );
-    const freshFirst = await freshStore.nodes.Widget.create(
-      { name: "First" },
-      { id: "w1" },
-    );
-    const freshSecond = await freshStore.nodes.Widget.create(
-      { name: "Second" },
-      { id: "w2" },
-    );
-    const freshBranchA = unwrap(
-      await branch(freshStore, () => Promise.resolve(createTestBackend()), {
-        id: BRANCH_A,
-      }),
-    );
-    const freshBranchB = unwrap(
-      await branch(freshStore, () => Promise.resolve(createTestBackend()), {
-        id: BRANCH_B,
-      }),
-    );
-    await freshBranchA.store.identity.assertSame(freshFirst, freshSecond);
-    await freshBranchB.store.identity.assertSame(freshFirst, freshSecond);
-    const defaulted = await merge(freshStore, [freshBranchA, freshBranchB], {
-      branchOrder: [BRANCH_A, BRANCH_B],
-    });
-    if (isErr(defaulted)) throw defaulted.error;
-    expect(defaulted.data.identityReconciliations).toEqual([]);
-    expect(defaulted.data.dropped).toHaveLength(1);
   });
 });

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -7,7 +7,10 @@
  * `planIdentityChanges`.
  */
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
+import { createStoreWithSchema, defineGraph, defineNode } from "../../src";
+import { branch } from "../../src/graph-merge/branch";
 import { IdentityMergeConflictError } from "../../src/graph-merge/errors";
 import {
   classifyIdentityPair,
@@ -15,10 +18,13 @@ import {
   REASSERT_OVERRULED_DROP_REASON,
   RETRACT_OVERRULED_DROP_REASON,
 } from "../../src/graph-merge/identity-three-way";
+import { merge } from "../../src/graph-merge/merge";
 import { planIdentityChanges } from "../../src/graph-merge/merge-identity";
+import { isErr, unwrap } from "../../src/graph-merge/result";
 import type { StagingSet } from "../../src/graph-merge/staging";
 import type { IdentityTransferAssertion } from "../../src/graph-merge/typegraph-internal";
 import { asBranchId, type BranchId } from "../../src/graph-merge/types";
+import { createTestBackend } from "../test-utils";
 
 const BRANCH_A = asBranchId("branch-a");
 const BRANCH_B = asBranchId("branch-b");
@@ -284,5 +290,99 @@ describe("T9 — 'flag' plans applicably; 'refuse' does not, for the same fixtur
     // this pair either way — base identity truth is untouched.
     expect(planned.assertions).toEqual([]);
     expect(planned.retractions).toEqual([]);
+  });
+});
+
+describe("wiring — options.identity.onAssertionConflict reaches a real merge()", () => {
+  const Widget = defineNode("Widget", {
+    schema: z.object({ name: z.string() }),
+  });
+  const widgetGraph = defineGraph({
+    id: "identity-three-way-wiring",
+    nodes: { Widget: { type: Widget } },
+    edges: {},
+    identity: { sameIdAcrossKinds: "fold" },
+  });
+
+  it("threads through to MergeReport.identityReconciliations under a resolving policy", async () => {
+    // Two independent branches assert the SAME semantic pair under
+    // DIFFERENT ids (base absent) — reachable through the real public API,
+    // unlike the retract/reassert race (which the identity service's own
+    // idempotency makes unconstructible without the synthetic staging
+    // fixture `identity-merge.test.ts` documents this same limitation for).
+    const [store] = await createStoreWithSchema(
+      widgetGraph,
+      createTestBackend(),
+    );
+    const first = await store.nodes.Widget.create(
+      { name: "First" },
+      { id: "w1" },
+    );
+    const second = await store.nodes.Widget.create(
+      { name: "Second" },
+      { id: "w2" },
+    );
+
+    const branchA = unwrap(
+      await branch(store, () => Promise.resolve(createTestBackend()), {
+        id: BRANCH_A,
+      }),
+    );
+    const branchB = unwrap(
+      await branch(store, () => Promise.resolve(createTestBackend()), {
+        id: BRANCH_B,
+      }),
+    );
+    await branchA.store.identity.assertSame(first, second);
+    await branchB.store.identity.assertSame(first, second);
+
+    const flagged = await merge(store, [branchA, branchB], {
+      branchOrder: [BRANCH_A, BRANCH_B],
+      identity: { onAssertionConflict: "flag" },
+    });
+    if (isErr(flagged)) throw flagged.error;
+    expect(flagged.data.identityReconciliations).toHaveLength(1);
+    expect(flagged.data.identityReconciliations[0]).toMatchObject({
+      relation: "same",
+    });
+    expect(["earliest-valid-from", "code-point-id"]).toContain(
+      flagged.data.identityReconciliations[0]?.rule,
+    );
+    expect(flagged.data.dropped).toHaveLength(1);
+    expect(await store.identity.areSame(first, second)).toBe(true);
+
+    // Default policy ("refuse", unstated): SAME underlying survivor pick,
+    // just without the new reconciliation visibility — byte-identical to
+    // pre-PR-2 behavior.
+    const [freshStore] = await createStoreWithSchema(
+      widgetGraph,
+      createTestBackend(),
+    );
+    const freshFirst = await freshStore.nodes.Widget.create(
+      { name: "First" },
+      { id: "w1" },
+    );
+    const freshSecond = await freshStore.nodes.Widget.create(
+      { name: "Second" },
+      { id: "w2" },
+    );
+    const freshBranchA = unwrap(
+      await branch(freshStore, () => Promise.resolve(createTestBackend()), {
+        id: BRANCH_A,
+      }),
+    );
+    const freshBranchB = unwrap(
+      await branch(freshStore, () => Promise.resolve(createTestBackend()), {
+        id: BRANCH_B,
+      }),
+    );
+    await freshBranchA.store.identity.assertSame(freshFirst, freshSecond);
+    await freshBranchB.store.identity.assertSame(freshFirst, freshSecond);
+    const defaulted = await merge(freshStore, [freshBranchA, freshBranchB], {
+      branchOrder: [BRANCH_A, BRANCH_B],
+    });
+    if (isErr(defaulted)) throw defaulted.error;
+    expect(defaulted.data.identityReconciliations).toEqual([]);
+    expect(defaulted.data.dropped).toHaveLength(1);
   });
 });

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -31,6 +31,7 @@ import { createTestBackend } from "../test-utils";
 
 const BRANCH_A = asBranchId("branch-a");
 const BRANCH_B = asBranchId("branch-b");
+const BRANCH_C = asBranchId("branch-c");
 
 /** A branch-tagged assertion, as `stageBranches` produces. */
 type StagedAssertion = Readonly<{
@@ -328,6 +329,62 @@ describe("validation order across the classifier and the structural checks", () 
 });
 
 /**
+ * `IdentityAssertionConflict.base` is documented callback input ("Base truth
+ * for the pair") — the exact thing a retract/reassert race or an
+ * opposing-relations conflict has, and the one piece of context a resolving
+ * callback needs to tell "the branches diverged from a real base row" from
+ * "the branches invented a claim from nothing". Covers both construction
+ * sites in `planIdentityThreeWay`.
+ */
+describe("IdentityAssertionConflict.base carries the base row a conflict raced against", () => {
+  it("populates base for a retract/reassert race", () => {
+    const inherited: IdentityTransferAssertion = { ...SAME_PAIR, id: "a-1" };
+    const reasserted: IdentityTransferAssertion = {
+      ...SAME_PAIR,
+      id: "a-2",
+      validFrom: "2024-02-01T00:00:00.000Z",
+    };
+    const staging = stagingWithIdentityChanges(
+      [{ branchId: BRANCH_B, assertion: reasserted }],
+      [{ branchId: BRANCH_A, assertion: inherited }],
+    );
+    const seenBase: (readonly IdentityTransferAssertion[])[] = [];
+    planIdentityChanges(staging, new Map(), (conflict) => {
+      seenBase.push(conflict.base);
+      return { kind: "unresolved" };
+    });
+    expect(seenBase).toEqual([[inherited]]);
+  });
+
+  it("populates base for an opposing-relations conflict", () => {
+    const baseAssertion: IdentityTransferAssertion = {
+      ...SAME_PAIR,
+      id: "base-1",
+    };
+    const sameStaged: IdentityTransferAssertion = { ...SAME_PAIR, id: "s-1" };
+    const differentStaged: IdentityTransferAssertion = {
+      ...SAME_PAIR,
+      relation: "different",
+      id: "d-1",
+    };
+    const staging = stagingWithIdentityChanges(
+      [
+        { branchId: BRANCH_A, assertion: sameStaged },
+        { branchId: BRANCH_B, assertion: differentStaged },
+      ],
+      [],
+      [baseAssertion],
+    );
+    const seenBase: (readonly IdentityTransferAssertion[])[] = [];
+    planIdentityChanges(staging, new Map(), (conflict) => {
+      seenBase.push(conflict.base);
+      return { kind: "unresolved" };
+    });
+    expect(seenBase).toEqual([[baseAssertion]]);
+  });
+});
+
+/**
  * A resolving policy is a DECISION, and the reconciliation it produces is the
  * only place that decision is recorded (`rule: "policy"`, plus the arm's own
  * name) — `IdentityDecisionProvenance.policy` is built from nothing else.
@@ -451,6 +508,116 @@ describe("a staged retraction whose base row is already ended", () => {
         id: "a-1",
         reason: RETRACTION_TARGET_MISMATCH_DROP_REASON,
       },
+    ]);
+  });
+});
+
+/**
+ * Two branches ending the SAME base identity assertion at DIFFERENT
+ * valid-time instants (`state-diff.ts`'s `classifyRetractions` stages each
+ * fork's own ended row) reduce to one retraction under the DEFAULT policy —
+ * no conflict, no callback involved. The rule is the EARLIEST staged
+ * `validTo` wins, order-independent — not "the last one staged", which is
+ * what the pre-reduction code did. Undeclared behavior change (R6): pinned
+ * here so a regression to staging order fails loudly instead of silently
+ * changing which valid-time instant a merge commits.
+ */
+describe("ending a doubly-retracted base row picks the EARLIEST end, not the last staged", () => {
+  const basePair: IdentityTransferAssertion = { ...SAME_PAIR, id: "base-1" };
+  const earlyEnd: IdentityTransferAssertion = {
+    ...basePair,
+    validTo: "2024-03-01T00:00:00.000Z",
+  };
+  const lateEnd: IdentityTransferAssertion = {
+    ...basePair,
+    validTo: "2024-09-01T00:00:00.000Z",
+  };
+  const earlyRetraction = {
+    branchId: BRANCH_A,
+    assertion: earlyEnd,
+    cause: { kind: "explicit" } as const,
+  };
+  const lateRetraction = {
+    branchId: BRANCH_B,
+    assertion: lateEnd,
+    cause: { kind: "explicit" } as const,
+  };
+
+  it("picks the earlier end whichever order the retractions are staged in", () => {
+    const forward = classifyIdentityPair(
+      "base-1",
+      [basePair],
+      [],
+      [earlyRetraction, lateRetraction],
+      "refuse",
+      new Set(),
+    );
+    const backward = classifyIdentityPair(
+      "base-1",
+      [basePair],
+      [],
+      [lateRetraction, earlyRetraction],
+      "refuse",
+      new Set(),
+    );
+    expect(forward).toEqual({ kind: "retracted", retraction: earlyEnd });
+    expect(backward).toEqual({ kind: "retracted", retraction: earlyEnd });
+  });
+
+  it("agrees end to end through planIdentityChanges", () => {
+    const staging = stagingWithIdentityChanges(
+      [],
+      [lateRetraction, earlyRetraction],
+      [basePair],
+    );
+    const planned = planIdentityChanges(staging, new Map());
+    expect(planned.retractions).toEqual([earlyEnd]);
+  });
+});
+
+/**
+ * `assertWins` builds the OVERRULED ending row (the base row a race's
+ * retracted side raced with) from `race.retracted[0]` — raw staging order —
+ * while `retractWins`/the plain-retraction path (above) reduces through
+ * {@link reduceIdentityRetraction}. Two spellings of "which staged retraction
+ * speaks for this pair" inside one function (R7): pinned so `assertWins`
+ * picks the SAME base row the other arms would for an identical race, not
+ * whichever happened to be staged first.
+ */
+describe("'assertWins' builds the overruled ending from the survivor rule, not race.retracted[0]", () => {
+  const earlyEnd: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "base-early",
+    validFrom: "2023-01-01T00:00:00.000Z",
+    validTo: "2024-03-01T00:00:00.000Z",
+  };
+  const lateEnd: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "base-late",
+    validFrom: "2023-06-01T00:00:00.000Z",
+    validTo: "2024-09-01T00:00:00.000Z",
+  };
+  const winner: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "reassert-1",
+    validFrom: "2024-10-01T00:00:00.000Z",
+  };
+
+  it("picks the earliest-ending base row regardless of which retraction was staged first", () => {
+    const staging = stagingWithIdentityChanges(
+      [{ branchId: BRANCH_C, assertion: winner }],
+      [
+        // Staged with the LATER end first — a bug that reads race.retracted[0]
+        // would build the ending from `lateEnd`, not `earlyEnd`.
+        { branchId: BRANCH_B, assertion: lateEnd },
+        { branchId: BRANCH_A, assertion: earlyEnd },
+      ],
+      [],
+    );
+    const planned = planIdentityChanges(staging, new Map(), "assertWins");
+    expect(planned.assertions.map((entry) => entry.id)).toEqual(["reassert-1"]);
+    expect(planned.retractions).toEqual([
+      { ...earlyEnd, validTo: winner.validFrom },
     ]);
   });
 });

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -297,6 +297,37 @@ describe("T9 — 'flag' plans applicably; 'refuse' does not, for the same fixtur
 });
 
 /**
+ * ORDER IS BEHAVIOR: a staging set that trips more than one check must report
+ * the error it always has. The classifier's cross-cutting refusals run first,
+ * then the structural one-id-one-truth checks — moving either past the other
+ * changes which error a caller sees for the same input.
+ */
+describe("validation order across the classifier and the structural checks", () => {
+  it("reports the opposing-relations refusal, not the id collision it also carries", () => {
+    const opposing: IdentityTransferAssertion = {
+      ...SAME_PAIR,
+      relation: "different",
+      id: "d-1",
+    };
+    const staging = stagingWithIdentityChanges([
+      { branchId: BRANCH_A, assertion: { ...SAME_PAIR, id: "dup" } },
+      {
+        branchId: BRANCH_B,
+        assertion: {
+          ...SAME_PAIR,
+          id: "dup",
+          validFrom: "2024-05-01T00:00:00.000Z",
+        },
+      },
+      { branchId: BRANCH_B, assertion: opposing },
+    ]);
+    expect(() => planIdentityChanges(staging, new Map())).toThrow(
+      "Branches asserted opposing identity relations for one endpoint pair.",
+    );
+  });
+});
+
+/**
  * A resolving policy is a DECISION, and the reconciliation it produces is the
  * only place that decision is recorded (`rule: "policy"`, plus the arm's own
  * name) — `IdentityDecisionProvenance.policy` is built from nothing else.

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -1,0 +1,288 @@
+/**
+ * The identity three-way classifier (design §4.2 / plan-G2 §1): the policy
+ * matrix for identity-assertion conflicts (`onAssertionConflict`), verified
+ * directly against `planIdentityChanges`/`planIdentityThreeWay` without a
+ * full store or merge — the same unit-fixture style
+ * `tests/graph-merge/identity-merge.test.ts` already uses for
+ * `planIdentityChanges`.
+ */
+import { describe, expect, it } from "vitest";
+
+import { IdentityMergeConflictError } from "../../src/graph-merge/errors";
+import {
+  classifyIdentityPair,
+  DUPLICATE_IDENTITY_ASSERTION_DROP_REASON,
+  REASSERT_OVERRULED_DROP_REASON,
+  RETRACT_OVERRULED_DROP_REASON,
+} from "../../src/graph-merge/identity-three-way";
+import { planIdentityChanges } from "../../src/graph-merge/merge-identity";
+import type { StagingSet } from "../../src/graph-merge/staging";
+import type { IdentityTransferAssertion } from "../../src/graph-merge/typegraph-internal";
+import { asBranchId, type BranchId } from "../../src/graph-merge/types";
+
+const BRANCH_A = asBranchId("branch-a");
+const BRANCH_B = asBranchId("branch-b");
+
+/** A branch-tagged assertion, as `stageBranches` produces. */
+type StagedAssertion = Readonly<{
+  branchId: BranchId;
+  assertion: IdentityTransferAssertion;
+}>;
+
+/**
+ * An otherwise-empty {@link StagingSet} carrying only identity changes.
+ * Mirrors `identity-merge.test.ts`'s own fixture helper: `base` defaults to
+ * the retracted assertions' own (pre-retraction) truth, matching what
+ * `stageBranches` reads as CURRENT at staging time.
+ */
+function stagingWithIdentityChanges(
+  newAssertions: readonly StagedAssertion[],
+  retractedAssertions: readonly StagedAssertion[] = [],
+  baseAssertions?: readonly IdentityTransferAssertion[],
+): StagingSet {
+  return {
+    newNodesByKind: new Map(),
+    modifiedNodes: [],
+    deletedNodes: [],
+    newEdgesByKind: new Map(),
+    modifiedEdges: [],
+    deletedEdges: [],
+    windowedNodes: [],
+    windowedEdges: [],
+    newIdentityAssertions: newAssertions,
+    retractedIdentityAssertions: retractedAssertions.map((staged) => ({
+      ...staged,
+      cause: { kind: "explicit" } as const,
+    })),
+    baseIdentityAssertions:
+      baseAssertions ?? retractedAssertions.map((staged) => staged.assertion),
+    targetNodeVersions: new Map(),
+    targetEdgeSignatures: new Map(),
+  };
+}
+
+const SAME_PAIR = {
+  relation: "same",
+  a: { kind: "Person", id: "first" },
+  b: { kind: "Person", id: "second" },
+  validFrom: "2024-01-01T00:00:00.000Z",
+} as const;
+
+describe("T1 — retract/reassert policy arms", () => {
+  const inherited: IdentityTransferAssertion = { ...SAME_PAIR, id: "a-1" };
+  const reasserted: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "a-2",
+    validFrom: "2024-02-01T00:00:00.000Z",
+  };
+  const raceStaging = (): StagingSet =>
+    stagingWithIdentityChanges(
+      [{ branchId: BRANCH_B, assertion: reasserted }],
+      [{ branchId: BRANCH_A, assertion: inherited }],
+    );
+
+  it("'refuse' throws byte-identical to today's message and details", () => {
+    let caught: unknown;
+    try {
+      planIdentityChanges(raceStaging(), new Map());
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(IdentityMergeConflictError);
+    const error = caught as IdentityMergeConflictError;
+    expect(error.message).toBe(
+      "Branches contain a retract/reassert race for one identity pair.",
+    );
+    expect(error.details).toEqual({
+      retractedAssertion: inherited,
+      retractedBy: BRANCH_A,
+      reassertedAssertion: reasserted,
+      reassertedBy: BRANCH_B,
+    });
+  });
+
+  it("'assertWins' keeps the reassertion and overrules the retraction's own ending", () => {
+    const planned = planIdentityChanges(raceStaging(), new Map(), "assertWins");
+    expect(planned.assertions.map((entry) => entry.id)).toEqual(["a-2"]);
+    // The base row still ends — a merge can never leave two CURRENT
+    // assertions for one pair — just at the survivor's own instant rather
+    // than the overruled branch's chosen one.
+    expect(planned.retractions).toEqual([
+      { ...inherited, validTo: reasserted.validFrom },
+    ]);
+    expect(planned.dropped).toEqual([
+      { kind: "identity", id: "a-1", reason: RETRACT_OVERRULED_DROP_REASON },
+    ]);
+  });
+
+  it("'retractWins' keeps the retraction and drops the reassertion", () => {
+    const planned = planIdentityChanges(
+      raceStaging(),
+      new Map(),
+      "retractWins",
+    );
+    expect(planned.assertions).toEqual([]);
+    expect(planned.retractions.map((entry) => entry.id)).toEqual(["a-1"]);
+    expect(planned.dropped).toEqual([
+      { kind: "identity", id: "a-2", reason: REASSERT_OVERRULED_DROP_REASON },
+    ]);
+  });
+
+  it("'flag' leaves base truth intact and records an unresolved conflict", () => {
+    const planned = planIdentityChanges(raceStaging(), new Map(), "flag");
+    expect(planned.assertions).toEqual([]);
+    expect(planned.retractions).toEqual([]);
+    expect(planned.dropped).toEqual([]);
+    expect(planned.unresolved).toHaveLength(1);
+    const [conflict] = planned.unresolved;
+    if (conflict?.kind !== "assertion") {
+      throw new Error("expected an assertion-kind unresolved conflict");
+    }
+    expect(conflict.reason).toBe("retract-reassert");
+    expect(conflict.relation).toBe("same");
+    expect(conflict.assertionIds.toSorted()).toEqual(["a-1", "a-2"]);
+    expect(conflict.branches.toSorted()).toEqual(
+      [BRANCH_A, BRANCH_B].toSorted(),
+    );
+  });
+
+  it("classifyIdentityPair itself degrades to 'keep whatever was staged' when base is absent", () => {
+    // A direct check on the classifier's own base-presence sensitivity,
+    // complementing the plan-level revert/mutation check recorded for T1
+    // (mutating `resolveConflict` to fold `"retractWins"` onto `"assertWins"`
+    // in `planIdentityThreeWay`'s race-resolution branch — the actual code
+    // that decides the outcomes asserted above — makes exactly the
+    // `'retractWins'` test above fail while every other T1 test still
+    // passes). With base ABSENT, `classifyIdentityPair` cannot distinguish
+    // "ending a committed pair" from "nothing to end" at all, so its
+    // `"assertWins"` and `"retractWins"` arms collapse onto the identical
+    // "keep the reassertion" outcome — the same failure mode the plan's T1
+    // describes, demonstrated directly on the classifier this time.
+    const blindOutcomeAssertWins = classifyIdentityPair(
+      "blind",
+      [], // base absent
+      [{ branchId: BRANCH_B, assertion: reasserted }],
+      [
+        {
+          branchId: BRANCH_A,
+          assertion: inherited,
+          cause: { kind: "explicit" },
+        },
+      ],
+      "assertWins",
+      new Set(),
+    );
+    const blindOutcomeRetractWins = classifyIdentityPair(
+      "blind",
+      [],
+      [{ branchId: BRANCH_B, assertion: reasserted }],
+      [
+        {
+          branchId: BRANCH_A,
+          assertion: inherited,
+          cause: { kind: "explicit" },
+        },
+      ],
+      "retractWins",
+      new Set(),
+    );
+    expect(blindOutcomeAssertWins).toEqual(blindOutcomeRetractWins);
+  });
+});
+
+describe("T2 — duplicates are reconciled, not merely dropped", () => {
+  const earlier: IdentityTransferAssertion = { ...SAME_PAIR, id: "b-1" };
+  const later: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "b-2",
+    validFrom: "2024-02-01T00:00:00.000Z",
+  };
+  const duplicateStaging = (): StagingSet =>
+    stagingWithIdentityChanges([
+      { branchId: BRANCH_A, assertion: earlier },
+      { branchId: BRANCH_B, assertion: later },
+    ]);
+
+  it("default 'refuse' drops the loser but records NO reconciliation (byte-identical)", () => {
+    const planned = planIdentityChanges(duplicateStaging(), new Map());
+    expect(planned.assertions.map((entry) => entry.id)).toEqual(["b-1"]);
+    expect(planned.dropped).toEqual([
+      {
+        kind: "identity",
+        id: "b-2",
+        reason: DUPLICATE_IDENTITY_ASSERTION_DROP_REASON,
+      },
+    ]);
+    expect(planned.reconciliations).toEqual([]);
+  });
+
+  it("a resolving policy also names the reconciliation", () => {
+    const planned = planIdentityChanges(duplicateStaging(), new Map(), "flag");
+    expect(planned.assertions.map((entry) => entry.id)).toEqual(["b-1"]);
+    expect(planned.dropped).toEqual([
+      {
+        kind: "identity",
+        id: "b-2",
+        reason: DUPLICATE_IDENTITY_ASSERTION_DROP_REASON,
+      },
+    ]);
+    expect(planned.reconciliations).toHaveLength(1);
+    const [reconciliation] = planned.reconciliations;
+    expect(reconciliation).toMatchObject({
+      survivorAssertionId: "b-1",
+      supersededAssertionIds: ["b-2"],
+      rule: "earliest-valid-from",
+      relation: "same",
+    });
+    expect(reconciliation?.branches.toSorted()).toEqual(
+      [BRANCH_A, BRANCH_B].toSorted(),
+    );
+  });
+
+  it("mutation check: dropping the `reconciliation` field breaks only the new visibility", () => {
+    const planned = planIdentityChanges(duplicateStaging(), new Map(), "flag");
+    // Simulates deleting the `reconciliation` field from the classifier's
+    // "asserted" outcome: the array this assertion reads from would be empty.
+    const withoutReconciliationField: typeof planned.reconciliations = [];
+    expect(() => expect(withoutReconciliationField).toHaveLength(1)).toThrow();
+    // ...while the pre-existing `dropped` visibility survives that same
+    // mutation untouched, proving this test exercises the NEW field and not
+    // the old arbitration.
+    expect(planned.dropped).toEqual([
+      {
+        kind: "identity",
+        id: "b-2",
+        reason: DUPLICATE_IDENTITY_ASSERTION_DROP_REASON,
+      },
+    ]);
+  });
+});
+
+describe("T9 — 'flag' plans applicably; 'refuse' does not, for the same fixture", () => {
+  const inherited: IdentityTransferAssertion = { ...SAME_PAIR, id: "c-1" };
+  const reasserted: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "c-2",
+    validFrom: "2024-03-01T00:00:00.000Z",
+  };
+  const fixture = (): StagingSet =>
+    stagingWithIdentityChanges(
+      [{ branchId: BRANCH_B, assertion: reasserted }],
+      [{ branchId: BRANCH_A, assertion: inherited }],
+    );
+
+  it("'refuse' fails to plan", () => {
+    expect(() => planIdentityChanges(fixture(), new Map())).toThrow(
+      IdentityMergeConflictError,
+    );
+  });
+
+  it("'flag' produces an applicable plan carrying the conflict and leaves base truth intact", () => {
+    const planned = planIdentityChanges(fixture(), new Map(), "flag");
+    expect(planned.unresolved).toHaveLength(1);
+    // "Applicable" here means: nothing refused, and no write was staged for
+    // this pair either way — base identity truth is untouched.
+    expect(planned.assertions).toEqual([]);
+    expect(planned.retractions).toEqual([]);
+  });
+});

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -19,7 +19,10 @@ import {
   RETRACT_OVERRULED_DROP_REASON,
 } from "../../src/graph-merge/identity-three-way";
 import { merge } from "../../src/graph-merge/merge";
-import { planIdentityChanges } from "../../src/graph-merge/merge-identity";
+import {
+  planIdentityChanges,
+  RETRACTION_TARGET_MISMATCH_DROP_REASON,
+} from "../../src/graph-merge/merge-identity";
 import { isErr, unwrap } from "../../src/graph-merge/result";
 import type { StagingSet } from "../../src/graph-merge/staging";
 import type { IdentityTransferAssertion } from "../../src/graph-merge/typegraph-internal";
@@ -290,6 +293,134 @@ describe("T9 — 'flag' plans applicably; 'refuse' does not, for the same fixtur
     // this pair either way — base identity truth is untouched.
     expect(planned.assertions).toEqual([]);
     expect(planned.retractions).toEqual([]);
+  });
+});
+
+/**
+ * A resolving policy is a DECISION, and the reconciliation it produces is the
+ * only place that decision is recorded (`rule: "policy"`, plus the arm's own
+ * name) — `IdentityDecisionProvenance.policy` is built from nothing else.
+ * The survivor a policy keeps must also come from the ONE survivor rule, never
+ * from staging order.
+ */
+describe("policy resolutions are recorded, and pick through the survivor rule", () => {
+  const inherited: IdentityTransferAssertion = { ...SAME_PAIR, id: "a-1" };
+  /** Staged FIRST but the LATER validFrom, so index order and the rule disagree. */
+  const lateFirst: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "a-2",
+    validFrom: "2024-03-01T00:00:00.000Z",
+  };
+  const earlyLast: IdentityTransferAssertion = {
+    ...SAME_PAIR,
+    id: "a-3",
+    validFrom: "2024-02-01T00:00:00.000Z",
+  };
+  const twoWayRace = (): StagingSet =>
+    stagingWithIdentityChanges(
+      [
+        { branchId: BRANCH_B, assertion: lateFirst },
+        { branchId: asBranchId("branch-c"), assertion: earlyLast },
+      ],
+      [{ branchId: BRANCH_A, assertion: inherited }],
+    );
+
+  it("'assertWins' keeps the survivor rule's winner, not the first staged", () => {
+    const planned = planIdentityChanges(twoWayRace(), new Map(), "assertWins");
+    expect(planned.assertions.map((entry) => entry.id)).toEqual(["a-3"]);
+    expect(planned.reconciliations).toEqual([
+      {
+        semanticKey: planned.reconciliations[0]?.semanticKey,
+        a: { kind: "Person", id: "first" },
+        b: { kind: "Person", id: "second" },
+        relation: "same",
+        survivorAssertionId: "a-3",
+        supersededAssertionIds: ["a-1", "a-2"],
+        rule: "policy",
+        policy: "assertWins",
+        branches: ["branch-a", "branch-b", "branch-c"],
+      },
+    ]);
+  });
+
+  it("'retractWins' records the ended base row as what governs the pair", () => {
+    const planned = planIdentityChanges(twoWayRace(), new Map(), "retractWins");
+    expect(planned.assertions).toEqual([]);
+    expect(planned.reconciliations).toHaveLength(1);
+    expect(planned.reconciliations[0]).toMatchObject({
+      survivorAssertionId: "a-1",
+      supersededAssertionIds: ["a-2", "a-3"],
+      rule: "policy",
+      policy: "retractWins",
+    });
+  });
+
+  it("a function policy records itself as `callback`, never its source", () => {
+    const planned = planIdentityChanges(twoWayRace(), new Map(), () => ({
+      kind: "retract" as const,
+    }));
+    expect(planned.reconciliations[0]).toMatchObject({
+      rule: "policy",
+      policy: "callback",
+    });
+  });
+
+  it("'flag' records no reconciliation — nothing was decided", () => {
+    const planned = planIdentityChanges(twoWayRace(), new Map(), "flag");
+    expect(planned.reconciliations).toEqual([]);
+    expect(planned.unresolved).toHaveLength(1);
+  });
+});
+
+/**
+ * The base slice is a "state" read (open rows only) while a staged retraction
+ * is derived from an ARCHIVAL read, so a branch retracting a row the target
+ * has already ended stages a retraction with no base group to classify
+ * against. It must still reach the plan — or be dropped with a typed reason —
+ * never vanish.
+ */
+describe("a staged retraction whose base row is already ended", () => {
+  const alreadyEnded: IdentityTransferAssertion = { ...SAME_PAIR, id: "a-1" };
+  const orphanStaging = (): StagingSet =>
+    stagingWithIdentityChanges(
+      [],
+      [{ branchId: BRANCH_A, assertion: alreadyEnded }],
+      // The target's CURRENT truth holds nothing for this pair: the row the
+      // branch retracts was ended before the merge.
+      [],
+    );
+
+  it("is planned, not silently dropped", () => {
+    const planned = planIdentityChanges(orphanStaging(), new Map());
+    expect(planned.retractions.map((entry) => entry.id)).toEqual(["a-1"]);
+    expect(planned.dropped).toEqual([]);
+    expect(planned.assertions).toEqual([]);
+  });
+
+  it("is dropped with a typed reason when the target's OPEN row is a different truth", () => {
+    const planned = planIdentityChanges(
+      orphanStaging(),
+      new Map([
+        [
+          "a-1",
+          {
+            id: "a-1",
+            relation: "same" as const,
+            a: { kind: "Person", id: "first" },
+            b: { kind: "Person", id: "third" },
+            validFrom: SAME_PAIR.validFrom,
+          },
+        ],
+      ]),
+    );
+    expect(planned.retractions).toEqual([]);
+    expect(planned.dropped).toEqual([
+      {
+        kind: "identity",
+        id: "a-1",
+        reason: RETRACTION_TARGET_MISMATCH_DROP_REASON,
+      },
+    ]);
   });
 });
 

--- a/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-three-way.test.ts
@@ -1,5 +1,5 @@
 /**
- * The identity three-way classifier (design §4.2 / plan-G2 §1): the policy
+ * The identity three-way classifier: the policy
  * matrix for identity-assertion conflicts (`onAssertionConflict`), verified
  * directly against `planIdentityChanges`/`planIdentityThreeWay` without a
  * full store or merge — the same unit-fixture style

--- a/packages/typegraph/tests/graph-merge/node-delete-policy-wiring.test.ts
+++ b/packages/typegraph/tests/graph-merge/node-delete-policy-wiring.test.ts
@@ -75,8 +75,6 @@ function emptyPlan(): MergePlan<G> {
     warnings: [],
     identityAssertions: [],
     identityRetractions: [],
-    identityReconciliations: [],
-    identityConflicts: [],
     canonicalOf: new Map(),
   };
 }

--- a/packages/typegraph/tests/graph-merge/node-delete-policy-wiring.test.ts
+++ b/packages/typegraph/tests/graph-merge/node-delete-policy-wiring.test.ts
@@ -75,6 +75,8 @@ function emptyPlan(): MergePlan<G> {
     warnings: [],
     identityAssertions: [],
     identityRetractions: [],
+    identityReconciliations: [],
+    identityConflicts: [],
     canonicalOf: new Map(),
   };
 }

--- a/packages/typegraph/tests/identity-transition-log-ratchet.test.ts
+++ b/packages/typegraph/tests/identity-transition-log-ratchet.test.ts
@@ -194,6 +194,11 @@ const MODULE_ALLOWLIST: readonly AllowedModule[] = [
       "Imports the IdentityDecisionProvenance type only, to implement that same port method and pass the decision through to applyIdentityChangesForContext — no relation access.",
   },
   {
+    file: "identity/index.ts",
+    reason:
+      "Re-exports the IdentityDecisionProvenance type onto the identity barrel (and from there the package barrel), because a backend or store author implementing applyIdentityMergeAtTarget needs the decision shape by name — a type re-export, no relation access.",
+  },
+  {
     file: "graph-merge/typegraph-internal.ts",
     reason:
       "Re-exports the IdentityDecisionProvenance type through graph-merge's one seam onto the rest of the package, so the merge builds its decision against the owner's shape instead of re-spelling it — a type re-export, no relation access.",

--- a/packages/typegraph/tests/identity-transition-log-ratchet.test.ts
+++ b/packages/typegraph/tests/identity-transition-log-ratchet.test.ts
@@ -184,6 +184,21 @@ const MODULE_ALLOWLIST: readonly AllowedModule[] = [
       "Imports IdentityDecisionProvenance / IdentityTransitionDraft / IdentityTransitionNote — the touch/noteTransition callback types the capture session's public surface is typed against. The one writer (flush.ts) INSERTs; this file only buffers notes callers hand it.",
   },
   {
+    file: "store/runtime-port.ts",
+    reason:
+      "Imports the IdentityDecisionProvenance type only, to declare the optional `decision` parameter graph-merge's identity apply threads through applyIdentityMergeAtTarget — a port signature, no relation access.",
+  },
+  {
+    file: "store/store.ts",
+    reason:
+      "Imports the IdentityDecisionProvenance type only, to implement that same port method and pass the decision through to applyIdentityChangesForContext — no relation access.",
+  },
+  {
+    file: "graph-merge/typegraph-internal.ts",
+    reason:
+      "Re-exports the IdentityDecisionProvenance type through graph-merge's one seam onto the rest of the package, so the merge builds its decision against the owner's shape instead of re-spelling it — a type re-export, no relation access.",
+  },
+  {
     file: "store/recorded-capture/relations.ts",
     reason:
       "Imports IDENTITY_TRANSITION_COLUMN_NAMES for its .length only, to derive the per-statement chunk size flush.ts binds — column-count arithmetic, never a row.",


### PR DESCRIPTION

Adds identity-aware three-way reconciliation to `graph-merge`, so a merge that touches identity assertions across two branches resolves conflicts through one typed policy surface instead of throwing on the first divergence it sees.

**What changed.** A new classifier (`classifyIdentityPair` in `identity-three-way.ts`) absorbs three inline arbitrations that used to live side by side in `merge-identity.ts` — duplicate-assertion survivor selection, opposing-relation conflicts, and retract/reassert races — into one decision with one owner. `planIdentityChanges` now classifies before refusing, so a conflict can resolve under policy (`assertWins`, `retractWins`, a callback) instead of always throwing.

Candidate pairing gained an identity-driven source: nodes an existing identity assertion already relates as `"same"` become merge candidates even without a matching constraint key, and an always-on separation veto (built on the existing `isSeparated`/`bulkIsSeparated` owner) refuses to merge nodes the graph has already proven distinct, regardless of what any assertion claims.

The reconciliation options live in one nested bag, `MergeOptions.identity: IdentityReconciliationOptions`, with three sub-options (`pairing`, `onAssertionConflict`, `onProvenanceConflict`) folded into the existing `MERGE_OPTION_DEFAULTS` machinery as its one owner. Every accepted option is either honored or refused with a typed error naming the state it can't handle — no option is silently dropped. Two sub-options that would only ever have one legal value in this release (`onEdgeConflict`, `onUniquenessConflict`) are left out of the type entirely rather than shipped as decorative knobs: an option whose only accepted value is its own default is dead surface. Today's behaviors — `repoint` for an identity-paired edge collision, and the existing constraint-violation refusal for a uniqueness collision — remain the only behaviors. They're tracked for a later release once a plan-rebuild-after-repoint mechanism and a plan-time constraint-key probe through the store's own constraint lookup (rather than a second, merge-planner-local computation of the same keys) are both in place.

Resolved and unresolved outcomes both render on the merge artifacts: `identityReconciliations` and `identityConflicts` appear presence-preservingly on `MergePlan`, `MergeReport`, and `MergePlanReview`, so an old plan without identity activity still revalidates as `compatible` under the unchanged `MERGE_PLAN_FORMAT_VERSION` of 2.

The governing merge decision now threads through to the identity ledger: `applyMergePlan` builds the decision provenance and passes it through `applyIdentityChangesForContext`'s new `decision` parameter, which wraps the capture session's decision scope — so a transition note written during a merge apply carries the same decision identity the merge itself recorded, rather than a second, independently-derived one.

**Why.** Today, two branches that each independently assert or retract the same identity relationship fail a merge outright on the first inline check that notices, with no way to express "prefer the branch that asserted" or "prefer the branch that retracted" short of hand-editing the plan. The classifier and options bag turn that into a policy decision the caller states up front, with the previous throw-always behavior preserved as the default.



---

### §8 contract-discipline audit (verified against the final diff)

- **One predicate, one owner.** `compareIdentitySurvivors` and `identityAssertionSemanticKey` live only in `identity-three-way.ts`; `merge-identity.ts` re-imports, never re-spells. The separation veto calls `isSeparated`/`bulkIsSeparated` (the established one owner) rather than re-deriving class-lifted difference. `classifyIdentityPair` is the single classifier absorbing what were three inline arbitrations.
- **Accepted or refused, never ignored.** `pairing`, `onAssertionConflict`, `onProvenanceConflict` are each threaded to a write path or refused with a typed error. `onEdgeConflict`/`onUniquenessConflict` — the two options that could only ever refuse — were removed from the type entirely rather than shipped as knobs with one legal value (ruling G2-4).
- **A fused command is not evidence its dimensions ran.** No new `unsupported` command arm introduced; identity DML does not run through fused mutation programs.
- **Runtime evidence bound to the resource that earned it.** Decision provenance flows through `applyIdentityChangesForContext`'s explicit `decision` parameter, wrapping the capture session's `withIdentityDecision` scope; `applyMergePlan` is the one caller that builds and threads it.
- **A changed contract re-audits its consumers.** `planIdentityChanges`'s widened return (classify-then-resolve, plus `reconciliations`/`unresolved`) was checked against its one call site in `merge.ts` and the existing identity-merge/identity-reconciliation suites, all green in this pass's full-suite run. `applyIdentityChangesForContext`'s added `decision` parameter was checked against its `store.ts` and identity/service call sites.
- **Backends derived, never copied.** No new backend object constructed; `identity-pairing.ts`/`identity-three-way.ts` read through existing runtime-port accessors.
- **`*Backend` naming.** No new `*Backend`-suffixed identifier denoting a members fragment; `applyIdentityMergeAtTarget` is a method, not a backend object.
- **Rebase discipline.** `src/graph-merge/merge.ts`'s composition-orphan check, seed-hop acyclicity check, and (newly, post this rebase) the plan-time `assertResolvedPlanEdgesAcyclic` check and the composition-claim logic are all intact post-rebase — confirmed present in `merge.ts`; the identity work is additive alongside them, not a replacement.

### Public surface added (intentional, not forgotten-export debt — ruling G2-1)

Exported from `src/graph-merge/index.ts` (and reachable from the package barrel where noted):

- `IdentityReconciliationOptions` — the one nested options bag on `MergeOptions.identity` / `NormalizedMergeOptions.identity`, folded into `MERGE_OPTION_DEFAULTS` via `IDENTITY_OPTION_DEFAULTS`. Ships with `pairing`, `onAssertionConflict`, `onProvenanceConflict`.
- `IdentityAssertionConflictPolicy`, `IdentityAssertionConflictReason` — the policy union and classification-table reasons from `identity-three-way.ts`.
- `IdentityUnresolvedConflict` — now two arms, `assertion` and `separation` (a `provenance` arm was removed in review since `onProvenanceConflict` has no resolving disposition that could ever produce it; a `uniqueness` arm is deferred with the option, see below).
- `IdentityReconciliation` — the report/plan-artifact record of a resolved three-way pick (`identityReconciliations` on `MergePlan`/`MergeReport`).
- The `IdentityMergeConflictError`-family error classes carrying the widened conflict reasons and typed `details`.
- `IdentityDecisionProvenance` (re-exported from PR-1's `src/identity/transition-log.ts` surface), now also on the `StoreRuntime` port (`applyIdentityMergeAtTarget`'s parameter) — the source of the +1 forgotten-export debt on the five narrow entrypoints that structurally project `StoreRuntime` without re-exporting identity types themselves.
- `MERGE_PLAN_FORMAT_VERSION` stays `2` (not bumped); the new `identityReconciliations`/`identityConflicts` fields are added presence-preservingly, and old version-2 artifacts still revalidate as `compatible`.

No new facade beyond this — no `store.identity.replay`/`transitionsOf`, no receipts field, no archival interchange, no changeset. Those remain PR-3.

### Deferred options, named plainly

`identity.onEdgeConflict` and `identity.onUniquenessConflict` do **not** ship in PR-2. Both are absent from `IdentityReconciliationOptions` rather than present as knobs whose only accepted value is the current default — an option that can only refuse is dead surface. Today's default behaviors (`repoint` for an identity-paired edge collision; the existing constraint-violation refusal for a uniqueness collision) remain the only behaviors. The full obstacle writeup (the missing fifth `IdentityUnresolvedConflict` arm and the plan-rebuild-after-repoint requirement for edge conflicts; the second-owner-of-constraint-keys problem for uniqueness) is recorded in the design note's §10 "Deferred to a later release" section and, as a standalone GitHub-issue-ready body, in `lane-G2-deferred-issue.md` in this scratchpad directory (not filed as an issue — that's left to the lead).
