### PR TITLE
chore(api): record the ontology and semantics program's declared surface breaks

### DIFF
--- a/.changeset/identity-reconciliation.md
+++ b/.changeset/identity-reconciliation.md
@@ -56,6 +56,13 @@ transaction's flush wrote, an annotation of the assertion/retraction writes
 
 ### Breaking changes
 
+- The identity transition log adds two relations, `typegraph_identity_transitions`
+  and `typegraph_identity_transition_retention`, which `ensureSchema` creates on
+  an identity-enabled graph. `createSqlSchema` accepts `identityTransitions` and
+  `identityTransitionRetention` as optional overrides alongside the existing
+  table names; a deployment whose migration tooling enumerates TypeGraph's
+  relations, or whose database role has restricted DDL, must account for both
+  before upgrading.
 - Restoring an archival export (`identityMode: "archival"`) whose source graph
   retains identity transitions or has ever pruned them now requires the
   restore target to be opened with `history: true`. `importGraph` and

--- a/packages/typegraph/etc/api-surface-exceptions.json
+++ b/packages/typegraph/etc/api-surface-exceptions.json
@@ -598,5 +598,7693 @@
     "kind": "required-member-added",
     "reason": "This entrypoint does not export WorkingCopyStrategy.create; StoreCore is reached at a contravariant (parameter) position through the Store-taking public exports it does have — CoordinatePinnedView's constructor, createStore's overloads, rebuildIdentityClosure, and the RecordedStoreView/StoreView constructors. No code hand-authors a Store-shaped object literal to pass to any of them; every real Store originates from createStore/createAdapterStore/createStoreWithSchema, which now always populate workingCopyOptions.",
     "issue": "#632"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-postgres.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-libsql.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-adapters-drizzle-sqlite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-backend.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "description",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-core.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "a",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "asserted",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "b",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "base",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "reason",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "relation",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "retracted",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityAssertionConflict",
+    "member": "semanticKey",
+    "kind": "required-member-added",
+    "reason": "`IdentityAssertionConflict` is a new library-produced record describing a retract/reassert race or an independently duplicated assertion found during three-way identity reconciliation; the checker reports every member of a new declaration as an addition. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#658"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "anchors",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "digest",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "formatVersion",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "guards",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "mode",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "proposed",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "provenance",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "review",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "target",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV1",
+    "member": "writes",
+    "kind": "member-removed",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "anchors",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "digest",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "formatVersion",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "guards",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "mode",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "proposed",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "provenance",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "review",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "target",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanArtifactV2",
+    "member": "writes",
+    "kind": "required-member-added",
+    "reason": "`MERGE_PLAN_FORMAT_VERSION` is now `2`: the artifact carries `review.compositionOrphans`, `parseMergePlanArtifact` reports a stored version-1 artifact as `unsupported-version`, and the type is renamed `MergePlanArtifactV1` -> `MergePlanArtifactV2` (the version-agnostic `MergePlanArtifact` alias is unchanged). The checker reports the rename as one declaration lost and one gained. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MergePlanReview",
+    "member": "compositionOrphans",
+    "kind": "required-member-added",
+    "reason": "`MergePlanReview` gains `compositionOrphans`, the review section a version-2 plan artifact carries. The library produces the review inside the artifact; a consumer reads it. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-graph-merge.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-interchange.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-postgres-pglite.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-profiler.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-provenance.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "ensureSchema(options)",
+    "member": "preloaded",
+    "kind": "member-removed",
+    "reason": "`ensureSchema`'s inline `preloaded` options literal is extracted, member for member, into the named `EnsureSchemaPreloadedOptions` type; the parameter's shape is byte-identical and `preloaded` stays optional. The checker does not inventory type-reference bodies, so it reads the extraction as a removal.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "ensureSchema(options)",
+    "member": "preloaded.activeRow",
+    "kind": "member-removed",
+    "reason": "`ensureSchema`'s inline `preloaded` options literal is extracted, member for member, into the named `EnsureSchemaPreloadedOptions` type; the parameter's shape is byte-identical and `preloaded` stays optional. The checker does not inventory type-reference bodies, so it reads the extraction as a removal.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-schema.api.md",
+    "declaration": "ensureSchema(options)",
+    "member": "preloaded.storedSchema",
+    "kind": "member-removed",
+    "reason": "`ensureSchema`'s inline `preloaded` options literal is extracted, member for member, into the named `EnsureSchemaPreloadedOptions` type; the parameter's shape is byte-identical and `preloaded` stays optional. The checker does not inventory type-reference bodies, so it reads the extraction as a removal.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph-sqlite-local.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CardinalityErrorDetails",
+    "member": "direction",
+    "kind": "required-member-added",
+    "reason": "`CardinalityErrorDetails` is the `details` payload the library attaches to a cardinality error; nothing outside the library constructs one. It gains required `direction`, `toKind` and `toId` so a target-axis violation names the endpoint it refused. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CardinalityErrorDetails",
+    "member": "toId",
+    "kind": "required-member-added",
+    "reason": "`CardinalityErrorDetails` is the `details` payload the library attaches to a cardinality error; nothing outside the library constructs one. It gains required `direction`, `toKind` and `toId` so a target-axis violation names the endpoint it refused. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CardinalityErrorDetails",
+    "member": "toKind",
+    "kind": "required-member-added",
+    "reason": "`CardinalityErrorDetails` is the `details` payload the library attaches to a cardinality error; nothing outside the library constructs one. It gains required `direction`, `toKind` and `toId` so a target-axis violation names the endpoint it refused. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "ClaimEdgeCardinalityParams",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionOptions",
+    "member": "via",
+    "kind": "required-member-added",
+    "reason": "`partOf` / `hasPart` now require a realizing edge, so `CompositionOptions` gains a required `via`; both factories take a third options argument and a declaration without one is refused with `ONTOLOGY_COMPOSITION_VIA_REQUIRED`. Declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionPair",
+    "member": "existence",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` gains a required `existence` axis. It is internal to the registry and is not exported from any entrypoint; the changeset already tells anything that constructs one directly, such as a test fixture, to add the field. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionPair",
+    "member": "partKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionPair",
+    "member": "partSide",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionPair",
+    "member": "population",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionPair",
+    "member": "viaEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionPair",
+    "member": "wholeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionRelation",
+    "member": "edgeKinds",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionRelation",
+    "member": "pairs",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CompositionRelation",
+    "member": "partSideByEdgeKind",
+    "kind": "required-member-added",
+    "reason": "`CompositionPair` and `CompositionRelation` are new registry-owned types, not exported from any entrypoint and produced only by the registry build; the checker reports every member of a new declaration as an addition. The composition relation they model is declared in .changeset/composition-relation.md under \"Breaking\".",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "ContendedEdgeRow",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "edgeKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "endpointKind",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesAtEndpointParams",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "activeOnly",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "edgeKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "fromKind",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "CountEdgesFromParams",
+    "member": "graphId",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "EdgeCardinalityDeclaration",
+    "member": "cardinality",
+    "kind": "member-removed",
+    "reason": "`cardinality` was not dropped: it moved, together with the new `direction: \"source\" | \"target\"` discriminant, into the shared `EdgeCardinalityAxisRef` member of an intersection, and the type still carries it. The checker does not inventory type-reference bodies, so it reads the move as a removal and never sees the `direction` addition. The real change — the added `direction` discriminant on the claim params, the declaration and the contended row — is declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesAtEndpoint",
+    "kind": "required-member-added",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "GraphBackend",
+    "member": "countEdgesFrom",
+    "kind": "member-removed",
+    "reason": "`GraphBackend.countEdgesFrom` is replaced by `countEdgesAtEndpoint`, whose params carry an `endpoint: \"from\" | \"to\"` discriminant and the endpoint identity as `endpointKind`/`endpointId` so the target axis can be counted; a custom backend renames its implementation and reads the discriminant. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "backend",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graph",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "graphId",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "historyEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "loadNodes",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "registry",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "revisionTrackingEnabled",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "sameIdAcrossKinds",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schema",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityServiceContext",
+    "member": "schemaVersion",
+    "kind": "required-member-added",
+    "reason": "`IdentityServiceContext` is a new library-constructed service context, not exported from any entrypoint; the checker reports every member of a new declaration as an addition and reaches it only through the `@internal` `StoreRuntime.identityContext` port. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "IdentityWriteSummary",
+    "member": "transitions",
+    "kind": "required-member-added",
+    "reason": "`IdentityWriteSummary` is the per-transaction identity write count the library attaches to a transaction receipt; a consumer reads it and never constructs one. It gains `transitions`, counted beside (never inside) `total`. Declared in .changeset/identity-reconciliation.md.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKinds",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionEdgeKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionExistence",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint; it gains the `compositionExistence` accessor for the new `existence` axis on a composition pair. Declared in .changeset/composition-existence.md under \"Breaking\".",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartKindsUnder",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPartSide",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionPopulation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionRelation",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "compositionWholeKindsOver",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "getCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionEdge",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionPart",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry",
+    "member": "isCompositionWhole",
+    "kind": "required-member-added",
+    "reason": "`KindRegistry` is built by the library (`buildKindRegistry`) and is not exported from any entrypoint, so no external consumer implements or constructs one; it gains the composition-relation accessors the registry now owns. The composition relation and its registry ownership are declared in .changeset/composition-relation.md.",
+    "issue": "#645"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "broaderClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "disjointPairs",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplicationsClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeImplyingClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "edgeInverses",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "equivalenceSets",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "hasPartClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "iriToKind",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "narrowerClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "partOfClosure",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "relatedKinds",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassAncestors",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "KindRegistry.constructor(closures)",
+    "member": "subClassDescendants",
+    "kind": "member-removed",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "ManagedEdgeCreatePlan",
+    "member": "cardinalityClaim",
+    "kind": "member-removed",
+    "reason": "`ManagedEdgeCreatePlan.cardinalityClaim` becomes `cardinalityClaims: readonly ClaimEdgeCardinalityParams[]` so a two-axis plan carries both claims; a command port applies every entry or returns `unsupported` for the `\"cardinalityClaim\"` dimension. Declared in .changeset/edge-target-cardinality.md under \"Breaking changes\".",
+    "issue": "#639"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "description",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeOptions",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "MetaEdgeProperties",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "PolymorphicNodeType",
+    "member": "kind",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryBuilder",
+    "member": "parts",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryBuilder",
+    "member": "wholes",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryBuilderConfig",
+    "member": "defaultIncludeSubClasses",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryBuilderState",
+    "member": "startExpansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryStart",
+    "member": "expansion",
+    "kind": "required-member-added",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "QueryStart",
+    "member": "includeSubClasses",
+    "kind": "member-removed",
+    "reason": "the query builder's subclass-expansion axis moves from a boolean `includeSubClasses` to a resolved `AliasExpansionAxis`, so the builder's internal state carries `startExpansion` / `expansion` and its config carries the store-level `defaultIncludeSubClasses`, and a supertype alias resolves to `PolymorphicNodeType`. None of `QueryBuilderConfig`, `QueryBuilderState`, `QueryStart` or `PolymorphicNodeType` is exported from any entrypoint; they are the builder's internal state, reached only because the builder class constructors appear in the report. Declared in .changeset/typed-subsumption.md.",
+    "issue": "#642"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "broaderClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "disjointPairs",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplicationsClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeImplyingClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "edgeInverses",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "equivalenceSets",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "hasPartClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "iriToKind",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "narrowerClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "partOfClosure",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "relatedKinds",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassAncestors",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "RegistryClosures",
+    "member": "subClassDescendants",
+    "kind": "required-member-added",
+    "reason": "the `KindRegistry` constructor's inline closures object literal is extracted, member for member, into the named `RegistryClosures` type — the checker reports the same members once as removed from the inline literal and once as added to the new named type, with nothing gained or lost between them. Neither `KindRegistry` nor `RegistryClosures` is exported from any entrypoint, and `buildKindRegistry` is the only producer of both.",
+    "issue": "#641"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitionRetention",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "ResolvedSqlTableNames",
+    "member": "identityTransitions",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inference",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "inverse",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "reflexive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "symmetric",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SerializedMetaEdge",
+    "member": "transitive",
+    "kind": "member-removed",
+    "reason": "custom `metaEdge()`, `MetaEdgeOptions` and the public `InferenceType` union are removed, and `MetaEdgeProperties` / `SerializedMetaEdge` narrow to their remaining members after the inference flags (`transitive`, `symmetric`, `reflexive`, `inverse`, `inference`) are dropped. Declared in .changeset/remove-custom-meta-edge.md under \"Breaking changes\".",
+    "issue": "#650"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionRetentionTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "SqlSchema",
+    "member": "identityTransitionsTable",
+    "kind": "required-member-added",
+    "reason": "the identity transition log adds two relations, `typegraph_identity_transitions` and `typegraph_identity_transition_retention`. `SqlTableNames` gains both as OPTIONAL override keys, so nothing a consumer passes to `createSqlSchema` changes; only the resolved `ResolvedSqlTableNames` and the `SqlSchema` the factory returns carry them as required, and the library is their sole producer. Declared in .changeset/identity-reconciliation.md under \"Breaking changes\".",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreRuntime",
+    "member": "detachDeletedImportedIdentityNode",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#659"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityContext",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#644"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreRuntime",
+    "member": "identityTransitionRetentionAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreRuntime",
+    "member": "importIdentityTransitionsAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "StoreRuntime",
+    "member": "readIdentityTransitionPageAtTarget",
+    "kind": "required-member-added",
+    "reason": "`StoreRuntime` is the `@internal`, symbol-keyed store runtime port documented as absent from the public `Store` contract; it is not exported from any entrypoint, so no external consumer can name or author one. The checker reaches it contravariantly only because `Store<G>` itself appears in parameter position on public functions such as `applyMergePlan`, which over-approximates a hand-authored `Store`-shaped value.",
+    "issue": "#660"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "TransactionRuntime",
+    "member": "deleteNodeWithPolicy",
+    "kind": "required-member-added",
+    "reason": "`TransactionRuntime` is the `@internal`, symbol-keyed transaction runtime port; it is not exported from any entrypoint, so no external consumer can name or author one. It gains `deleteNodeWithPolicy` so merge apply deletes through the transaction port. The checker reaches it contravariantly only because the transaction object itself appears in parameter position.",
+    "issue": "#640"
+  },
+  {
+    "entrypoint": "typegraph.api.md",
+    "declaration": "TraversalBuilder",
+    "member": "toKindSet",
+    "kind": "required-member-added",
+    "reason": "`parts()` / `wholes()` are new navigation methods on the library-produced query builder, and `TraversalBuilder` gains the `toKindSet` the composition traversal resolves against. A consumer calls the builder `store.query()` returns and never implements one, and `TraversalBuilder` is not exported from any entrypoint. Declared in .changeset/composition-navigation.md.",
+    "issue": "#646"
   }
 ]

--- a/packages/typegraph/src/store/runtime-port.ts
+++ b/packages/typegraph/src/store/runtime-port.ts
@@ -66,13 +66,15 @@ export type StoreRuntime<G extends GraphDef> = Readonly<{
    * a second verdict for the same backend — the same reason `backend` itself
    * is exposed here rather than reconstructed.
    *
-   * Optional at this boundary — a `StoreRuntime`-shaped value is a
-   * contravariant (externally-authorable) position, so a new REQUIRED member
-   * here would be a breaking change (`scripts/api-surface-compat.ts`).
-   * Required after resolution instead, the same pattern
+   * Optional at this boundary, required after resolution — the same pattern
    * `CompileQueryOptions.recursiveTraversal` uses: the one real producer
    * (`store.ts`'s constructor) always populates it, and the one real
-   * consumer (`provenance/index.ts`) asserts it with `requireDefined`.
+   * consumer (`provenance/index.ts`) asserts it with `requireDefined`. This
+   * shim predates the ruling that `StoreRuntime` is an `@internal`,
+   * symbol-keyed port no external consumer can name; later members are added
+   * as plain required members, and the API-surface checker's findings for
+   * them are recorded in `etc/api-surface-exceptions.json` rather than
+   * shimmed. Kept as is so its consumer's assertion stays truthful.
    */
   uniqueSidecarBatch?: BundleVerdictOf<typeof UNIQUE_SIDECAR_BATCH> | undefined;
   /**


### PR DESCRIPTION
CI's public API surface compatibility check compares `etc/*.api.md` against the last published tag and fails on every external-consumer breaking change that has no entry in `etc/api-surface-exceptions.json`. The integration branch's declared breaking changes (147 unique declaration/member/kind breaks across the entrypoints, 961 findings) are now recorded there, one entry per entrypoint as the checker matches, each with the specific reason, the changeset section that declares it, and the introducing PR as its issue. Every entry maps to a `### Breaking` bullet in one of the release's changesets; four intended contract changes the changesets had not listed (the identity transition-log relations and their table-name overrides) get their bullet in the identity reconciliation changeset. No type an external consumer authors gained a required member without a declaration. The runtime port's one optional-member shim comment now says the shim was a one-off rather than the port's rule, since the port is an `@internal` symbol-keyed contract no consumer can name and its new members are recorded in the ledger instead of shimmed. Dispositions per declaration are in the session record; the checker exits 0 on this branch and the ledger audit reports no stale entry.