### PR TITLE
fix(identity)!: discover lineage past the replay window, page history instead of refusing, and mark restored transitions

### DIFF
--- a/.changeset/identity-reconciliation.md
+++ b/.changeset/identity-reconciliation.md
@@ -18,24 +18,30 @@ recorded-revision counter and there is no revision on the destination's own
 axis to pair the timestamp with — the retention watermark
 (`truncatedBefore`) remains the only revision-shaped signal a restore
 leaves behind.
+
 `transitionsOf` and `replay` both page: `limit` caps the number of boundaries
 one page returns and a capped page hands back a `nextFrom` cursor to pass as
 the next call's `fromRecorded`. Bounding the answer with
 `fromRecorded`/`toRecorded` never bounds the lineage search — discovery walks
 the whole log, because the note naming an earlier class canonical routinely
-sits above the requested window. `store.identity.replay(ref)` pairs each transition with the
-class membership before and after it, reconstructed through the same
-historical reader `asOf` and `asOfRecorded` reads already use, so replay can
-never disagree with a live read. `pruneIdentityTransitions(store, { beforeRecorded })`
-trims retained explanations and records a watermark that replay reports rather
-than hiding, and archival interchange carries a `transitions` section plus the
-retention watermark, bumping the interchange format to `3.0` (older documents
-still import and validate unchanged). Restoring an archive's transitions
-validates shape only and never re-derives membership; every restored row is
-marked as such so `replay` never pairs it with a fabricated before/after, and
-— when the destination has no identity transitions of its own yet — the
-restore also sets its own watermark so `replay` reports the pre-restore range
-honestly instead of claiming a complete history it cannot reconstruct.
+sits above the requested window; discovery itself keyset-pages through every
+matching row rather than capping at a fixed ceiling, so an ordinary lineage
+never needs a destructive prune to become readable again.
+
+`store.identity.replay(ref)` pairs each transition with the class membership
+before and after it, reconstructed through the same historical reader `asOf`
+and `asOfRecorded` reads already use, so replay can never disagree with a
+live read. `pruneIdentityTransitions(store, { beforeRecorded })` trims
+retained explanations and records a watermark that replay reports rather
+than hiding, and archival interchange carries a `transitions` section plus
+the retention watermark, bumping the interchange format to `3.0` (older
+documents still import and validate unchanged). Restoring an archive's
+transitions validates shape only and never re-derives membership; every
+restored row is marked as such so `replay` never pairs it with a fabricated
+before/after, and — when the destination has no identity transitions of its
+own yet — the restore also sets its own watermark so `replay` reports the
+pre-restore range honestly instead of claiming a complete history it cannot
+reconstruct.
 
 Graph merge gains identity reconciliation under a new `identity` merge-options
 bag: `pairing` lets an explicit `same` assertion propose or force a candidate
@@ -83,10 +89,14 @@ transaction's flush wrote, an annotation of the assertion/retraction writes
 - Lineage discovery no longer honors `fromRecorded`/`toRecorded`: the walk
   reads the whole transition log and the window is applied to the converged
   result, so a window can never hide the notes that name an earlier class
-  canonical. Two consequences: a narrow-window audit read now scans the full
-  lineage on every call, and `IDENTITY_REPLAY_WALK_INCOMPLETE`'s only remedy
-  is `pruneIdentityTransitions` — narrowing the window no longer lowers the
-  walk's read volume, and the error's suggestion says so.
+  canonical. One consequence: a narrow-window audit read now scans the full
+  lineage on every call — narrowing the window no longer lowers the walk's
+  read volume. Discovery keyset-pages through every matching row rather than
+  capping at a fixed ceiling, so this does not turn into an unreadable
+  lineage in practice; only a single class lineage whose transition rows
+  exceed an internal total safety ceiling still hits
+  `IDENTITY_REPLAY_WALK_INCOMPLETE`, whose only remedy remains the
+  destructive `pruneIdentityTransitions`, as the error's suggestion says.
 
 - The identity transition log adds two relations, `typegraph_identity_transitions`
   and `typegraph_identity_transition_retention`, which `ensureSchema` creates on

--- a/.changeset/identity-reconciliation.md
+++ b/.changeset/identity-reconciliation.md
@@ -9,7 +9,12 @@ retractions, same-id folds, deletes and restores, validity-window ends, kind
 drops, schema transitions and reconciliation decisions — each carrying the
 assertion ids involved, both temporal coordinates, and, for a decision made by
 a merge, the policy arm, branch, branch ancestry and plan and review digests
-that produced it. `store.identity.replay(ref)` pairs each transition with the
+that produced it. `transitionsOf` and `replay` both page: `limit` caps the number of boundaries
+one page returns and a capped page hands back a `nextFrom` cursor to pass as
+the next call's `fromRecorded`. Bounding the answer with
+`fromRecorded`/`toRecorded` never bounds the lineage search — discovery walks
+the whole log, because the note naming an earlier class canonical routinely
+sits above the requested window. `store.identity.replay(ref)` pairs each transition with the
 class membership before and after it, reconstructed through the same
 historical reader `asOf` and `asOfRecorded` reads already use, so replay can
 never disagree with a live read. `pruneIdentityTransitions(store, { beforeRecorded })`
@@ -55,6 +60,17 @@ transaction's flush wrote, an annotation of the assertion/retraction writes
 `total` already counts rather than a fourth kind of write.
 
 ### Breaking changes
+
+- `store.identity.transitionsOf` returns `{ transitions, nextFrom? }` rather
+  than a bare array, so a capped page can carry its continuation cursor.
+  Destructure the result (`const { transitions } = await
+  store.identity.transitionsOf(ref)`).
+- `IDENTITY_REPLAY_LIMIT_EXCEEDED` is gone from `IdentityReplayErrorDetails`
+  and the error catalog. A lineage with more boundaries than `limit` now
+  pages: `replay` and `transitionsOf` return a `nextFrom` recorded instant
+  naming the first boundary the page stopped short of. Code that caught the
+  refusal and resumed from `details.resumeFromRecorded` reads `nextFrom` off
+  the successful result instead.
 
 - The identity transition log adds two relations, `typegraph_identity_transitions`
   and `typegraph_identity_transition_retention`, which `ensureSchema` creates on

--- a/.changeset/identity-reconciliation.md
+++ b/.changeset/identity-reconciliation.md
@@ -9,7 +9,10 @@ retractions, same-id folds, deletes and restores, validity-window ends, kind
 drops, schema transitions and reconciliation decisions — each carrying the
 assertion ids involved, both temporal coordinates, and, for a decision made by
 a merge, the policy arm, branch, branch ancestry and plan and review digests
-that produced it. `transitionsOf` and `replay` both page: `limit` caps the number of boundaries
+that produced it. A transition an archival restore brought in carries
+`restored.at`, the destination's wall clock at restore time, so an audit view
+can tell an imported explanation from a locally replayable event.
+`transitionsOf` and `replay` both page: `limit` caps the number of boundaries
 one page returns and a capped page hands back a `nextFrom` cursor to pass as
 the next call's `fromRecorded`. Bounding the answer with
 `fromRecorded`/`toRecorded` never bounds the lineage search — discovery walks

--- a/.changeset/identity-reconciliation.md
+++ b/.changeset/identity-reconciliation.md
@@ -11,7 +11,13 @@ assertion ids involved, both temporal coordinates, and, for a decision made by
 a merge, the policy arm, branch, branch ancestry and plan and review digests
 that produced it. A transition an archival restore brought in carries
 `restored.at`, the destination's wall clock at restore time, so an audit view
-can tell an imported explanation from a locally replayable event.
+can tell an imported explanation from a locally replayable event. That marker
+is a wall clock rather than a `RecordedInstant` on purpose: a restore records
+history, it does not relive it, so it never advances the destination's
+recorded-revision counter and there is no revision on the destination's own
+axis to pair the timestamp with — the retention watermark
+(`truncatedBefore`) remains the only revision-shaped signal a restore
+leaves behind.
 `transitionsOf` and `replay` both page: `limit` caps the number of boundaries
 one page returns and a capped page hands back a `nextFrom` cursor to pass as
 the next call's `fromRecorded`. Bounding the answer with
@@ -74,6 +80,13 @@ transaction's flush wrote, an annotation of the assertion/retraction writes
   naming the first boundary the page stopped short of. Code that caught the
   refusal and resumed from `details.resumeFromRecorded` reads `nextFrom` off
   the successful result instead.
+- Lineage discovery no longer honors `fromRecorded`/`toRecorded`: the walk
+  reads the whole transition log and the window is applied to the converged
+  result, so a window can never hide the notes that name an earlier class
+  canonical. Two consequences: a narrow-window audit read now scans the full
+  lineage on every call, and `IDENTITY_REPLAY_WALK_INCOMPLETE`'s only remedy
+  is `pruneIdentityTransitions` — narrowing the window no longer lowers the
+  walk's read volume, and the error's suggestion says so.
 
 - The identity transition log adds two relations, `typegraph_identity_transitions`
   and `typegraph_identity_transition_retention`, which `ensureSchema` creates on

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -329,16 +329,19 @@ cannot answer a request. Its code names the reason:
   section targets a history-off store: without `history: true` those rows
   could never be read back through `transitionsOf` / `replay` either, so the
   import refuses rather than writing them write-only.
-- `IDENTITY_REPLAY_LIMIT_EXCEEDED` — the lineage walk found more boundaries
-  than the requested `limit` (default 200, maximum 2000). `details
-  .resumeFromRecorded` names a cursor; pass it as `fromRecorded` to page.
 - `IDENTITY_REPLAY_HISTORY_TRUNCATED` — the requested range lies entirely
   below the graph's retention watermark (see
   [`pruneIdentityTransitions`](/identity/#retention)); `details.prunedBefore`
   names the watermark.
 - `IDENTITY_REPLAY_WALK_INCOMPLETE` — an internal safety ceiling on the
-  lineage walk's own reads was hit; narrow `fromRecorded`/`toRecorded` or
-  prune older history.
+  lineage walk's own reads was hit; prune older history with
+  `pruneIdentityTransitions`. Narrowing `fromRecorded`/`toRecorded` does not
+  help: lineage discovery reads the whole log deliberately, so that a
+  requested window can never hide the notes that name a class.
+
+A range with more boundaries than the requested `limit` is not an error —
+`replay` and `transitionsOf` page, returning a `nextFrom` cursor on the
+result (see [Replay and identity history](/identity/#replay-and-identity-history)).
 
 ```typescript
 import { IdentityReplayError } from "@nicia-ai/typegraph";
@@ -1801,7 +1804,6 @@ try {
 | `IDENTITY_VALIDITY_OPEN_WINDOW_CONFLICT` | `IdentityValidityWindowError` | constraint | A different open window already represents the current semantic pair |
 | `IDENTITY_ENDPOINT_VALIDITY` | `IdentityEndpointValidityError` | constraint | An endpoint does not cover the explicit assertion window |
 | `IDENTITY_REPLAY_REQUIRES_HISTORY` | `IdentityReplayError` | constraint | `replay` / `transitionsOf` called on a store opened without `history: true` |
-| `IDENTITY_REPLAY_LIMIT_EXCEEDED` | `IdentityReplayError` | constraint | The lineage walk found more boundaries than the requested `limit` |
 | `IDENTITY_REPLAY_HISTORY_TRUNCATED` | `IdentityReplayError` | constraint | The requested range lies entirely below the retention watermark |
 | `IDENTITY_REPLAY_WALK_INCOMPLETE` | `IdentityReplayError` | constraint | The lineage walk's internal read ceiling was hit before the seed set converged |
 | `GRAPH_MERGE_IDENTITY_CONFLICT` | `IdentityMergeConflictError` | system | Branches carry opposing identity truth |

--- a/apps/docs/src/content/docs/errors.md
+++ b/apps/docs/src/content/docs/errors.md
@@ -333,11 +333,16 @@ cannot answer a request. Its code names the reason:
   below the graph's retention watermark (see
   [`pruneIdentityTransitions`](/identity/#retention)); `details.prunedBefore`
   names the watermark.
-- `IDENTITY_REPLAY_WALK_INCOMPLETE` — an internal safety ceiling on the
-  lineage walk's own reads was hit; prune older history with
-  `pruneIdentityTransitions`. Narrowing `fromRecorded`/`toRecorded` does not
-  help: lineage discovery reads the whole log deliberately, so that a
-  requested window can never hide the notes that name a class.
+- `IDENTITY_REPLAY_WALK_INCOMPLETE` — the lineage walk keyset-pages through
+  every matching row with no per-round limit, so ordinary lineages — however
+  many rows they hold — never hit this refusal; it fires only when a single
+  class lineage's transition rows exceed an internal total safety ceiling
+  (`details.ceiling`), which is a backstop against a pathologically large or
+  corrupted log, not a cap on legitimate history. Its only remedy is
+  destructive: prune older history with `pruneIdentityTransitions`.
+  Narrowing `fromRecorded`/`toRecorded` does not help: lineage discovery
+  reads the whole log deliberately, so that a requested window can never
+  hide the notes that name a class.
 
 A range with more boundaries than the requested `limit` is not an error —
 `replay` and `transitionsOf` page, returning a `nextFrom` cursor on the
@@ -1805,7 +1810,7 @@ try {
 | `IDENTITY_ENDPOINT_VALIDITY` | `IdentityEndpointValidityError` | constraint | An endpoint does not cover the explicit assertion window |
 | `IDENTITY_REPLAY_REQUIRES_HISTORY` | `IdentityReplayError` | constraint | `replay` / `transitionsOf` called on a store opened without `history: true` |
 | `IDENTITY_REPLAY_HISTORY_TRUNCATED` | `IdentityReplayError` | constraint | The requested range lies entirely below the retention watermark |
-| `IDENTITY_REPLAY_WALK_INCOMPLETE` | `IdentityReplayError` | constraint | The lineage walk's internal read ceiling was hit before the seed set converged |
+| `IDENTITY_REPLAY_WALK_INCOMPLETE` | `IdentityReplayError` | constraint | A single lineage's transition rows exceeded the walk's internal total safety ceiling |
 | `GRAPH_MERGE_IDENTITY_CONFLICT` | `IdentityMergeConflictError` | system | Branches carry opposing identity truth |
 | `GRAPH_MERGE_IDENTITY_SEPARATION_CONFLICT` | `IdentityMergeConflictError` | system | A forced identity-paired match crosses a class-lifted `different` assertion |
 | `GRAPH_MERGE_IDENTITY_PROVENANCE_CONFLICT` | `IdentityMergeConflictError` | system | `onProvenanceConflict: "refuse"` found contradictory branch attribution across a fused cluster |

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -712,15 +712,24 @@ both endpoints are *staged new nodes of the kind being planned*, drawn from
 the same staging slices the three-way classifier reads. An assertion naming a
 node already committed on the target, a node of another kind, or a node no
 branch staged proposes nothing at all — recall proposes over the nodes in
-scope, silently and by design. So this is a **branch-reconciliation** knob:
-it decides which rows two branches contributed collapse into one entity as
-they land. It is not an API for consolidating two entities that already live
-in the target graph; there is no `store.identity.consolidate(a, b)` today,
-and asserting `same` between two committed nodes records identity truth (a
-class, honored by every identity-aware read) without ever rewriting them into
-a single row. A future direct consolidation API would build on this same
-reviewed merge machinery — the plan artifact, the review digest, the
-separation veto — rather than introducing a second, unaudited path.
+scope. What it does instead depends on where the assertion came from: a
+branch-staged assertion whose endpoints are out of scope is reported on
+[`MergeReport.identityConflicts`](#identity-conflicts) with reason
+`out-of-scope-pairing`, and *every* cross-kind `same` is reported with
+`cross-kind-pairing` regardless of provenance. Both are reported, never
+fatal — the merge proceeds and fuses nothing for that pair, whatever
+`onAssertionConflict` says. Only an **inherited** assertion no branch
+restaged — the target's own existing ledger between two committed rows — is
+silent, because it is not a conflict any branch caused. So this is a
+**branch-reconciliation** knob: it decides which rows two branches
+contributed collapse into one entity as they land. It is not an API for
+consolidating two entities that already live in the target graph; there is no
+`store.identity.consolidate(a, b)` today, and asserting `same` between two
+committed nodes records identity truth (a class, honored by every
+identity-aware read) without ever rewriting them into a single row. A future
+direct consolidation API would build on this same reviewed merge machinery —
+the plan artifact, the review digest, the separation veto — rather than
+introducing a second, unaudited path.
 
 **`pairing: "definitional"` is consolidation, said once and loudly.** It
 merges nodes that were created under different ids purely because a `same`

--- a/apps/docs/src/content/docs/graph-merge.md
+++ b/apps/docs/src/content/docs/graph-merge.md
@@ -707,6 +707,21 @@ const result = await merge(base, branches, {
 | `"candidate"` | Each `same` assertion emits a **scored** candidate pair, subject to the kind's own threshold — strong recall, not proof |
 | `"definitional"` | Each `same` assertion **forces** a fused candidate edge, merging its endpoints regardless of similarity score |
 
+**What the pairing source can reach.** An assertion proposes a pair only when
+both endpoints are *staged new nodes of the kind being planned*, drawn from
+the same staging slices the three-way classifier reads. An assertion naming a
+node already committed on the target, a node of another kind, or a node no
+branch staged proposes nothing at all — recall proposes over the nodes in
+scope, silently and by design. So this is a **branch-reconciliation** knob:
+it decides which rows two branches contributed collapse into one entity as
+they land. It is not an API for consolidating two entities that already live
+in the target graph; there is no `store.identity.consolidate(a, b)` today,
+and asserting `same` between two committed nodes records identity truth (a
+class, honored by every identity-aware read) without ever rewriting them into
+a single row. A future direct consolidation API would build on this same
+reviewed merge machinery — the plan artifact, the review digest, the
+separation veto — rather than introducing a second, unaudited path.
+
 **`pairing: "definitional"` is consolidation, said once and loudly.** It
 merges nodes that were created under different ids purely because a `same`
 assertion relates them — not because they scored above a threshold. That is

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -344,13 +344,13 @@ current canonical and hops backwards). A window that returned nothing would
 otherwise be indistinguishable from a lineage that genuinely had no
 transitions in it.
 
-`options.limit` (default 200, maximum 2000) caps the number of BOUNDARIES one
-page returns. Both `replay` and `transitionsOf` page rather than refuse: a
-capped result carries `nextFrom`, the recorded instant of the first boundary
-it stopped short of, and passing that back as `fromRecorded` reads the next
-page. They page on identical boundaries, so a `replay` page and a
-`transitionsOf` page taken with the same options always cover the same
-revisions.
+`options.limit` (default 200, an integer from 1 to 2000 — anything else is a
+`ValidationError`) caps the number of BOUNDARIES one page returns. Both
+`replay` and `transitionsOf` page rather than refuse: a capped result carries
+`nextFrom`, the recorded instant of the first boundary it stopped short of,
+and passing that back as `fromRecorded` reads the next page. They page on
+identical boundaries, so a `replay` page and a `transitionsOf` page taken
+with the same options always cover the same revisions.
 
 ```typescript
 let cursor: RecordedInstant | undefined;

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -299,6 +299,14 @@ for (const transition of transitions) {
 }
 ```
 
+A transition that an archival restore brought into this graph — rather than
+this graph's own history capture recording it — carries `restored`, whose
+`at` is the destination's wall clock at restore time. That is the marker
+`replay` itself uses to leave the row out of `steps`, made public so an audit
+view can label an imported explanation instead of inferring it from a
+revision comparison (see [Archival transitions and the retention
+watermark](#archival-transitions-and-the-retention-watermark)).
+
 | Cause | Fires when |
 | --- | --- |
 | `assert` | An explicit `same` assertion (or a merge's own union) fused two classes |
@@ -381,6 +389,11 @@ await store.transaction(async (tx) => {
 });
 await store.identity.transitionsOf(alice); // now includes it, post-commit
 ```
+
+Restored transitions are never `steps`, but they are always
+`transitions` — see [Archival transitions and the retention
+watermark](#archival-transitions-and-the-retention-watermark) for the marker
+that tells them apart.
 
 ### Retention
 
@@ -574,9 +587,15 @@ so nothing was silently dropped, but it also could not throw. Open the
 restore target with `history: true` if it needs to accept archival exports
 from a history-enabled source.
 
-Every restored row is also marked as such internally, regardless of what the
-source graph thought of it: a restore always inserts rows this graph did not
-record itself. `replay` uses that marker — never a comparison against
+Every restored row is also marked as such, regardless of what the source
+graph thought of it: a restore always inserts rows this graph did not record
+itself. The marker is public — `transitionsOf` returns it as
+`transition.restored.at`, the destination's wall clock at restore time — so
+an audit view can label an imported explanation. It is a wall clock and not a
+`RecordedInstant` because a restore records history without reliving it: it
+never advances the destination's own recorded revision counter, so there is
+no revision on this graph's axis to pair the timestamp with. `replay` uses
+that same marker — never a comparison against
 `recordedRevision` — to decide whether a row may be paired with a
 reconstructed before/after snapshot, because a restored row's revision is
 minted by the *source* graph's own clock and interleaves arbitrarily with

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -293,7 +293,7 @@ fold, a delete or restore, a validity-window end, a kind drop, a schema
 transition, or a reconciliation decision made by a governed graph merge:
 
 ```typescript
-const transitions = await store.identity.transitionsOf(alice);
+const { transitions } = await store.identity.transitionsOf(alice);
 for (const transition of transitions) {
   console.log(transition.cause, transition.recorded, transition.assertionIds);
 }
@@ -328,12 +328,37 @@ for (const step of steps) {
 }
 ```
 
-`options.fromRecorded` / `toRecorded` bound the range by recorded instant;
-`options.limit` (default 200, maximum 2000) caps the number of boundaries a
-single call returns, throwing `IDENTITY_REPLAY_LIMIT_EXCEEDED` with a
-`resumeFromRecorded` cursor when there are more. Both `replay` and
-`transitionsOf` throw `IDENTITY_REPLAY_REQUIRES_HISTORY` on a store opened
-without `history: true` — there is nothing for them to annotate.
+`options.fromRecorded` / `toRecorded` bound the range by recorded instant.
+Bounding the ANSWER never bounds the LINEAGE SEARCH: discovery always walks
+the whole log, because the note that names an earlier class canonical
+routinely sits above the requested window (the walk starts at the node's
+current canonical and hops backwards). A window that returned nothing would
+otherwise be indistinguishable from a lineage that genuinely had no
+transitions in it.
+
+`options.limit` (default 200, maximum 2000) caps the number of BOUNDARIES one
+page returns. Both `replay` and `transitionsOf` page rather than refuse: a
+capped result carries `nextFrom`, the recorded instant of the first boundary
+it stopped short of, and passing that back as `fromRecorded` reads the next
+page. They page on identical boundaries, so a `replay` page and a
+`transitionsOf` page taken with the same options always cover the same
+revisions.
+
+```typescript
+let cursor: RecordedInstant | undefined;
+do {
+  const page = await store.identity.transitionsOf(alice, {
+    limit: 50,
+    ...(cursor === undefined ? {} : { fromRecorded: cursor }),
+  });
+  render(page.transitions);
+  cursor = page.nextFrom;
+} while (cursor !== undefined);
+```
+
+Both `replay` and `transitionsOf` throw `IDENTITY_REPLAY_REQUIRES_HISTORY` on
+a store opened without `history: true` — there is nothing for them to
+annotate.
 
 `replay` and `transitionsOf` live on `store.identity` and `tx.identity`
 only, never on a coordinate-pinned read lens (`store.asOf(t).identity`,

--- a/apps/docs/src/content/docs/identity.md
+++ b/apps/docs/src/content/docs/identity.md
@@ -350,7 +350,16 @@ transitions in it.
 `nextFrom`, the recorded instant of the first boundary it stopped short of,
 and passing that back as `fromRecorded` reads the next page. They page on
 identical boundaries, so a `replay` page and a `transitionsOf` page taken
-with the same options always cover the same revisions.
+with the same options always stop at the same boundary — though `steps` can
+be shorter than `transitions` on that page (see below): `nextFrom` names
+where the page stopped, not how many revisions it covered.
+
+`nextFrom` addresses the transition log only. When the boundary it names
+holds a restored row (see [Archival transitions and the retention
+watermark](#archival-transitions-and-the-retention-watermark)), the revision
+it names was minted by the *source* graph's clock, not this graph's — pass it
+only as the next call's `fromRecorded`, and never to `store.asOfRecorded`,
+which anchors a historical read on this graph's own recorded axis.
 
 ```typescript
 let cursor: RecordedInstant | undefined;

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -3266,7 +3266,7 @@ type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph-graph-merge.api.md
+++ b/packages/typegraph/etc/typegraph-graph-merge.api.md
@@ -3180,7 +3180,7 @@ type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -3256,6 +3256,7 @@ export type IdentityRelation = "same" | "different";
 type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public (undocumented)
@@ -3318,6 +3319,9 @@ type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -3327,6 +3331,12 @@ type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" | "resto
 type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -3058,7 +3058,7 @@ type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -3105,6 +3105,7 @@ type IdentityRelation = "same" | "different";
 type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public (undocumented)
@@ -3156,6 +3157,9 @@ type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -3165,6 +3169,12 @@ type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" | "resto
 type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -3115,7 +3115,7 @@ type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -2734,7 +2734,7 @@ export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonl
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -2772,6 +2772,7 @@ export type IdentityRelation = "same" | "different";
 type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public (undocumented)
@@ -2823,6 +2824,9 @@ type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -2832,6 +2836,12 @@ type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" | "resto
 type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-postgres-pglite.api.md
+++ b/packages/typegraph/etc/typegraph-postgres-pglite.api.md
@@ -2782,7 +2782,7 @@ type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -2712,7 +2712,7 @@ type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -2750,6 +2750,7 @@ type IdentityRelation = "same" | "different";
 type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public (undocumented)
@@ -2801,6 +2802,9 @@ type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -2810,6 +2814,12 @@ type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" | "resto
 type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-profiler.api.md
+++ b/packages/typegraph/etc/typegraph-profiler.api.md
@@ -2760,7 +2760,7 @@ type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -2766,7 +2766,7 @@ type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph-provenance.api.md
+++ b/packages/typegraph/etc/typegraph-provenance.api.md
@@ -2718,7 +2718,7 @@ type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonly<{
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -2756,6 +2756,7 @@ type IdentityRelation = "same" | "different";
 type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public (undocumented)
@@ -2807,6 +2808,9 @@ type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -2816,6 +2820,12 @@ type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" | "resto
 type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -2744,7 +2744,7 @@ export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonl
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -2782,6 +2782,7 @@ export type IdentityRelation = "same" | "different";
 type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public (undocumented)
@@ -2833,6 +2834,9 @@ type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -2842,6 +2846,12 @@ type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" | "resto
 type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/etc/typegraph-sqlite-local.api.md
+++ b/packages/typegraph/etc/typegraph-sqlite-local.api.md
@@ -2792,7 +2792,7 @@ type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -4027,7 +4027,7 @@ export type IdentityReplayOptions = Readonly<{
     limit?: number | undefined;
 }>;
 
-// @public (undocumented)
+// @public
 export type IdentityReplayStep<G extends GraphDef> = Readonly<{
     transition: IdentityTransition<G>;
     before: readonly IdentityNodeReference<G>[];

--- a/packages/typegraph/etc/typegraph.api.md
+++ b/packages/typegraph/etc/typegraph.api.md
@@ -3956,7 +3956,7 @@ export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> & Readonl
     retractSameAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     retractDifferentAssertion: (a: IdentityNodeRefInput<G>, b: IdentityNodeRefInput<G>) => Promise<IdentityAssertion<G> | undefined>;
     bulkRetractAssertions: (ids: readonly IdentityAssertionId[]) => Promise<readonly IdentityAssertion<G>[]>;
-    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<readonly IdentityTransition<G>[]>;
+    transitionsOf: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityTransitionHistory<G>>;
     replay: (ref: IdentityNodeRefInput<G>, options?: IdentityReplayOptions) => Promise<IdentityReplay<G>>;
 }>;
 
@@ -3994,6 +3994,7 @@ export type IdentityRelation = "same" | "different";
 export type IdentityReplay<G extends GraphDef> = Readonly<{
     steps: readonly IdentityReplayStep<G>[];
     truncatedBefore?: RecordedInstant | undefined;
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public
@@ -4009,10 +4010,6 @@ export class IdentityReplayError extends TypeGraphError {
 export type IdentityReplayErrorDetails = Readonly<{
     code: "IDENTITY_REPLAY_REQUIRES_HISTORY";
     graphId: string;
-}> | Readonly<{
-    code: "IDENTITY_REPLAY_LIMIT_EXCEEDED";
-    limit: number;
-    resumeFromRecorded: string;
 }> | Readonly<{
     code: "IDENTITY_REPLAY_HISTORY_TRUNCATED";
     requestedFrom?: string;
@@ -4097,6 +4094,9 @@ export type IdentityTransition<G extends GraphDef> = Readonly<{
     priorClass?: IdentityNodeReference<G> | undefined;
     assertionIds: readonly IdentityAssertionId[];
     decision?: IdentityDecisionProvenance | undefined;
+    restored?: Readonly<{
+        at: string;
+    }> | undefined;
 }>;
 
 // @public
@@ -4106,6 +4106,12 @@ export type IdentityTransitionCause = "assert" | "retract" | "fold" | "detach" |
 export type IdentityTransitionCursor = Readonly<{
     recordedRevision: number;
     transitionId: string;
+}>;
+
+// @public
+export type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+    transitions: readonly IdentityTransition<G>[];
+    nextFrom?: RecordedInstant | undefined;
 }>;
 
 // @public

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -829,12 +829,13 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "f88c3ebb710441aa204483f98147921b40dd8ba978c7b87b803c561c82137638",
   },
   // Paged identity history: `IdentityFacade.transitionsOf` now returns the
-  // named `IdentityTransitionHistory` instead of a bare array. `.` (and
-  // `./identity`) export the type directly, so their debt is unchanged; the
-  // six entrypoints below reach it only transitively through `Store`'s
-  // identity facade and each gains exactly that one name (+1 apiece). Gate:
-  // no entrypoint's debt decreased, no seventh entrypoint moved, and the
-  // single added symbol at each of the six is `IdentityTransitionHistory`.
+  // named `IdentityTransitionHistory` instead of a bare array. The root
+  // entrypoint `.` already exports the type directly, so its debt is
+  // unchanged; the six entrypoints below reach it only transitively through
+  // `Store`'s identity facade and each gains exactly that one name
+  // (+1 apiece). Gate: no entrypoint's debt decreased, no seventh entrypoint
+  // moved, and the single added symbol at each of the six is
+  // `IdentityTransitionHistory`.
   // Delta: `./graph-merge` 774→775, `./interchange` 759→760,
   // `./postgres/pglite` 756→757, `./profiler` 761→762, `./provenance`
   // 767→768, `./sqlite/local` 756→757.

--- a/packages/typegraph/scripts/api-report.ts
+++ b/packages/typegraph/scripts/api-report.ts
@@ -828,32 +828,42 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     count: 20,
     sha256: "f88c3ebb710441aa204483f98147921b40dd8ba978c7b87b803c561c82137638",
   },
+  // Paged identity history: `IdentityFacade.transitionsOf` now returns the
+  // named `IdentityTransitionHistory` instead of a bare array. `.` (and
+  // `./identity`) export the type directly, so their debt is unchanged; the
+  // six entrypoints below reach it only transitively through `Store`'s
+  // identity facade and each gains exactly that one name (+1 apiece). Gate:
+  // no entrypoint's debt decreased, no seventh entrypoint moved, and the
+  // single added symbol at each of the six is `IdentityTransitionHistory`.
+  // Delta: `./graph-merge` 774→775, `./interchange` 759→760,
+  // `./postgres/pglite` 756→757, `./profiler` 761→762, `./provenance`
+  // 767→768, `./sqlite/local` 756→757.
   // MergePlanReadContext derives its read-only surface from the runtime method
   // lists: EDGE_TEMPORAL_READ_NAMES, IDENTITY_READ_NAMES, and NODE_READ_NAMES.
   // These three implementation constants are referenced, not public exports.
   "./graph-merge": {
-    count: 774,
-    sha256: "96ddc19ead33fcd31f66f13af55e29a6cdf9ec065a7f4cd118e25c833cdd975e",
+    count: 775,
+    sha256: "9ef27cba14b673e7dedba18628834b363af387d1a7e83ae401e6caf34b57556e",
   },
   "./indexes": {
     count: 46,
     sha256: "5a43d419097711d242c6208632e7e498374a5977eb10a7faba904b10e13f35cd",
   },
   "./interchange": {
-    count: 759,
-    sha256: "118f3e94db13af60a49f7b454f1d1666718002eefcd0a413ffda59cc003c5c82",
+    count: 760,
+    sha256: "f42d54bd8616a1db700f08c75372bc1599320c7dc0e86ae211a1205567e2587b",
   },
   "./postgres/pglite": {
-    count: 756,
-    sha256: "656057c9846f97d4bc6661c33dd30c9e8148f9eac8d66054cc8f1496eec79c04",
+    count: 757,
+    sha256: "14007c138d3075a97b151b829f018fd2950fcc00993b4431cf1048ea3e6f6eea",
   },
   "./profiler": {
-    count: 761,
-    sha256: "efdcfa24bd79ac609f99442af77ae1b75218c8335f399dfd61c66cd9d5358750",
+    count: 762,
+    sha256: "3d9a67c3b66f380a5aea8d9665637cd6cf05a99f1c3609b1b78bdfe2679603dd",
   },
   "./provenance": {
-    count: 767,
-    sha256: "600c77b8ea8edbeec3527f2892f451afba32858896f80123daa90da38868bcf5",
+    count: 768,
+    sha256: "a093df3338fc755a61c6bf927c8902121e7c92aead8840b370d25711ed1bfa15",
   },
   // Identity transition log: `ensureSchema`'s inline `{ preloaded?: ... }`
   // options type was extracted into the named (but non-exported)
@@ -869,8 +879,8 @@ const FORGOTTEN_EXPORT_DEBT: Readonly<Record<string, ForgottenExportDebt>> = {
     sha256: "ff190fe91f16dd83780cc450653f95fae7b2bcf2653620dbd2719ab62b8547be",
   },
   "./sqlite/local": {
-    count: 756,
-    sha256: "656057c9846f97d4bc6661c33dd30c9e8148f9eac8d66054cc8f1496eec79c04",
+    count: 757,
+    sha256: "14007c138d3075a97b151b829f018fd2950fcc00993b4431cf1048ea3e6f6eea",
   },
 };
 

--- a/packages/typegraph/src/errors/index.ts
+++ b/packages/typegraph/src/errors/index.ts
@@ -1044,11 +1044,6 @@ export class IdentitySeparationViolationError extends TypeGraphError {
 export type IdentityReplayErrorDetails =
   | Readonly<{ code: "IDENTITY_REPLAY_REQUIRES_HISTORY"; graphId: string }>
   | Readonly<{
-      code: "IDENTITY_REPLAY_LIMIT_EXCEEDED";
-      limit: number;
-      resumeFromRecorded: string;
-    }>
-  | Readonly<{
       code: "IDENTITY_REPLAY_HISTORY_TRUNCATED";
       /**
        * The caller's OWN `fromRecorded`, present only when the caller
@@ -1071,8 +1066,10 @@ export type IdentityReplayErrorDetails =
  * Thrown by `store.identity.replay` / `transitionsOf` (and
  * `pruneIdentityTransitions`'s own history precondition) when the transition
  * log cannot answer a request: history capture is off, the requested range
- * would return more boundaries than the caller's limit, or the requested
- * range lies entirely below the retention watermark.
+ * lies entirely below the retention watermark, or the lineage walk's own
+ * internal read ceiling was reached before the seed set converged. A range
+ * with more boundaries than the caller's `limit` is NOT a refusal — it pages,
+ * through the `nextFrom` cursor on the result.
  */
 export class IdentityReplayError extends TypeGraphError {
   declare readonly details: IdentityReplayErrorDetails;

--- a/packages/typegraph/src/identity/index.ts
+++ b/packages/typegraph/src/identity/index.ts
@@ -6,6 +6,7 @@ export {
   type IdentityReplayOptions,
   type IdentityReplayStep,
   type IdentityTransition,
+  type IdentityTransitionHistory,
 } from "./replay";
 export {
   type IdentityDecisionProvenance,

--- a/packages/typegraph/src/identity/replay.ts
+++ b/packages/typegraph/src/identity/replay.ts
@@ -33,6 +33,7 @@ import {
   type IdentityDecisionProvenance,
   identityReplayRequiresHistoryError,
   type IdentityTransitionCause,
+  type IdentityTransitionCursor,
   type IdentityTransitionRow,
   isRestoredTransitionRow,
   readIdentityTransitions,
@@ -80,6 +81,17 @@ export type IdentityTransition<G extends GraphDef> = Readonly<{
   restored?: Readonly<{ at: string }> | undefined;
 }>;
 
+/**
+ * One paired boundary from {@link identityReplay}. `transition.restored` is
+ * NEVER set here — `identityReplay` builds `steps` only from `nativeRows`
+ * (rows this graph's own history capture recorded), by construction; a
+ * restored row's revision is minted by the source graph's clock and cannot
+ * be paired with a before/after reconstructed on THIS graph's historical
+ * reader (see {@link IdentityTransition.restored}'s docblock for why). The
+ * invariant lives on the `IdentityTransition` field rather than a narrower
+ * type here so the two APIs share one transition shape; a step's `restored`
+ * check, if ever written, is permanently dead code.
+ */
 export type IdentityReplayStep<G extends GraphDef> = Readonly<{
   transition: IdentityTransition<G>;
   before: readonly IdentityNodeReference<G>[];
@@ -92,6 +104,15 @@ export type IdentityReplayStep<G extends GraphDef> = Readonly<{
  * the page reached the end of the lineage. Pass it back as `fromRecorded` to
  * read the next page — `fromRecorded` is inclusive, so the boundary this
  * names opens the next page exactly once.
+ *
+ * SCOPED TO THE TRANSITION LOG ONLY. When the cutoff boundary holds a
+ * restored row (see {@link IdentityTransition.restored}), the revision this
+ * names was minted by the SOURCE graph's clock, not this graph's — it is
+ * `RecordedInstant`-shaped by construction (`requireTypeGraphRecordedRevision`
+ * cannot tell the two apart), but it must never be passed to
+ * `store.asOfRecorded`, which anchors a historical read on THIS graph's own
+ * recorded axis. Use it only as `fromRecorded` on the next `transitionsOf` /
+ * `replay` call.
  */
 type PagedTransitions = Readonly<{
   rows: readonly IdentityTransitionRow[];
@@ -102,14 +123,26 @@ export type IdentityReplay<G extends GraphDef> = Readonly<{
   steps: readonly IdentityReplayStep<G>[];
   /** Set when the retention watermark cut history above the requested start. */
   truncatedBefore?: RecordedInstant | undefined;
-  /** Set when `limit` capped this page; pass it as `fromRecorded` for the next one. */
+  /**
+   * Set when `limit` capped this page; pass it as `fromRecorded` for the
+   * next one. Addresses the TRANSITION LOG only — like
+   * {@link IdentityTransition.restored}'s `at`, this can name a revision a
+   * restored row's SOURCE graph allocated, not this graph. Never pass it to
+   * `store.asOfRecorded`; pass it only as `fromRecorded`.
+   */
   nextFrom?: RecordedInstant | undefined;
 }>;
 
 /** One page of {@link identityTransitionsOf}'s answer. */
 export type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
   transitions: readonly IdentityTransition<G>[];
-  /** Set when `limit` capped this page; pass it as `fromRecorded` for the next one. */
+  /**
+   * Set when `limit` capped this page; pass it as `fromRecorded` for the
+   * next one. Addresses the TRANSITION LOG only — like
+   * {@link IdentityTransition.restored}'s `at`, this can name a revision a
+   * restored row's SOURCE graph allocated, not this graph. Never pass it to
+   * `store.asOfRecorded`; pass it only as `fromRecorded`.
+   */
   nextFrom?: RecordedInstant | undefined;
 }>;
 
@@ -177,13 +210,25 @@ async function currentClassCanonicalSeed<G extends GraphDef>(
 }
 
 /**
- * Generous internal ceiling for the seed-lineage walk's OWN reads (never the
+ * Page size for each ROUND-TRIP the seed-lineage walk issues while reading
+ * one round to exhaustion (see {@link walkClassLineage}): generous enough
+ * that a typical lineage's round completes in a single page, but never the
  * caller's `limit`, which caps the PAGE assembled from the fully-converged
- * result below): a round that truncated its read before the seed set
- * converged could hide the very rows that would have grown that set,
- * silently returning an incomplete lineage instead of a typed refusal.
+ * result below.
  */
-const IDENTITY_REPLAY_WALK_READ_CEILING = 100_000;
+const IDENTITY_REPLAY_WALK_PAGE_SIZE = 100_000;
+
+/**
+ * Safety backstop on the fixed-point walk's TOTAL accumulated row count,
+ * across every round and every page within a round combined. This is not a
+ * bound on any lineage's legitimate size — a real lineage, however large,
+ * pages through {@link IDENTITY_REPLAY_WALK_PAGE_SIZE}-sized reads via the
+ * `after` keyset cursor with no destructive remedy required, up to this
+ * ceiling. Reached only by a pathologically large or corrupted transition
+ * log, where the alternative is an unbounded read; see
+ * `identityReplayWalkIncompleteError`.
+ */
+const IDENTITY_REPLAY_WALK_ROW_CEILING = 2_000_000;
 
 /**
  * The fixed-point class-lineage walk (§3.2 step 2): starting from `ref`'s
@@ -206,43 +251,52 @@ const IDENTITY_REPLAY_WALK_READ_CEILING = 100_000;
  * `readIdentityTransitions` therefore takes no revision bounds at all
  * (transition-log.ts) — the window is applied once, by
  * {@link windowedRows}, to the converged result.
+ *
+ * DISCOVERY IS ALSO UNBOUNDED BY ROW COUNT, deliberately: each round pages
+ * to exhaustion through `readIdentityTransitions`'s `after` keyset cursor
+ * rather than capping at a fixed ceiling, so a class lineage with more rows
+ * than any one page holds still converges correctly — it costs more round
+ * trips, never an incomplete or refused read. Only
+ * {@link IDENTITY_REPLAY_WALK_ROW_CEILING}, a backstop against a
+ * pathologically large or corrupted log, can still refuse.
  */
 async function walkClassLineage<G extends GraphDef>(
   ctx: IdentityServiceContext<G>,
   seed: PlainNodeRef,
 ): Promise<readonly IdentityTransitionRow[]> {
   const seeds = new Map<string, PlainNodeRef>([[refKey(seed), seed]]);
+  let totalRowsRead = 0;
   for (;;) {
     const scopeReferences = [...seeds.values()];
-    const rows = await readIdentityTransitions(
-      ctx.backend,
-      ctx.schema,
-      ctx.graphId,
-      {
-        classRefs: scopeReferences,
-        limit: IDENTITY_REPLAY_WALK_READ_CEILING,
-      },
-    );
-    // A round that read exactly the ceiling cannot tell "these are all the
-    // rows there are" from "the read cut off before the seed set converged" —
-    // exactly the hazard this constant's docblock names. Refuse rather than
-    // silently return a lineage that might be missing the rows that would
-    // have grown the seed set further.
-    if (rows.length === IDENTITY_REPLAY_WALK_READ_CEILING) {
-      throw new IdentityReplayError(
-        "Identity replay's lineage walk read more transition rows in one round than its internal ceiling allows, so completeness cannot be guaranteed.",
+    const roundRows: IdentityTransitionRow[] = [];
+    let after: IdentityTransitionCursor | undefined;
+    for (;;) {
+      const page = await readIdentityTransitions(
+        ctx.backend,
+        ctx.schema,
+        ctx.graphId,
         {
-          code: "IDENTITY_REPLAY_WALK_INCOMPLETE",
-          ceiling: IDENTITY_REPLAY_WALK_READ_CEILING,
-        },
-        {
-          suggestion:
-            "Prune older transitions with pruneIdentityTransitions. Narrowing fromRecorded/toRecorded does not help: lineage discovery reads the whole log on purpose, so that a window can never hide the notes that name a class.",
+          classRefs: scopeReferences,
+          limit: IDENTITY_REPLAY_WALK_PAGE_SIZE,
+          ...(after === undefined ? {} : { after }),
         },
       );
+      roundRows.push(...page);
+      totalRowsRead += page.length;
+      if (totalRowsRead > IDENTITY_REPLAY_WALK_ROW_CEILING) {
+        throw identityReplayWalkIncompleteError(
+          IDENTITY_REPLAY_WALK_ROW_CEILING,
+        );
+      }
+      if (page.length < IDENTITY_REPLAY_WALK_PAGE_SIZE) break;
+      const lastOfPage = requireDefined(page.at(-1));
+      after = {
+        recordedRevision: lastOfPage.recorded_revision,
+        transitionId: lastOfPage.transition_id,
+      };
     }
     let grew = false;
-    for (const row of rows) {
+    for (const row of roundRows) {
       const classRef = transitionClassRef(row);
       const priorClassRef = transitionPriorClassRef(row);
       if (!seeds.has(refKey(classRef))) {
@@ -254,7 +308,7 @@ async function walkClassLineage<G extends GraphDef>(
         grew = true;
       }
     }
-    if (!grew) return rows;
+    if (!grew) return roundRows;
   }
 }
 
@@ -314,6 +368,28 @@ function invalidReplayLimitError(
   return new ValidationError(`replay limit must be ${requirement}.`, {
     issues: [{ path: "limit", message: `Got ${String(resolved)}.` }],
   });
+}
+
+/**
+ * The typed refusal `walkClassLineage` throws when
+ * {@link IDENTITY_REPLAY_WALK_ROW_CEILING} is exceeded. Exported (module
+ * path only, not through a package barrel — mirrors how `readIdentityTransitions`
+ * is imported "by module path directly" in transition-log.ts's own tests) so
+ * a unit test can assert its `code`, `ceiling` detail, and suggestion string
+ * directly, without constructing a lineage large enough to trigger it for
+ * real.
+ */
+export function identityReplayWalkIncompleteError(
+  ceiling: number,
+): IdentityReplayError {
+  return new IdentityReplayError(
+    "Identity replay's lineage walk accumulated more transition rows than its internal safety ceiling allows, so completeness cannot be guaranteed.",
+    { code: "IDENTITY_REPLAY_WALK_INCOMPLETE", ceiling },
+    {
+      suggestion:
+        "Prune older transitions with pruneIdentityTransitions. Narrowing fromRecorded/toRecorded does not help: lineage discovery reads the whole log on purpose, so that a window can never hide the notes that name a class.",
+    },
+  );
 }
 
 /**
@@ -538,9 +614,11 @@ export async function identityReplay<G extends GraphDef>(
   // are therefore built ONLY from this graph's own (never restored) rows;
   // `transitionsOf` (no such filter) remains the complete answer for "what
   // changed and why". Filtering the boundary set itself — not merely the
-  // rows matched at each boundary — also means the next NATIVE boundary
-  // computes its own fresh `before` here (`previousAfter` never chains
-  // through a boundary that held only restored rows).
+  // rows matched at each boundary — also means `previousAfter` is only ever
+  // set from a `reconstructAt` at a revision THIS graph allocated: a
+  // restored-only boundary is dropped from `boundaries` entirely, so it can
+  // never overwrite `previousAfter` with a reconstruction at a foreign
+  // revision, and the next NATIVE boundary's `before` stays sound.
   const nativeRows = rows.filter((row) => !isRestoredTransitionRow(row));
   const boundaries = distinctBoundaries(nativeRows);
 

--- a/packages/typegraph/src/identity/replay.ts
+++ b/packages/typegraph/src/identity/replay.ts
@@ -59,6 +59,25 @@ export type IdentityTransition<G extends GraphDef> = Readonly<{
   priorClass?: IdentityNodeReference<G> | undefined;
   assertionIds: readonly IdentityAssertionId[];
   decision?: IdentityDecisionProvenance | undefined;
+  /**
+   * Present when an ARCHIVAL RESTORE inserted this row into the graph being
+   * read, rather than this graph's own history capture recording it — the
+   * public face of the internal marker `isRestoredTransitionRow` reads. An
+   * audit surface uses it to tell an imported explanation from a locally
+   * replayable event: `replay` deliberately excludes every restored
+   * transition from `steps` (a restored row's `recorded` revision was minted
+   * by the SOURCE graph's clock and interleaves arbitrarily with this
+   * graph's, so no before/after could be reconstructed for it honestly),
+   * while `transitionsOf` returns it like any other.
+   *
+   * `at` is the destination graph's WALL CLOCK at restore time, not a
+   * {@link RecordedInstant}: a restore records history, it does not relive
+   * it, so it never advances this graph's recorded revision counter and
+   * there is no revision on this graph's own axis to pair the timestamp
+   * with. The coarser retention watermark (`truncatedBefore`) is the only
+   * revision-shaped signal a restore leaves behind.
+   */
+  restored?: Readonly<{ at: string }> | undefined;
 }>;
 
 export type IdentityReplayStep<G extends GraphDef> = Readonly<{
@@ -115,6 +134,9 @@ function publicTransition<G extends GraphDef>(
       ),
     assertionIds: row.assertion_ids as readonly IdentityAssertionId[],
     decision: row.decision,
+    ...(row.restored_at === undefined ?
+      {}
+    : { restored: { at: row.restored_at } }),
   };
 }
 

--- a/packages/typegraph/src/identity/replay.ts
+++ b/packages/typegraph/src/identity/replay.ts
@@ -307,21 +307,33 @@ async function reconstructAt<G extends GraphDef>(
   return found.visible.map((ref) => publicNodeRef<G>(ref));
 }
 
+function invalidReplayLimitError(
+  requirement: string,
+  resolved: number,
+): ValidationError {
+  return new ValidationError(`replay limit must be ${requirement}.`, {
+    issues: [{ path: "limit", message: `Got ${String(resolved)}.` }],
+  });
+}
+
+/**
+ * A page size must be a whole number of at least one. The lower bound is not
+ * decoration: {@link pageBoundaries} cuts the page at `boundaries[limit]`, so
+ * `limit: 0` would hand back an empty page whose `nextFrom` names the very
+ * first boundary — re-issuing with that cursor returns the identical empty
+ * page forever, and the documented `while (cursor !== undefined)` paging loop
+ * never terminates. A fractional limit indexes past a boundary that is not
+ * there and escapes as a bare `TypeError` from `requireDefined`.
+ */
 function resolveLimit(limit: number | undefined): number {
   const resolved = limit ?? IDENTITY_REPLAY_DEFAULT_LIMIT;
-  if (resolved > IDENTITY_REPLAY_MAX_LIMIT) {
-    throw new ValidationError(
-      `replay limit must be at most ${String(IDENTITY_REPLAY_MAX_LIMIT)}.`,
-      {
-        issues: [
-          {
-            path: "limit",
-            message: `Got ${String(resolved)}.`,
-          },
-        ],
-      },
+  if (!Number.isInteger(resolved) || resolved < 1)
+    throw invalidReplayLimitError("an integer of at least 1", resolved);
+  if (resolved > IDENTITY_REPLAY_MAX_LIMIT)
+    throw invalidReplayLimitError(
+      `at most ${String(IDENTITY_REPLAY_MAX_LIMIT)}`,
+      resolved,
     );
-  }
   return resolved;
 }
 

--- a/packages/typegraph/src/identity/replay.ts
+++ b/packages/typegraph/src/identity/replay.ts
@@ -46,7 +46,7 @@ import {
   type IdentityNodeRefInput,
 } from "./types";
 
-/** Default and maximum boundary counts a single `replay` call returns. */
+/** Default and maximum boundary counts a single `replay` PAGE returns. */
 export const IDENTITY_REPLAY_DEFAULT_LIMIT = 200;
 export const IDENTITY_REPLAY_MAX_LIMIT = 2000;
 
@@ -67,10 +67,31 @@ export type IdentityReplayStep<G extends GraphDef> = Readonly<{
   after: readonly IdentityNodeReference<G>[];
 }>;
 
+/**
+ * The continuation cursor a paged transition read hands back: the recorded
+ * instant of the first BOUNDARY the page did not include, or `undefined` when
+ * the page reached the end of the lineage. Pass it back as `fromRecorded` to
+ * read the next page — `fromRecorded` is inclusive, so the boundary this
+ * names opens the next page exactly once.
+ */
+type PagedTransitions = Readonly<{
+  rows: readonly IdentityTransitionRow[];
+  nextFrom?: RecordedInstant | undefined;
+}>;
+
 export type IdentityReplay<G extends GraphDef> = Readonly<{
   steps: readonly IdentityReplayStep<G>[];
   /** Set when the retention watermark cut history above the requested start. */
   truncatedBefore?: RecordedInstant | undefined;
+  /** Set when `limit` capped this page; pass it as `fromRecorded` for the next one. */
+  nextFrom?: RecordedInstant | undefined;
+}>;
+
+/** One page of {@link identityTransitionsOf}'s answer. */
+export type IdentityTransitionHistory<G extends GraphDef> = Readonly<{
+  transitions: readonly IdentityTransition<G>[];
+  /** Set when `limit` capped this page; pass it as `fromRecorded` for the next one. */
+  nextFrom?: RecordedInstant | undefined;
 }>;
 
 export type IdentityReplayOptions = Readonly<{
@@ -135,11 +156,10 @@ async function currentClassCanonicalSeed<G extends GraphDef>(
 
 /**
  * Generous internal ceiling for the seed-lineage walk's OWN reads (never the
- * caller's `limit`, which is enforced once, on the fully-converged result
- * below): a round that truncated its read before the seed set converged
- * could hide the very rows that would have grown that set, silently
- * returning an incomplete lineage instead of the caller's requested
- * `IDENTITY_REPLAY_LIMIT_EXCEEDED` refusal.
+ * caller's `limit`, which caps the PAGE assembled from the fully-converged
+ * result below): a round that truncated its read before the seed set
+ * converged could hide the very rows that would have grown that set,
+ * silently returning an incomplete lineage instead of a typed refusal.
  */
 const IDENTITY_REPLAY_WALK_READ_CEILING = 100_000;
 
@@ -149,12 +169,25 @@ const IDENTITY_REPLAY_WALK_READ_CEILING = 100_000;
  * known set of class keys (forward AND reverse — a note's `class` or
  * `priorClass`), adding any newly discovered keys, until a round adds
  * nothing new.
+ *
+ * DISCOVERY IS UNBOUNDED BY THE CALLER'S WINDOW, deliberately: the seed set
+ * has to reach every class name the node ever carried before any window can
+ * be applied to the result. A class key enters the set only by appearing on
+ * some note, and the note that names it can sit anywhere on the recorded
+ * axis — typically ABOVE the requested window, since the walk starts from
+ * the node's CURRENT canonical and works backwards through `priorClass`
+ * hops. Scoping the read by the caller's `fromRecorded`/`toRecorded` cut
+ * exactly those hops and silently returned an empty lineage for a window
+ * whose transitions were sitting in the log: B and C merge at revision 1, A
+ * joins and becomes canonical at revision 2, and a walk bounded at revision
+ * 1 never sees the revision-2 note that would have taught it B's name.
+ * `readIdentityTransitions` therefore takes no revision bounds at all
+ * (transition-log.ts) — the window is applied once, by
+ * {@link windowedRows}, to the converged result.
  */
 async function walkClassLineage<G extends GraphDef>(
   ctx: IdentityServiceContext<G>,
   seed: PlainNodeRef,
-  fromRevision: number | undefined,
-  toRevision: number | undefined,
 ): Promise<readonly IdentityTransitionRow[]> {
   const seeds = new Map<string, PlainNodeRef>([[refKey(seed), seed]]);
   for (;;) {
@@ -165,8 +198,6 @@ async function walkClassLineage<G extends GraphDef>(
       ctx.graphId,
       {
         classRefs: scopeReferences,
-        fromRevision,
-        toRevision,
         limit: IDENTITY_REPLAY_WALK_READ_CEILING,
       },
     );
@@ -184,7 +215,7 @@ async function walkClassLineage<G extends GraphDef>(
         },
         {
           suggestion:
-            "Narrow fromRecorded/toRecorded to shrink the scanned range, or prune older transitions with pruneIdentityTransitions.",
+            "Prune older transitions with pruneIdentityTransitions. Narrowing fromRecorded/toRecorded does not help: lineage discovery reads the whole log on purpose, so that a window can never hide the notes that name a class.",
         },
       );
     }
@@ -287,41 +318,49 @@ function distinctBoundaries(
   );
 }
 
-function identityReplayLimitExceededError(
+/** Applies the caller's recorded window to the fully-discovered lineage — the ONE place `fromRecorded`/`toRecorded` narrow anything, since discovery itself must stay unbounded (see {@link walkClassLineage}). */
+function windowedRows(
   rows: readonly IdentityTransitionRow[],
-  boundaries: readonly number[],
+  fromRevision: number | undefined,
+  toRevision: number | undefined,
+): readonly IdentityTransitionRow[] {
+  return rows.filter(
+    (row) =>
+      (fromRevision === undefined || row.recorded_revision >= fromRevision) &&
+      (toRevision === undefined || row.recorded_revision <= toRevision),
+  );
+}
+
+/**
+ * Cuts the windowed lineage into one page of at most `limit` BOUNDARIES
+ * (distinct recorded revisions), not `limit` rows — §3.2 step 3 counts
+ * boundaries, and every note sharing a boundary shares one replay step, so a
+ * row-counted page could split a single step's rows across two pages.
+ *
+ * `nextFrom` names the first boundary this page did NOT include, so a caller
+ * pages by re-issuing the identical call with `fromRecorded: nextFrom`
+ * (`fromRecorded` is inclusive). One owner for both `transitionsOf` and
+ * `replay`: they page identically, or a caller pairing an explanation from
+ * one with a membership step from the other would see the two disagree about
+ * where the page ended.
+ */
+function pageBoundaries(
+  rows: readonly IdentityTransitionRow[],
   limit: number,
-): IdentityReplayError {
+): PagedTransitions {
+  const boundaries = distinctBoundaries(rows);
+  if (boundaries.length <= limit) return { rows };
   const cutoffRevision = requireDefined(boundaries[limit]);
   const cutoffRow = requireDefined(
     rows.find((row) => row.recorded_revision === cutoffRevision),
   );
-  return new IdentityReplayError(
-    `Identity replay found more transition boundaries than the requested limit (${String(limit)}).`,
-    {
-      code: "IDENTITY_REPLAY_LIMIT_EXCEEDED",
-      limit,
-      resumeFromRecorded: createRecordedInstant(
-        cutoffRow.recorded_revision,
-        cutoffRow.recorded_at,
-      ),
-    },
-    {
-      suggestion:
-        "Pass a larger limit, or page by re-calling with fromRecorded set to details.resumeFromRecorded.",
-    },
-  );
-}
-
-/** Throws `IDENTITY_REPLAY_LIMIT_EXCEEDED` when the walk found more DISTINCT boundaries (recorded revisions) than `limit` allows — §3.2 step 3 compares boundary count, not raw row count. */
-function assertBoundaryLimit(
-  rows: readonly IdentityTransitionRow[],
-  limit: number,
-): void {
-  const boundaries = distinctBoundaries(rows);
-  if (boundaries.length > limit) {
-    throw identityReplayLimitExceededError(rows, boundaries, limit);
-  }
+  return {
+    rows: rows.filter((row) => row.recorded_revision < cutoffRevision),
+    nextFrom: createRecordedInstant(
+      cutoffRow.recorded_revision,
+      cutoffRow.recorded_at,
+    ),
+  };
 }
 
 function identityReplayHistoryTruncatedError(
@@ -348,18 +387,23 @@ type WalkedTransitions = Readonly<{
   seed: PlainNodeRef;
   fromRevision: number | undefined;
   toRevision: number | undefined;
-  limit: number;
   rows: readonly IdentityTransitionRow[];
+  nextFrom?: RecordedInstant | undefined;
 }>;
 
 /**
  * The shared setup both `identityTransitionsOf` and `identityReplay` need
  * before they diverge: enforce `history: true`, resolve the requested limit
- * and revision bounds, seed and run the lineage walk (§3.2 step 2), and
- * enforce the boundary-count limit (§3.2 step 3) on the result. `seed` is the
- * caller's ORIGINAL reference (not the resolved class canonical), for
- * `identityReplay`'s `reconstructAt` calls — see that function's docblock for
- * why the two must not be conflated.
+ * and revision bounds, seed and run the lineage walk (§3.2 step 2), narrow
+ * the converged result to the requested window, and cut it into one page of
+ * at most `limit` boundaries (§3.2 step 3). `seed` is the caller's ORIGINAL
+ * reference (not the resolved class canonical), for `identityReplay`'s
+ * `reconstructAt` calls — see that function's docblock for why the two must
+ * not be conflated.
+ *
+ * The three stages are ordered and cannot be reshuffled: discovery must run
+ * unbounded, the window applies to what discovery found, and the page is cut
+ * from what the window kept.
  */
 async function walkedTransitionsFor<G extends GraphDef>(
   ctx: IdentityServiceContext<G>,
@@ -378,22 +422,35 @@ async function walkedTransitionsFor<G extends GraphDef>(
     options?.toRecorded === undefined ?
       undefined
     : requireTypeGraphRecordedRevision(options.toRecorded, "toRecorded");
-  const rows = await walkClassLineage(ctx, walkSeed, fromRevision, toRevision);
-  assertBoundaryLimit(rows, limit);
-  return { seed, fromRevision, toRevision, limit, rows };
+  const discovered = await walkClassLineage(ctx, walkSeed);
+  const page = pageBoundaries(
+    windowedRows(discovered, fromRevision, toRevision),
+    limit,
+  );
+  return {
+    seed,
+    fromRevision,
+    toRevision,
+    rows: page.rows,
+    ...(page.nextFrom === undefined ? {} : { nextFrom: page.nextFrom }),
+  };
 }
 
 /**
  * Every transition touching `ref`'s class lineage, ascending by recorded
- * revision. `store.identity.transitionsOf` is a thin wrapper over this.
+ * revision, in pages of at most `limit` boundaries.
+ * `store.identity.transitionsOf` is a thin wrapper over this.
  */
 export async function identityTransitionsOf<G extends GraphDef>(
   ctx: IdentityServiceContext<G>,
   ref: IdentityNodeRefInput<G>,
   options?: IdentityReplayOptions,
-): Promise<readonly IdentityTransition<G>[]> {
-  const { rows } = await walkedTransitionsFor(ctx, ref, options);
-  return rows.map((row) => publicTransition<G>(row));
+): Promise<IdentityTransitionHistory<G>> {
+  const { rows, nextFrom } = await walkedTransitionsFor(ctx, ref, options);
+  return {
+    transitions: rows.map((row) => publicTransition<G>(row)),
+    ...(nextFrom === undefined ? {} : { nextFrom }),
+  };
 }
 
 /**
@@ -404,17 +461,21 @@ export async function identityTransitionsOf<G extends GraphDef>(
  * `IdentityTransitionCause`), so no membership-changing revision can fall
  * between two consecutive boundaries undetected. `store.identity.replay` is
  * a thin wrapper over this.
+ *
+ * Paged by boundary exactly as `transitionsOf` is: `nextFrom` names the first
+ * boundary this page stopped short of. Because the page is cut BEFORE
+ * restored rows are excluded, `steps` can be shorter than `limit` boundaries
+ * on a page whose lineage mixes restored and native rows — the page boundary
+ * stays identical between the two methods, which is what lets a caller pair
+ * a `transitionsOf` explanation with a `replay` step page for page.
  */
 export async function identityReplay<G extends GraphDef>(
   ctx: IdentityServiceContext<G>,
   ref: IdentityNodeRefInput<G>,
   options?: IdentityReplayOptions,
 ): Promise<IdentityReplay<G>> {
-  const { seed, fromRevision, toRevision, rows } = await walkedTransitionsFor(
-    ctx,
-    ref,
-    options,
-  );
+  const { seed, fromRevision, toRevision, rows, nextFrom } =
+    await walkedTransitionsFor(ctx, ref, options);
 
   const retention = await readTransitionRetentionDetails(
     ctx.backend,
@@ -475,5 +536,6 @@ export async function identityReplay<G extends GraphDef>(
   return {
     steps,
     ...(truncatedBefore === undefined ? {} : { truncatedBefore }),
+    ...(nextFrom === undefined ? {} : { nextFrom }),
   };
 }

--- a/packages/typegraph/src/identity/transition-log.ts
+++ b/packages/typegraph/src/identity/transition-log.ts
@@ -490,6 +490,39 @@ export type IdentityTransitionCursor = Readonly<{
   transitionId: string;
 }>;
 
+/**
+ * One owner for the `(recorded_revision, transition_id)` keyset predicate
+ * both transition-log readers page by: `readIdentityTransitions` (replay's
+ * fixed-point walk) and `readIdentityTransitionPageForInterchange` (archival
+ * export). `transitionIdKey` is the tie-break column wrapped in the same
+ * `binaryText` collation-safety seam both callers' `ORDER BY` uses — left
+ * bare, `>`/`ORDER BY` on that column would compare under the column's
+ * collation, which is locale-dependent on PostgreSQL and could disagree with
+ * each other on some inputs. `cursorFilter` is the empty fragment when
+ * `after` is `undefined`.
+ */
+function identityTransitionCursorSeam(
+  target: IdentityTarget,
+  after: IdentityTransitionCursor | undefined,
+): Readonly<{ transitionIdKey: SqlFragment; cursorFilter: SqlFragment }> {
+  const transitionIdKey = getDialect(target.dialect).binaryText(
+    sql`transition_id`,
+  );
+  const cursorFilter =
+    after === undefined ?
+      sql``
+    : sql`
+      AND (
+        recorded_revision > ${after.recordedRevision}
+        OR (
+          recorded_revision = ${after.recordedRevision}
+          AND ${transitionIdKey} > ${after.transitionId}
+        )
+      )
+    `;
+  return { transitionIdKey, cursorFilter };
+}
+
 export type IdentityTransitionReadScope = Readonly<{
   classRefs: readonly PlainNodeRef[];
   limit: number;
@@ -593,21 +626,10 @@ export async function readIdentityTransitions(
     ),
     sql` OR `,
   );
-  const transitionIdKey = getDialect(target.dialect).binaryText(
-    sql`transition_id`,
+  const { transitionIdKey, cursorFilter } = identityTransitionCursorSeam(
+    target,
+    scope.after,
   );
-  const cursorFilter =
-    scope.after === undefined ?
-      sql``
-    : sql`
-      AND (
-        recorded_revision > ${scope.after.recordedRevision}
-        OR (
-          recorded_revision = ${scope.after.recordedRevision}
-          AND ${transitionIdKey} > ${scope.after.transitionId}
-        )
-      )
-    `;
   const rows = await target.execute<RawIdentityTransitionRow>(
     asCompiledRowsSql(sql`
       SELECT ${IDENTITY_TRANSITION_COLUMNS}
@@ -656,21 +678,10 @@ export async function readIdentityTransitionPageForInterchange(
     limit: number;
   }>,
 ): Promise<IdentityTransitionPage> {
-  const transitionIdKey = getDialect(target.dialect).binaryText(
-    sql`transition_id`,
+  const { transitionIdKey, cursorFilter } = identityTransitionCursorSeam(
+    target,
+    options.after,
   );
-  const cursorFilter =
-    options.after === undefined ?
-      sql``
-    : sql`
-      AND (
-        recorded_revision > ${options.after.recordedRevision}
-        OR (
-          recorded_revision = ${options.after.recordedRevision}
-          AND ${transitionIdKey} > ${options.after.transitionId}
-        )
-      )
-    `;
   const rows = await target.execute<RawIdentityTransitionRow>(
     asCompiledRowsSql(sql`
       SELECT ${IDENTITY_TRANSITION_COLUMNS}

--- a/packages/typegraph/src/identity/transition-log.ts
+++ b/packages/typegraph/src/identity/transition-log.ts
@@ -484,9 +484,25 @@ export function toTransitionTransfer(
   };
 }
 
+/** A (recorded revision, transition id) keyset cursor, ordering ties by the transition id. */
+export type IdentityTransitionCursor = Readonly<{
+  recordedRevision: number;
+  transitionId: string;
+}>;
+
 export type IdentityTransitionReadScope = Readonly<{
   classRefs: readonly PlainNodeRef[];
   limit: number;
+  /**
+   * Keyset-pages the read strictly past this cursor, ordered the same way
+   * the result is (`recorded_revision` then `transition_id`) — pass the
+   * cursor built from the previous page's LAST row to read the next `limit`
+   * rows. `undefined` (the default) reads from the start. This is how
+   * `walkClassLineage`'s fixed-point walk (replay.ts) reads one round to
+   * exhaustion without a fixed per-round ceiling: it keeps requesting pages
+   * until a page comes back shorter than `limit`.
+   */
+  after?: IdentityTransitionCursor | undefined;
 }>;
 
 /**
@@ -518,9 +534,20 @@ export type IdentityTransitionReadScope = Readonly<{
  * (`deleteAssertionsTouchingKinds`, `loadCurrentStructuralClasses`) — a wide
  * lineage must hit a typed refusal, never the driver's own opaque
  * bind-variable-limit error. Each chunk is read with the full `scope.limit`
- * and the merged, deduplicated rows are re-sorted and re-truncated to that
- * same limit, so chunking never changes the result a single unchunked query
- * would have returned.
+ * (past `scope.after`, when given) and the merged, deduplicated rows are
+ * re-sorted and re-truncated to that same limit, so chunking never changes
+ * the result a single unchunked query would have returned.
+ *
+ * `scope.after` keyset-pages the result past a prior page's last row: the
+ * caller (`walkClassLineage`, replay.ts) reads one fixed-point round to
+ * exhaustion by re-issuing this call with `after` set to the previous page's
+ * last row until a page comes back shorter than `scope.limit`, rather than
+ * capping the round at a fixed row ceiling. The tie-break column
+ * (`transition_id`) goes through the same `binaryText` collation-safety seam
+ * `readIdentityTransitionPageForInterchange` uses, for the same reason: left
+ * bare, `>` on that column would compare under the column's collation, which
+ * is locale-dependent on PostgreSQL and would disagree with the ORDER BY's
+ * own comparison of the same rows on some inputs.
  */
 export async function readIdentityTransitions(
   target: IdentityTarget,
@@ -530,7 +557,7 @@ export async function readIdentityTransitions(
 ): Promise<readonly IdentityTransitionRow[]> {
   if (scope.classRefs.length === 0) return [];
   const chunkSize = identityChunkSize(target, {
-    fixedParameters: 4,
+    fixedParameters: scope.after === undefined ? 4 : 6,
     maxItems: MAX_REFERENCE_CHUNK_SIZE,
     parametersPerItem: 4,
   });
@@ -566,24 +593,34 @@ export async function readIdentityTransitions(
     ),
     sql` OR `,
   );
+  const transitionIdKey = getDialect(target.dialect).binaryText(
+    sql`transition_id`,
+  );
+  const cursorFilter =
+    scope.after === undefined ?
+      sql``
+    : sql`
+      AND (
+        recorded_revision > ${scope.after.recordedRevision}
+        OR (
+          recorded_revision = ${scope.after.recordedRevision}
+          AND ${transitionIdKey} > ${scope.after.transitionId}
+        )
+      )
+    `;
   const rows = await target.execute<RawIdentityTransitionRow>(
     asCompiledRowsSql(sql`
       SELECT ${IDENTITY_TRANSITION_COLUMNS}
       FROM ${schema.identityTransitionsTable}
       WHERE graph_id = ${graphId}
         AND (${classMatches} OR ${priorMatches})
-      ORDER BY recorded_revision ASC, transition_id ASC
+        ${cursorFilter}
+      ORDER BY recorded_revision ASC, ${transitionIdKey} ASC
       LIMIT ${scope.limit}
     `),
   );
   return rows.map((row) => normalizeIdentityTransitionRow(row));
 }
-
-/** A (recorded revision, transition id) keyset cursor, ordering ties by the transition id. */
-export type IdentityTransitionCursor = Readonly<{
-  recordedRevision: number;
-  transitionId: string;
-}>;
 
 export type IdentityTransitionPage = Readonly<{
   transitions: readonly IdentityTransitionRow[];

--- a/packages/typegraph/src/identity/transition-log.ts
+++ b/packages/typegraph/src/identity/transition-log.ts
@@ -486,8 +486,6 @@ export function toTransitionTransfer(
 
 export type IdentityTransitionReadScope = Readonly<{
   classRefs: readonly PlainNodeRef[];
-  fromRevision?: number | undefined;
-  toRevision?: number | undefined;
   limit: number;
 }>;
 
@@ -505,6 +503,14 @@ export type IdentityTransitionReadScope = Readonly<{
  * one boundary shares the same `before`/`after` step in replay — but a
  * future reader that does must not assume this ordering reflects buffering
  * order.
+ *
+ * TAKES NO RECORDED-REVISION BOUNDS, on purpose. Its one caller is replay's
+ * fixed-point lineage walk, whose seed set has to reach every class name the
+ * node ever carried — and the note that teaches the walk a name routinely
+ * sits ABOVE the window the caller asked about, because the walk starts at
+ * the node's CURRENT canonical and hops backwards through `priorClass`. A
+ * bounded read cut exactly those hops. The caller's `fromRecorded` /
+ * `toRecorded` are applied once, to the converged lineage, by `replay.ts`.
  *
  * `scope.classRefs` is chunked through the shared bind-budget helper (each
  * reference costs four bind parameters: kind+id in the forward match, kind+id
@@ -560,22 +566,12 @@ export async function readIdentityTransitions(
     ),
     sql` OR `,
   );
-  const fromFilter =
-    scope.fromRevision === undefined ?
-      sql``
-    : sql`AND recorded_revision >= ${scope.fromRevision}`;
-  const toFilter =
-    scope.toRevision === undefined ?
-      sql``
-    : sql`AND recorded_revision <= ${scope.toRevision}`;
   const rows = await target.execute<RawIdentityTransitionRow>(
     asCompiledRowsSql(sql`
       SELECT ${IDENTITY_TRANSITION_COLUMNS}
       FROM ${schema.identityTransitionsTable}
       WHERE graph_id = ${graphId}
         AND (${classMatches} OR ${priorMatches})
-        ${fromFilter}
-        ${toFilter}
       ORDER BY recorded_revision ASC, transition_id ASC
       LIMIT ${scope.limit}
     `),

--- a/packages/typegraph/src/identity/types.ts
+++ b/packages/typegraph/src/identity/types.ts
@@ -14,7 +14,7 @@ import {
 import {
   type IdentityReplay,
   type IdentityReplayOptions,
-  type IdentityTransition,
+  type IdentityTransitionHistory,
 } from "./replay";
 
 /**
@@ -197,8 +197,11 @@ export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> &
     /**
      * Every transition (assertion, retraction, fold, deletion, restore,
      * window end, kind drop, or reconciliation decision) that changed
-     * `ref`'s identity class, ascending by recorded revision. Requires the
-     * store to be opened with `history: true`.
+     * `ref`'s identity class, ascending by recorded revision, in pages of at
+     * most `options.limit` boundaries (default 200, maximum 2000). A capped
+     * page carries `nextFrom`, the recorded instant of the first boundary it
+     * stopped short of: pass it back as `options.fromRecorded` for the next
+     * page. Requires the store to be opened with `history: true`.
      *
      * On `tx.identity` specifically: reads the transition log itself, which
      * — unlike every other read on this facade — is NOT read-your-writes
@@ -215,12 +218,14 @@ export type IdentityFacade<G extends GraphDef> = IdentityReadFacade<G> &
     transitionsOf: (
       ref: IdentityNodeRefInput<G>,
       options?: IdentityReplayOptions,
-    ) => Promise<readonly IdentityTransition<G>[]>;
+    ) => Promise<IdentityTransitionHistory<G>>;
     /**
      * Pairs every transition touching `ref`'s identity class lineage with the
      * class membership immediately before and after it, reconstructed through
-     * the same historical reader `asOf` / `asOfRecorded` reads use. Requires
-     * the store to be opened with `history: true`.
+     * the same historical reader `asOf` / `asOfRecorded` reads use. Pages by
+     * boundary exactly as {@link IdentityFacade.transitionsOf} does, through
+     * the same `nextFrom` cursor. Requires the store to be opened with
+     * `history: true`.
      *
      * On `tx.identity`: carries the same pending-notes caveat as
      * {@link IdentityFacade.transitionsOf} — a transition noted earlier in

--- a/packages/typegraph/src/index.ts
+++ b/packages/typegraph/src/index.ts
@@ -137,6 +137,7 @@ export {
   // `StoreRuntime.readIdentityTransitionPageAtTarget` /
   // `importIdentityTransitionsAtTarget`, named so the port is implementable.
   type IdentityTransitionCursor,
+  type IdentityTransitionHistory,
   type IdentityTransitionTransfer,
   type IdentityValidityWindow,
   type IdentityWriteSummary,

--- a/packages/typegraph/tests/backends/integration/identity-replay.ts
+++ b/packages/typegraph/tests/backends/integration/identity-replay.ts
@@ -118,5 +118,49 @@ export function registerIdentityReplayIntegrationTests(
         liveMembers.map((ref) => ref.id).toSorted(),
       );
     });
+
+    // Discovery-vs-window and boundary paging on EVERY backend: both moved
+    // out of the reader's SQL (which no longer takes revision bounds at all)
+    // and into `replay.ts`, so the shared suite is where the two dialects are
+    // pinned to the same answer rather than each certifying its own.
+    it("discovers lineage outside the requested window, and pages by boundary through nextFrom", async () => {
+      const store = await provisionIdentityReplayStore(context);
+      const a = { kind: "Person" as const, id: "page-a" };
+      const b = { kind: "Person" as const, id: "page-b" };
+      const c = { kind: "Person" as const, id: "page-c" };
+      await store.nodes.Person.create({}, { id: a.id });
+      await store.nodes.Person.create({}, { id: b.id });
+      await store.nodes.Person.create({}, { id: c.id });
+
+      await store.identity.assertSame(b, c);
+      const throughFirstMerge = requireDefined(await store.recordedNow());
+      await store.identity.assertSame(a, b);
+
+      // `a` is the class canonical now, and no note at or below the first
+      // merge names it — only an unbounded walk can reach that boundary.
+      const windowed = await store.identity.transitionsOf(b, {
+        toRecorded: throughFirstMerge,
+      });
+      expect(windowed.transitions.length).toBeGreaterThan(0);
+
+      const whole = await store.identity.transitionsOf(a);
+      expect(whole.nextFrom).toBeUndefined();
+      const boundaries = new Set(
+        whole.transitions.map((transition) => transition.recorded),
+      );
+      expect(boundaries.size).toBeGreaterThan(1);
+
+      const firstPage = await store.identity.transitionsOf(a, { limit: 1 });
+      expect(firstPage.nextFrom).toBeDefined();
+      const secondPage = await store.identity.transitionsOf(a, {
+        limit: 1,
+        fromRecorded: requireDefined(firstPage.nextFrom),
+      });
+      expect(
+        secondPage.transitions.map((transition) => transition.transitionId),
+      ).not.toEqual(
+        firstPage.transitions.map((transition) => transition.transitionId),
+      );
+    });
   });
 }

--- a/packages/typegraph/tests/backends/integration/identity-replay.ts
+++ b/packages/typegraph/tests/backends/integration/identity-replay.ts
@@ -132,9 +132,13 @@ export function registerIdentityReplayIntegrationTests(
       await store.nodes.Person.create({}, { id: b.id });
       await store.nodes.Person.create({}, { id: c.id });
 
-      await store.identity.assertSame(b, c);
+      const firstMerge = await store.identity.assertSame(b, c);
       const throughFirstMerge = requireDefined(await store.recordedNow());
       await store.identity.assertSame(a, b);
+      // Four boundaries, not two: a page size of 1 has to be cut three times
+      // for reassembly to be able to catch a cursor that skips one.
+      await store.identity.retractAssertion(firstMerge.assertion.id);
+      await store.identity.assertSame(b, c);
 
       // `a` is the class canonical now, and no note at or below the first
       // merge names it — only an unbounded walk can reach that boundary.
@@ -148,18 +152,33 @@ export function registerIdentityReplayIntegrationTests(
       const boundaries = new Set(
         whole.transitions.map((transition) => transition.recorded),
       );
-      expect(boundaries.size).toBeGreaterThan(1);
+      expect(boundaries.size).toBeGreaterThan(2);
 
-      const firstPage = await store.identity.transitionsOf(a, { limit: 1 });
-      expect(firstPage.nextFrom).toBeDefined();
-      const secondPage = await store.identity.transitionsOf(a, {
-        limit: 1,
-        fromRecorded: requireDefined(firstPage.nextFrom),
-      });
-      expect(
-        secondPage.transitions.map((transition) => transition.transitionId),
-      ).not.toEqual(
-        firstPage.transitions.map((transition) => transition.transitionId),
+      // Reassembly, not merely "the second page differs from the first": a
+      // cursor that skipped a boundary, or a page that came back empty,
+      // satisfies "differs" and fails here. This is also the one place a
+      // dialect-decoded `recorded_at` (PostgreSQL hands back a timestamptz,
+      // SQLite a text column) round-trips back in through `fromRecorded`.
+      const paged: string[] = [];
+      let cursor: string | undefined;
+      for (let page = 0; page <= boundaries.size; page += 1) {
+        const result = await store.identity.transitionsOf(a, {
+          limit: 1,
+          ...(cursor === undefined ? {} : { fromRecorded: cursor }),
+        });
+        expect(
+          new Set(result.transitions.map((transition) => transition.recorded))
+            .size,
+        ).toBe(1);
+        paged.push(
+          ...result.transitions.map((transition) => transition.transitionId),
+        );
+        cursor = result.nextFrom;
+        if (cursor === undefined) break;
+      }
+      expect(cursor).toBeUndefined();
+      expect(paged).toEqual(
+        whole.transitions.map((transition) => transition.transitionId),
       );
     });
   });

--- a/packages/typegraph/tests/backends/integration/identity.ts
+++ b/packages/typegraph/tests/backends/integration/identity.ts
@@ -852,7 +852,8 @@ export function registerIdentityIntegrationTests(
       // `transitionsOf` answers fully (restore is complete); none of the
       // RESTORED transitions may surface as a `replay` step — that would
       // pair a foreign transition with a fabricated before/after.
-      const targetTransitions = await target.identity.transitionsOf(a);
+      const { transitions: targetTransitions } =
+        await target.identity.transitionsOf(a);
       expect(targetTransitions.length).toBeGreaterThanOrEqual(
         sourceTransitions.length,
       );
@@ -875,7 +876,7 @@ export function registerIdentityIntegrationTests(
       });
       expect(secondImport.success).toBe(true);
       expect(secondImport.errors).toEqual([]);
-      const targetTransitionsAfterSecond =
+      const { transitions: targetTransitionsAfterSecond } =
         await target.identity.transitionsOf(a);
       expect(targetTransitionsAfterSecond.length).toBe(
         targetTransitions.length,

--- a/packages/typegraph/tests/backends/postgres/pglite-identity-transition-log.test.ts
+++ b/packages/typegraph/tests/backends/postgres/pglite-identity-transition-log.test.ts
@@ -48,7 +48,7 @@ describe("identity transition log on PGlite (PostgreSQL dialect)", () => {
       );
 
       const ctx = storeRuntime(store).identityContext();
-      const transitions = await identityTransitionsOf(ctx, {
+      const { transitions } = await identityTransitionsOf(ctx, {
         kind: "Person",
         id: alice.id,
       });

--- a/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
+++ b/packages/typegraph/tests/graph-merge/identity-reconciliation.test.ts
@@ -117,7 +117,7 @@ describe.each(backendMatrix())(
       expect(applied.data.merged.identity.asserted).toBe(1);
 
       const ctx = storeRuntime(target).identityContext();
-      const transitions = await identityTransitionsOf(ctx, {
+      const { transitions } = await identityTransitionsOf(ctx, {
         kind: "Person",
         id: "ada",
       });
@@ -185,7 +185,7 @@ describe.each(backendMatrix())(
         }
 
         const ctx = storeRuntime(target).identityContext();
-        const transitions = await identityTransitionsOf(ctx, {
+        const { transitions } = await identityTransitionsOf(ctx, {
           kind: "Person",
           id: "ada",
         });
@@ -263,7 +263,7 @@ describe.each(backendMatrix())(
       ]);
 
       const ctx = storeRuntime(target).identityContext();
-      const transitions = await identityTransitionsOf(ctx, {
+      const { transitions } = await identityTransitionsOf(ctx, {
         kind: "Person",
         id: "ada",
       });

--- a/packages/typegraph/tests/identity-import-hardening.test.ts
+++ b/packages/typegraph/tests/identity-import-hardening.test.ts
@@ -420,7 +420,8 @@ describe("archival identity import window bounds", () => {
     await source.identity.retractAssertion(first.assertion.id);
     await source.identity.assertSame(alice, bob);
 
-    const sourceTransitions = await source.identity.transitionsOf(alice);
+    const { transitions: sourceTransitions } =
+      await source.identity.transitionsOf(alice);
     expect(sourceTransitions.length).toBeGreaterThanOrEqual(3);
     expect(sourceTransitions.map((transition) => transition.cause)).toEqual(
       expect.arrayContaining(["assert", "retract"]),
@@ -452,7 +453,8 @@ describe("archival identity import window bounds", () => {
     // merge on the target, and that generates its own new "assert" note on
     // top of the transplanted explanatory history, exactly as any other
     // identity-affecting write would.
-    const targetTransitions = await target.identity.transitionsOf(alice);
+    const { transitions: targetTransitions } =
+      await target.identity.transitionsOf(alice);
     expect(targetTransitions.length).toBeGreaterThanOrEqual(
       sourceTransitions.length,
     );
@@ -688,7 +690,8 @@ describe("archival identity import window bounds", () => {
 
     const alice = { kind: "Person" as const, id: "alice" };
     // `transitionsOf` (unaffected by the watermark) still answers fully.
-    const targetTransitions = await target.identity.transitionsOf(alice);
+    const { transitions: targetTransitions } =
+      await target.identity.transitionsOf(alice);
     expect(targetTransitions.length).toBeGreaterThanOrEqual(
       sourceTransitions.length,
     );
@@ -761,7 +764,8 @@ describe("archival identity import window bounds", () => {
     // `transitionsOf` still answers fully — the restore itself is complete.
     // (Archival mode ALSO imports the current assertion as live truth, which
     // notes one native transition of its own, so this is `>=`, not `==`.)
-    const targetTransitions = await target.identity.transitionsOf(alice);
+    const { transitions: targetTransitions } =
+      await target.identity.transitionsOf(alice);
     expect(targetTransitions.length).toBeGreaterThanOrEqual(
       sourceTransitions.length,
     );
@@ -882,7 +886,8 @@ describe("archival identity import window bounds", () => {
     });
     expect(firstImport.success).toBe(true);
     const alice = { kind: "Person" as const, id: "alice" };
-    const transitionsAfterFirst = await target.identity.transitionsOf(alice);
+    const { transitions: transitionsAfterFirst } =
+      await target.identity.transitionsOf(alice);
 
     const secondImport = await importGraph(target, archive, {
       onConflict: "skip",
@@ -890,7 +895,8 @@ describe("archival identity import window bounds", () => {
     expect(secondImport.success).toBe(true);
     expect(secondImport.errors).toEqual([]);
     // Verbatim restore of the SAME rows: re-importing must not duplicate them.
-    const transitionsAfterSecond = await target.identity.transitionsOf(alice);
+    const { transitions: transitionsAfterSecond } =
+      await target.identity.transitionsOf(alice);
     expect(transitionsAfterSecond.length).toBe(transitionsAfterFirst.length);
   });
 
@@ -990,7 +996,8 @@ describe("archival identity import window bounds", () => {
       { id: "bob" },
     );
     await source.identity.assertSame(alice, bob);
-    const sourceTransitions = await source.identity.transitionsOf(alice);
+    const { transitions: sourceTransitions } =
+      await source.identity.transitionsOf(alice);
     expect(sourceTransitions.length).toBeGreaterThan(0);
 
     const chunks: GraphInterchangeChunk[] = [];
@@ -1014,7 +1021,7 @@ describe("archival identity import window bounds", () => {
     expect(result.errors).toEqual([]);
     expect(result.success).toBe(true);
 
-    const targetStreamedTransitions =
+    const { transitions: targetStreamedTransitions } =
       await target.identity.transitionsOf(alice);
     const targetTransitionIds = new Set(
       targetStreamedTransitions.map((transition) => transition.transitionId),

--- a/packages/typegraph/tests/identity-import-hardening.test.ts
+++ b/packages/typegraph/tests/identity-import-hardening.test.ts
@@ -463,7 +463,28 @@ describe("archival identity import window bounds", () => {
     );
     for (const sourceTransition of sourceTransitions) {
       expect(targetTransitionIds.has(sourceTransition.transitionId)).toBe(true);
+      // Load-bearing (R-S4): the restore marker is PUBLIC on the transition,
+      // so an audit surface can tell an imported explanation (excluded from
+      // `replay`'s steps) from a locally replayable event without inferring
+      // it from a revision comparison — the inference the marker exists to
+      // replace. Mutation check: drop the `restored` spread from
+      // `publicTransition` (src/identity/replay.ts) and this expectation
+      // fails on the first restored id.
+      const restoredHere = targetTransitions.find(
+        (transition) =>
+          transition.transitionId === sourceTransition.transitionId,
+      );
+      expect(restoredHere?.restored?.at).toEqual(expect.any(String));
+      // ...and the SOURCE's own copy of the identical row is not marked:
+      // the marker names where the row was inserted, never what it explains.
+      expect(sourceTransition.restored).toBeUndefined();
     }
+    // The target's own post-restore note (the import's genuine merge) is
+    // native, so `restored` distinguishes rather than blanketing everything.
+    const nativeTargetTransitions = targetTransitions.filter(
+      (transition) => transition.restored === undefined,
+    );
+    expect(nativeTargetTransitions.length).toBeGreaterThan(0);
 
     // `replay`, by contrast, reports the seam honestly rather than silently
     // claiming a complete history: the restore set the watermark to the

--- a/packages/typegraph/tests/identity-replay.test.ts
+++ b/packages/typegraph/tests/identity-replay.test.ts
@@ -20,7 +20,7 @@ import {
   createRecordedInstant,
   recordedInstantRevision,
 } from "../src/core/temporal";
-import { IdentityReplayError } from "../src/errors";
+import { IdentityReplayError, ValidationError } from "../src/errors";
 import {
   IDENTITY_REPLAY_MAX_LIMIT,
   identityReplay,
@@ -82,6 +82,41 @@ describe("identity replay", () => {
         },
       ),
     ).rejects.toThrow();
+  });
+
+  // Load-bearing: a page size below 1, or a fractional one, is a typed
+  // refusal — never a page. Mutation check: drop the
+  // `!Number.isInteger(resolved) || resolved < 1` guard from `resolveLimit`
+  // (replay.ts) and every case below fails — `limit: 0` resolves to an empty
+  // page whose `nextFrom` names the FIRST boundary, so the documented
+  // `while (cursor !== undefined)` loop re-reads that same empty page
+  // forever, and the fractional cases escape as a bare `TypeError` from
+  // `requireDefined` instead of a `ValidationError`.
+  it("rejects a limit below 1 or fractional, so a page always advances the cursor", async () => {
+    const store = await buildAbcStore();
+    const a = { kind: "Person" as const, id: "a" };
+    const b = { kind: "Person" as const, id: "b" };
+    await store.identity.assertSame(a, b);
+    const ctx = storeRuntime(store).identityContext();
+
+    for (const limit of [0, -1, 0.5, 1.5]) {
+      await expect(identityTransitionsOf(ctx, a, { limit })).rejects.toThrow(
+        ValidationError,
+      );
+      await expect(identityReplay(ctx, a, { limit })).rejects.toThrow(
+        ValidationError,
+      );
+    }
+    await expect(
+      identityTransitionsOf(ctx, a, { limit: 0 }),
+    ).rejects.toMatchObject({
+      details: { issues: [{ path: "limit", message: "Got 0." }] },
+    });
+
+    // The smallest ACCEPTED page still moves: one boundary, and a cursor
+    // pointing past it.
+    const page = await identityTransitionsOf(ctx, a, { limit: 1 });
+    expect(page.transitions.length).toBeGreaterThan(0);
   });
 
   it("replays merge / split / re-merge: every step's before/after matches an independent asOfRecorded read", async () => {

--- a/packages/typegraph/tests/identity-replay.test.ts
+++ b/packages/typegraph/tests/identity-replay.test.ts
@@ -153,10 +153,120 @@ describe("identity replay", () => {
     await store.identity.assertSame(a, b);
 
     const ctx = storeRuntime(store).identityContext();
-    const transitions = await identityTransitionsOf(ctx, a);
+    const { transitions } = await identityTransitionsOf(ctx, a);
     const replay = await identityReplay(ctx, a);
     expect(replay.steps.map((step) => step.transition.transitionId)).toEqual(
       transitions.map((transition) => transition.transitionId),
+    );
+  });
+
+  // Load-bearing (R3): lineage DISCOVERY must ignore the caller's window.
+  // The seed set can only learn a class name from a note that mentions it,
+  // and the note that teaches it routinely sits ABOVE the window — the walk
+  // starts at the CURRENT canonical and hops backwards through `priorClass`.
+  // Mutation check: give `readIdentityTransitions` back its `fromRevision` /
+  // `toRevision` filters and pass the caller's bounds into
+  // `walkClassLineage` (its pre-R3 shape) — the walk from `a` then reads
+  // nothing at or below the first merge's revision, both `windowed` and
+  // `windowedReplay` come back empty, and the first two expectations here
+  // fail. `pnpm exec vitest run tests/identity-replay.test.ts --maxWorkers=2`.
+  it("R3: a windowed read discovers lineage the window itself cannot see", async () => {
+    const store = await buildAbcStore();
+    const a = { kind: "Person" as const, id: "a" };
+    const b = { kind: "Person" as const, id: "b" };
+    const c = { kind: "Person" as const, id: "c" };
+
+    // B and C merge FIRST. Every note at this boundary names the {b, c}
+    // class — `a` appears nowhere at or below it.
+    await store.identity.assertSame(b, c);
+    const throughFirstMerge = await store.recordedNow();
+    if (throughFirstMerge === undefined) {
+      throw new Error("expected a recorded instant");
+    }
+    // A joins and takes over as canonical (code-point-smallest member), so
+    // the walk from `b` now seeds on `a`.
+    await store.identity.assertSame(a, b);
+
+    const ctx = storeRuntime(store).identityContext();
+    const firstMergeRevision = recordedInstantRevision(throughFirstMerge);
+
+    const { transitions: windowed } = await identityTransitionsOf(ctx, b, {
+      toRecorded: throughFirstMerge,
+    });
+    expect(windowed.length).toBeGreaterThan(0);
+    const windowedReplay = await identityReplay(ctx, b, {
+      toRecorded: throughFirstMerge,
+    });
+    expect(windowedReplay.steps.length).toBeGreaterThan(0);
+
+    // The window still narrows the ANSWER — discovery being unbounded must
+    // not leak the later boundary back into the result.
+    for (const transition of windowed) {
+      expect(recordedInstantRevision(transition.recorded)).toBeLessThanOrEqual(
+        firstMergeRevision,
+      );
+    }
+    const { transitions: unbounded } = await identityTransitionsOf(ctx, b);
+    expect(unbounded.length).toBeGreaterThan(windowed.length);
+  });
+
+  // Load-bearing (R7): the boundary limit pages, it never refuses. Mutation
+  // check: make `pageBoundaries` (replay.ts) throw when
+  // `boundaries.length > limit` instead of cutting the page — every
+  // `limit: 1` call below rejects and the whole test fails.
+  it("R7: limit caps a page and hands back nextFrom, and the pages reassemble the whole lineage", async () => {
+    const store = await buildAbcStore();
+    const a = { kind: "Person" as const, id: "a" };
+    const b = { kind: "Person" as const, id: "b" };
+    const c = { kind: "Person" as const, id: "c" };
+    const same1 = await store.identity.assertSame(a, b);
+    await store.identity.assertSame(b, c);
+    await store.identity.retractAssertion(same1.assertion.id);
+    await store.identity.assertSame(a, b);
+
+    const ctx = storeRuntime(store).identityContext();
+    const { transitions: whole, nextFrom: wholeNextFrom } =
+      await identityTransitionsOf(ctx, a);
+    expect(wholeNextFrom).toBeUndefined();
+    const wholeBoundaries = new Set(
+      whole.map((transition) => transition.recorded),
+    );
+    expect(wholeBoundaries.size).toBeGreaterThan(2);
+
+    const paged: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page <= wholeBoundaries.size; page += 1) {
+      const result = await identityTransitionsOf(ctx, a, {
+        limit: 1,
+        ...(cursor === undefined ? {} : { fromRecorded: cursor }),
+      });
+      // Exactly one boundary per page, and the boundary the cursor named.
+      expect(
+        new Set(result.transitions.map((transition) => transition.recorded))
+          .size,
+      ).toBe(1);
+      paged.push(
+        ...result.transitions.map((transition) => transition.transitionId),
+      );
+      cursor = result.nextFrom;
+      if (cursor === undefined) break;
+    }
+    expect(cursor).toBeUndefined();
+    expect(paged).toEqual(whole.map((transition) => transition.transitionId));
+
+    // `replay` pages on the identical boundaries — the two must agree about
+    // where a page ended, or an audit view pairing them would drift.
+    const firstReplayPage = await identityReplay(ctx, a, { limit: 1 });
+    const firstTransitionPage = await identityTransitionsOf(ctx, a, {
+      limit: 1,
+    });
+    expect(firstReplayPage.nextFrom).toBe(firstTransitionPage.nextFrom);
+    expect(
+      firstReplayPage.steps.map((step) => step.transition.transitionId),
+    ).toEqual(
+      firstTransitionPage.transitions.map(
+        (transition) => transition.transitionId,
+      ),
     );
   });
 
@@ -284,13 +394,14 @@ describe("identity replay — public facade surface", () => {
     const b = { kind: "Person" as const, id: "b" };
     await store.identity.assertSame(a, b);
 
-    const storeTransitions = await store.identity.transitionsOf(a);
+    const { transitions: storeTransitions } =
+      await store.identity.transitionsOf(a);
     expect(storeTransitions.length).toBeGreaterThan(0);
     const storeReplay = await store.identity.replay(a);
     expect(storeReplay.steps.length).toBe(storeTransitions.length);
 
     await store.transaction(async (tx) => {
-      const txTransitions = await tx.identity.transitionsOf(a);
+      const { transitions: txTransitions } = await tx.identity.transitionsOf(a);
       expect(txTransitions).toEqual(storeTransitions);
       const txReplay = await tx.identity.replay(a);
       expect(txReplay).toEqual(storeReplay);

--- a/packages/typegraph/tests/identity-replay.test.ts
+++ b/packages/typegraph/tests/identity-replay.test.ts
@@ -24,6 +24,7 @@ import { IdentityReplayError, ValidationError } from "../src/errors";
 import {
   IDENTITY_REPLAY_MAX_LIMIT,
   identityReplay,
+  identityReplayWalkIncompleteError,
   identityTransitionsOf,
 } from "../src/identity/replay";
 import { pruneIdentityTransitionsForContext } from "../src/identity/transition-log";
@@ -410,6 +411,25 @@ describe("identity replay", () => {
         error.details.requestedTo === beforePruneRecorded
       );
     });
+  });
+
+  // Load-bearing: `IDENTITY_REPLAY_WALK_INCOMPLETE`'s code, `ceiling` detail,
+  // and suggestion are pinned directly against the factory `walkClassLineage`
+  // throws, rather than against a fixture large enough to trigger the
+  // multi-million-row safety ceiling for real. Mutation check: change the
+  // `code`, drop the `ceiling` detail, or edit the suggestion string in
+  // `identityReplayWalkIncompleteError` (replay.ts) and this test fails on
+  // the exact field that changed.
+  it("identityReplayWalkIncompleteError names the safety ceiling that tripped it", () => {
+    const error = identityReplayWalkIncompleteError(2_000_000);
+    expect(error).toBeInstanceOf(IdentityReplayError);
+    expect(error.details).toEqual({
+      code: "IDENTITY_REPLAY_WALK_INCOMPLETE",
+      ceiling: 2_000_000,
+    });
+    expect(error.suggestion).toBe(
+      "Prune older transitions with pruneIdentityTransitions. Narrowing fromRecorded/toRecorded does not help: lineage discovery reads the whole log on purpose, so that a window can never hide the notes that name a class.",
+    );
   });
 });
 

--- a/packages/typegraph/tests/identity-transition-log.test.ts
+++ b/packages/typegraph/tests/identity-transition-log.test.ts
@@ -33,6 +33,7 @@ import {
 import { applyIdentityChangesForContext } from "../src/identity/service-interchange-write";
 import { type IdentityServiceContext } from "../src/identity/service-types";
 import {
+  type IdentityTransitionRow,
   pruneIdentityTransitions,
   pruneIdentityTransitionsForContext,
   readIdentityTransitions,
@@ -104,6 +105,77 @@ describe("identity transition log", () => {
     const assertRows = rows.filter((row) => row.cause === "assert");
     expect(assertRows.length).toBeGreaterThanOrEqual(1);
     expect(assertRows[0]?.assertion_ids.length).toBe(1);
+  });
+
+  // Load-bearing: `scope.after` keyset-pages `readIdentityTransitions` past a
+  // prior page's last row — this is what lets `walkClassLineage` (replay.ts)
+  // read a fixed-point round to exhaustion via many small pages instead of
+  // one read capped at a fixed ceiling. Mutation check: change the cursor
+  // filter's `recorded_revision > ${scope.after.recordedRevision}` to `>=`
+  // (transition-log.ts) and this fails: the second page re-includes the
+  // first page's own last row (and any earlier same-revision row), so
+  // `collected` gains a duplicate the equality check catches before the
+  // bounded round guard below would otherwise mask an infinite loop as a
+  // length mismatch.
+  it("keyset-pages past scope.after, converging to the same rows a single unbounded read returns", async () => {
+    const [store] = await createAdapterStoreWithSchema(
+      graph,
+      createTestBackend(),
+      { history: true },
+    );
+    await store.nodes.Person.create({ name: "A" }, { id: "a" });
+    await store.nodes.Person.create({ name: "B" }, { id: "b" });
+    await store.identity.assertSame(
+      { kind: "Person", id: "a" },
+      { kind: "Person", id: "b" },
+    );
+    const [firstAssertion] = await store.identity.assertionsOf({
+      kind: "Person",
+      id: "a",
+    });
+    if (firstAssertion === undefined) throw new Error("expected an assertion");
+    await store.identity.retractAssertion(firstAssertion.id);
+    await store.identity.assertSame(
+      { kind: "Person", id: "a" },
+      { kind: "Person", id: "b" },
+    );
+
+    const ctx = storeRuntime(store).identityContext();
+    const everything = await readTransitions(ctx);
+    expect(everything.length).toBeGreaterThanOrEqual(3);
+
+    const pageSize = 1;
+    const collected: IdentityTransitionRow[] = [];
+    let after:
+      Readonly<{ recordedRevision: number; transitionId: string }> | undefined;
+    // Bounded by `everything.length + 1` rounds: a correct pager finishes in
+    // exactly `everything.length` rounds (one row per page), so one extra
+    // round of slack still turns a broken, non-advancing cursor into a
+    // length/content mismatch below rather than an unbounded loop.
+    for (let round = 0; round <= everything.length; round += 1) {
+      const page = await readIdentityTransitions(
+        ctx.backend,
+        ctx.schema,
+        ctx.graphId,
+        {
+          classRefs: PERSON_CLASS_REFS,
+          limit: pageSize,
+          ...(after === undefined ? {} : { after }),
+        },
+      );
+      collected.push(...page);
+      if (page.length < pageSize) break;
+      const last = page.at(-1);
+      if (last === undefined) break;
+      after = {
+        recordedRevision: last.recorded_revision,
+        transitionId: last.transition_id,
+      };
+    }
+
+    expect(collected.map((row) => row.transition_id)).toEqual(
+      everything.map((row) => row.transition_id),
+    );
   });
 
   it("notes a retract transition when a same assertion is retracted", async () => {

--- a/packages/typegraph/tests/property/identity-replay-exhaustive.test.ts
+++ b/packages/typegraph/tests/property/identity-replay-exhaustive.test.ts
@@ -404,7 +404,7 @@ describe("identity replay exhaustiveness property", () => {
           // revision touched by any OTHER row is not, and the positive check
           // below independently confirms `window-end` still fires when it
           // must — closing the gap a blanket exemption would leave for L2.
-          const transitions = await identityTransitionsOf(ctx, seed, {
+          const { transitions } = await identityTransitionsOf(ctx, seed, {
             limit: 2000,
           });
           const selfReferentialRevisions = new Set(


### PR DESCRIPTION
Revisions to the identity history surface from the first whole-branch review of the integration branch: lineage discovery that a bounded replay could truncate, a limit that threw instead of paging, and two missing pieces of public information.

## What changed

**Lineage is discovered past the requested window.** `replay` and `transitionsOf` used to apply the caller's `fromRecorded` / `toRecorded` bounds while walking a class's lineage, so a bounded read could miss the very transition that names an earlier class canonical: with B and C merged at revision 1 and A joining at revision 2 to become canonical, replaying B through revision 1 started from A, never saw the revision-2 bridge to B, and silently omitted the revision-1 merge. Discovery now walks the whole log to a fixed point and only the returned transitions are filtered to the window. The walk itself keyset-pages through every matching row rather than refusing at a fixed ceiling, so a lineage that has grown past one read never needs a destructive prune to become readable.

**History pages instead of refusing.** `limit` caps the number of boundaries one page returns, and a capped page hands back `nextFrom`, a cursor to pass as the next call's `fromRecorded`. The `IDENTITY_REPLAY_LIMIT_EXCEEDED` refusal, whose recovery hint advanced past boundaries the caller never received, is removed. A non-positive `limit` is refused up front. `nextFrom` is scoped to the transition log and documented as never being a valid `asOfRecorded` input.

**Restored transitions say so.** A transition an archival restore brought in carries `restored.at`, the destination's wall clock at restore time, so an audit view can tell an imported explanation from a locally replayable event. The field is a wall clock rather than a `RecordedInstant` because a restore records history without reliving it: it never advances the destination's recorded-revision counter, so there is no revision on the destination's own axis to pair with the timestamp. `transitionsOf` returns restored rows with the field set; `replay` never uses one as a boundary, and the retention watermark stays the only revision-shaped signal a restore leaves.

**Reconciliation scope stated up front.** The graph-merge guide now says beside its identity reconciliation introduction what the identity pairing source reaches (staged new nodes of the same kind across branches) and that it is not a consolidate-existing-entities operation; a future direct consolidation API builds on the reviewed merge machinery.

## Breaking

- `IdentityReplayError` no longer raises `IDENTITY_REPLAY_LIMIT_EXCEEDED`; `IdentityReplay` and the `transitionsOf` result gain `nextFrom`. Callers that caught the code to page must read the cursor instead.
- `IdentityTransition` gains the optional `restored` field.

The identity reconciliation changeset carries the updated text.
