### PR TITLE
test(postgres): drain the template before forking it, and budget for the host

### DIFF
--- a/packages/typegraph/tests/backends/postgres/forked-working-copy.test.ts
+++ b/packages/typegraph/tests/backends/postgres/forked-working-copy.test.ts
@@ -103,6 +103,67 @@ function quoteIdentifier(identifier: string): string {
   return `"${identifier.replaceAll('"', '""')}"`;
 }
 
+/**
+ * How long to wait for the template database's last session to be reaped.
+ *
+ * `pg.Pool.end()` resolves when the client sockets are closed; the server-side
+ * backends exit independently and, on a loaded machine, a little later.
+ * `CREATE DATABASE ... TEMPLATE` refuses to copy a database that any other
+ * session is connected to, and its own tolerance for this is a FIXED
+ * five-second poll (`CountOtherDBBackends`) after which it fails with
+ * SQLSTATE 55006 — measured directly against the server: holding one idle
+ * connection open makes the statement stall 5122 ms and then error.
+ *
+ * So the interval between `end()` resolving and the backend exiting is a race
+ * this suite would otherwise run against a deadline it does not control, with
+ * a hard failure rather than a slow one on the losing side. Waiting for the
+ * observable condition instead makes the fork deterministic, costs nothing
+ * when the reap is prompt (the normal case), and outlasts PostgreSQL's own
+ * five seconds when the machine is busy.
+ */
+const TEMPLATE_DRAIN_TIMEOUT_MS = 30_000;
+const TEMPLATE_DRAIN_POLL_MS = 25;
+
+/**
+ * Resolves once no session other than this one is connected to `database`.
+ *
+ * Fails by naming the sessions that would not leave, which is the diagnosis
+ * PostgreSQL's own "is being accessed by other users" withholds.
+ */
+async function waitForNoOtherSessions(
+  admin: Pool,
+  database: string,
+  timeoutMs: number = TEMPLATE_DRAIN_TIMEOUT_MS,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const { rows } = await admin.query<{
+      pid: number;
+      application_name: string;
+      state: string;
+    }>(
+      `SELECT pid, application_name, state
+         FROM pg_stat_activity
+        WHERE datname = $1 AND pid <> pg_backend_pid()`,
+      [database],
+    );
+    if (rows.length === 0) return;
+    if (Date.now() >= deadline) {
+      const holders = rows
+        .map(
+          (row) =>
+            `pid ${row.pid} (${row.application_name || "?"}, ${row.state})`,
+        )
+        .join(", ");
+      throw new Error(
+        `Sessions still connected to template database "${database}" after ` +
+          `${timeoutMs} ms: ${holders}`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, TEMPLATE_DRAIN_POLL_MS));
+  }
+}
+
 /** The bare database name `provisionPostgresTestDatabase` chose. */
 function databaseNameFromUrl(url: string): string {
   return decodeURIComponent(new URL(url).pathname.replace(/^\//, ""));
@@ -141,109 +202,182 @@ it("forkedDatabaseNameFor never collapses onto its stem, even at the identifier 
 describe.runIf(process.env["POSTGRES_URL"])(
   "forkedWorkingCopyStrategy [postgres, CREATE DATABASE ... TEMPLATE]",
   () => {
-    it("forks the base database by template, merges a fork write back to the base", async () => {
+    /**
+     * A budget sized for HOST latency, not for TypeGraph work (#655).
+     *
+     * The measured costs here are small — an 8.7 MB template copies in ~11 ms
+     * idle and ~130 ms under saturating concurrent write load — so the copy
+     * itself was never what pushed this past the project's 15 s default. What
+     * scales with how busy the machine is, is the waiting: `DROP DATABASE ...
+     * WITH (FORCE)` terminates and reaps the fork's backends, and the copy
+     * waits on the template's. This suite is the only one in the default
+     * project that asks the server to do either, so it gets the same 60 s
+     * allowance the other host-lifecycle projects (`pglite`, `graph-merge`)
+     * already give themselves, for the same reason: normal provisioning
+     * latency must not report as a correctness failure.
+     */
+    const FORK_TEST_TIMEOUT_MS = 60_000;
+
+    /**
+     * The drain is the difference between a deterministic fork and a race
+     * against PostgreSQL's own five-second poll, so it is asserted directly:
+     * a helper that returned immediately would resolve here instead of
+     * reporting the session that is still attached.
+     */
+    it("waits for the template's other sessions, and names them if they stay", async () => {
       const configuredUrl = process.env["POSTGRES_URL"];
       if (configuredUrl === undefined) throw new Error("unreachable");
       const isolatedDatabase = databaseNameFromUrl(TEST_DATABASE_URL);
-      // `branch()`'s own DROP/CREATE DATABASE ... TEMPLATE calls target this
-      // name — assert it before any DROP runs, not only inside
-      // `forkedDatabaseNameFor`'s own unit test above.
-      const forkedDatabase = forkedDatabaseNameFor(isolatedDatabase);
-      expect(forkedDatabase).not.toBe(isolatedDatabase);
-
-      async function withAdmin<T>(fn: (admin: Pool) => Promise<T>): Promise<T> {
-        const admin = new Pool({ connectionString: configuredUrl, max: 1 });
-        try {
-          return await fn(admin);
-        } finally {
-          await admin.end();
-        }
+      const admin = new Pool({ connectionString: configuredUrl, max: 1 });
+      const lingering = new Pool({
+        connectionString: TEST_DATABASE_URL,
+        max: 1,
+        application_name: "lingering-template-session",
+      });
+      // `pg.Pool.end()` refuses a second call, and the happy path below ends
+      // this pool mid-test, so the cleanup tracks whether it still owns it.
+      let lingeringOpen = true;
+      async function endLingering(): Promise<void> {
+        if (!lingeringOpen) return;
+        lingeringOpen = false;
+        await lingering.end();
       }
+      try {
+        await lingering.query("SELECT 1");
+        await expect(
+          waitForNoOtherSessions(admin, isolatedDatabase, 250),
+        ).rejects.toThrow(/lingering-template-session/);
 
-      const swappablePool = new SwappablePool(
-        new Pool({ connectionString: TEST_DATABASE_URL, max: 1 }),
-      );
-      // Cast: SwappablePool duck-types the subset of `Pool` Drizzle's
-      // node-postgres driver actually calls (see the class doc comment).
-      const baseDb = drizzle(
-        swappablePool as unknown as Pool,
-      ) as NodePgDatabase;
-      const baseBackend = createPostgresBackend(baseDb);
-      const [baseStore] = await createStoreWithSchema(graph, baseBackend);
-      const widget = await baseStore.nodes.Widget.create({ name: "Original" });
-
-      type PgTemplateFork = ForkHandle & Readonly<{ database: string }>;
-
-      const strategy = forkedWorkingCopyStrategy<G, PgTemplateFork>({
-        fork: async () => {
-          // No other session — active or idle-in-pool — may be connected to
-          // the template database while it is copied.
-          await swappablePool.current.end();
-          await withAdmin(async (admin) => {
-            await admin.query(
-              `DROP DATABASE IF EXISTS ${quoteIdentifier(forkedDatabase)} WITH (FORCE)`,
-            );
-            await admin.query(
-              `CREATE DATABASE ${quoteIdentifier(forkedDatabase)} TEMPLATE ${quoteIdentifier(isolatedDatabase)}`,
-            );
-          });
-          // Reconnect the base's pool now that the template copy is done —
-          // `baseStore` keeps working, unchanged, for the rest of the test.
-          swappablePool.current = new Pool({
-            connectionString: TEST_DATABASE_URL,
-            max: 1,
-          });
-          return {
-            database: forkedDatabase,
-            dispose: async () => {
-              await withAdmin(async (admin) => {
-                await admin.query(
-                  `DROP DATABASE IF EXISTS ${quoteIdentifier(forkedDatabase)} WITH (FORCE)`,
-                );
-              });
-            },
-          };
-        },
-        connect: (fork) => {
-          const pool = new Pool({
-            connectionString: urlForDatabase(TEST_DATABASE_URL, fork.database),
-            max: 1,
-          });
-          const forkBackend = createPostgresBackend(drizzle(pool));
-          return Promise.resolve(
-            wrapWithManagedClose(forkBackend, async () => {
-              await pool.end();
-            }),
-          );
-        },
-      });
-
-      const branchResult = await branch<G>(
-        baseStore,
-        rejectMakeBackend,
-        undefined,
-        strategy,
-      );
-      expect(isOk(branchResult)).toBe(true);
-      const forkBranch = unwrap(branchResult);
-
-      await forkBranch.store.nodes.Widget.update(widget.id, {
-        name: "Forked Edit",
-      });
-
-      // The base is unaffected before the merge commits.
-      const beforeCommit = await baseStore.nodes.Widget.getById(widget.id);
-      expect(beforeCommit?.name).toBe("Original");
-
-      const mergeResult = await merge<G>(baseStore, [forkBranch], {});
-      expect(isOk(mergeResult)).toBe(true);
-
-      // The base sees the fork's write after commit.
-      const afterCommit = await baseStore.nodes.Widget.getById(widget.id);
-      expect(afterCommit?.name).toBe("Forked Edit");
-
-      await forkBranch.close();
-      await swappablePool.current.end();
+        await endLingering();
+        // Now it resolves — within PostgreSQL's own tolerance, without having
+        // spent it.
+        await expect(
+          waitForNoOtherSessions(admin, isolatedDatabase, 5000),
+        ).resolves.toBeUndefined();
+      } finally {
+        await endLingering();
+        await admin.end();
+      }
     });
+
+    it(
+      "forks the base database by template, merges a fork write back to the base",
+      async () => {
+        const configuredUrl = process.env["POSTGRES_URL"];
+        if (configuredUrl === undefined) throw new Error("unreachable");
+        const isolatedDatabase = databaseNameFromUrl(TEST_DATABASE_URL);
+        // `branch()`'s own DROP/CREATE DATABASE ... TEMPLATE calls target this
+        // name — assert it before any DROP runs, not only inside
+        // `forkedDatabaseNameFor`'s own unit test above.
+        const forkedDatabase = forkedDatabaseNameFor(isolatedDatabase);
+        expect(forkedDatabase).not.toBe(isolatedDatabase);
+
+        async function withAdmin<T>(
+          fn: (admin: Pool) => Promise<T>,
+        ): Promise<T> {
+          const admin = new Pool({ connectionString: configuredUrl, max: 1 });
+          try {
+            return await fn(admin);
+          } finally {
+            await admin.end();
+          }
+        }
+
+        const swappablePool = new SwappablePool(
+          new Pool({ connectionString: TEST_DATABASE_URL, max: 1 }),
+        );
+        // Cast: SwappablePool duck-types the subset of `Pool` Drizzle's
+        // node-postgres driver actually calls (see the class doc comment).
+        const baseDb = drizzle(
+          swappablePool as unknown as Pool,
+        ) as NodePgDatabase;
+        const baseBackend = createPostgresBackend(baseDb);
+        const [baseStore] = await createStoreWithSchema(graph, baseBackend);
+        const widget = await baseStore.nodes.Widget.create({
+          name: "Original",
+        });
+
+        type PgTemplateFork = ForkHandle & Readonly<{ database: string }>;
+
+        const strategy = forkedWorkingCopyStrategy<G, PgTemplateFork>({
+          fork: async () => {
+            // No other session — active or idle-in-pool — may be connected to
+            // the template database while it is copied.
+            await swappablePool.current.end();
+            await withAdmin(async (admin) => {
+              await admin.query(
+                `DROP DATABASE IF EXISTS ${quoteIdentifier(forkedDatabase)} WITH (FORCE)`,
+              );
+              // `end()` above closed the sockets; wait for the server to finish
+              // reaping the backends before asking it to copy the database they
+              // were attached to (see TEMPLATE_DRAIN_TIMEOUT_MS).
+              await waitForNoOtherSessions(admin, isolatedDatabase);
+              await admin.query(
+                `CREATE DATABASE ${quoteIdentifier(forkedDatabase)} TEMPLATE ${quoteIdentifier(isolatedDatabase)}`,
+              );
+            });
+            // Reconnect the base's pool now that the template copy is done —
+            // `baseStore` keeps working, unchanged, for the rest of the test.
+            swappablePool.current = new Pool({
+              connectionString: TEST_DATABASE_URL,
+              max: 1,
+            });
+            return {
+              database: forkedDatabase,
+              dispose: async () => {
+                await withAdmin(async (admin) => {
+                  await admin.query(
+                    `DROP DATABASE IF EXISTS ${quoteIdentifier(forkedDatabase)} WITH (FORCE)`,
+                  );
+                });
+              },
+            };
+          },
+          connect: (fork) => {
+            const pool = new Pool({
+              connectionString: urlForDatabase(
+                TEST_DATABASE_URL,
+                fork.database,
+              ),
+              max: 1,
+            });
+            const forkBackend = createPostgresBackend(drizzle(pool));
+            return Promise.resolve(
+              wrapWithManagedClose(forkBackend, async () => {
+                await pool.end();
+              }),
+            );
+          },
+        });
+
+        const branchResult = await branch<G>(
+          baseStore,
+          rejectMakeBackend,
+          undefined,
+          strategy,
+        );
+        expect(isOk(branchResult)).toBe(true);
+        const forkBranch = unwrap(branchResult);
+
+        await forkBranch.store.nodes.Widget.update(widget.id, {
+          name: "Forked Edit",
+        });
+
+        // The base is unaffected before the merge commits.
+        const beforeCommit = await baseStore.nodes.Widget.getById(widget.id);
+        expect(beforeCommit?.name).toBe("Original");
+
+        const mergeResult = await merge<G>(baseStore, [forkBranch], {});
+        expect(isOk(mergeResult)).toBe(true);
+
+        // The base sees the fork's write after commit.
+        const afterCommit = await baseStore.nodes.Widget.getById(widget.id);
+        expect(afterCommit?.name).toBe("Forked Edit");
+
+        await forkBranch.close();
+        await swappablePool.current.end();
+      },
+      FORK_TEST_TIMEOUT_MS,
+    );
   },
 );


### PR DESCRIPTION
The forked-working-copy suite timed out under load. The issue attributed this to `CREATE DATABASE ... TEMPLATE` copying the whole template on disk; measurement says otherwise, and the real mechanism needed a different fix.

## What the numbers say

The template database is 8.7 MB. The DROP + copy pair the suite's `fork()` issues, sampled five times idle and five times under eight saturating concurrent writers on the same server:

| | idle | under load |
| --- | --- | --- |
| `DROP DATABASE ... WITH (FORCE)` | 5, 904, 4, 5, 5 ms | 162, 97, 75, 20, 32 ms |
| `CREATE DATABASE ... TEMPLATE` | 46, 11, 11, 11, 11 ms | 126, 127, 35, 37, 43 ms |

The copy is tens of milliseconds. It was never what pushed the test past a 15-second budget.

The 904 ms idle outlier on `DROP` is the actual shape of the problem: the cost here is *waiting*, not copying, and the wait is unbounded from the suite's side while being bounded from PostgreSQL's.

## The race

`pg.Pool.end()` resolves when the client sockets are closed. The server-side backends exit independently, and on a loaded machine, later. `CREATE DATABASE ... TEMPLATE` refuses to copy a database any other session is attached to, and its tolerance for this is a **fixed five-second poll** (`CountOtherDBBackends`), after which it fails with SQLSTATE 55006. Confirmed directly against the server by holding one idle connection open:

```
waited 5122 ms, then failed: 55006 source database "..." is being accessed by other users
```

So the interval between `end()` resolving and the backend actually exiting was a race the suite ran against a deadline it does not control — and the losing side is a hard error, not a slow test. Raising the budget alone would not have fixed that; it would have converted a timeout into a 55006 sometimes and left it a timeout the rest of the time.

## The fix

`fork()` now waits for the observable condition — no session other than its own on the template, read from `pg_stat_activity` — before asking for the copy. This costs nothing when the reap is prompt (the normal case, and the suite's own runtime is unchanged at ~0.4 s), outlasts PostgreSQL's five seconds when the machine is busy, and on giving up names the sessions that would not leave, which "is being accessed by other users" withholds.

A test asserts the drain directly, against a deliberately lingering session with a short budget: it must reject naming that session, then resolve once the session ends. Verified load-bearing — neutering the drain to return immediately makes it fail.

The forking test also takes the 60 s budget the other host-lifecycle projects (`pglite`, `graph-merge`) already give themselves for the same reason. This is the only suite in the default project that asks the server to drop and template-copy a database, and normal provisioning latency should not report as a correctness failure.

## On reproduction

I could not reproduce the original timeout on this hardware — the full PostgreSQL lane passes at one worker and at CI's four, and the suite alone runs in ~0.4 s even under sixteen saturating writers. The evidence above is therefore mechanism, measured directly, rather than a before/after on the failing run. Both fixes are justified by that mechanism independently of the timeout: the drain removes a real race with a hard-failure mode, and the budget matches an existing convention for the same class of work.

Closes #655
