### PR TITLE
fix(graph-merge): fork a PostgreSQL working copy without waiting on the template's checkpoint

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -252,6 +252,19 @@ Consequences worth knowing:
   server carries no state a run depends on — the per-suite databases are
   dropped and recreated — but leftovers from inspection do accumulate until
   the container is recreated.
+- **`DROP DATABASE` is a cluster-wide checkpoint, so it belongs in a hook, not
+  in a test body.** PostgreSQL forces an immediate checkpoint and waits for it
+  before removing a database's files, so the statement's duration is set by how
+  much every *other* suite in the lane has written since the last checkpoint —
+  not by the size of the database being dropped. Measured mid-run on the
+  PostgreSQL 18 lane server: 13.7 s to drop a 7 MB database, 12.3 s of it the
+  checkpoint's fsync phase, against 0.1 s for the same drop on an idle server.
+  A suite that creates a database of its own (only
+  `tests/backends/postgres/forked-working-copy.test.ts` does) therefore runs
+  both its drops in `beforeAll`/`afterAll` under an explicit hook timeout and
+  keeps the timed test body to the statement it is actually about. Raising the
+  test budget instead would only move the same unbounded wait behind a larger
+  number.
 
 The lane runs its suites **file-parallel**, and the worker count follows who
 provisioned the server. The bundled `docker-compose.yml` starts PostgreSQL

--- a/packages/typegraph/tests/backends/postgres/forked-working-copy.test.ts
+++ b/packages/typegraph/tests/backends/postgres/forked-working-copy.test.ts
@@ -23,6 +23,10 @@
  * its sessions: whatever is memoized on a live connection does not survive a
  * suspend, so only the write fence and the lock memo — which re-acquire per
  * transaction — may be relied on across one.
+ *
+ * The two `DROP DATABASE` statements this suite needs — clearing residue from
+ * an earlier run, and releasing the fork — run in `beforeAll`/`afterAll`, not
+ * in the test body, for the reason `HOST_DDL_TIMEOUT_MS` documents below.
  */
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import {
@@ -31,7 +35,7 @@ import {
   type QueryResult,
   type QueryResultRow,
 } from "pg";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { createStoreWithSchema, defineGraph, defineNode } from "../../../src";
@@ -40,6 +44,7 @@ import { createPostgresBackend } from "../../../src/backend/postgres";
 import { branch } from "../../../src/graph-merge/branch";
 import { merge } from "../../../src/graph-merge/merge";
 import { isOk, unwrap } from "../../../src/graph-merge/result";
+import type { GraphBranch } from "../../../src/graph-merge/types";
 import {
   forkedWorkingCopyStrategy,
   type ForkHandle,
@@ -138,31 +143,111 @@ it("forkedDatabaseNameFor never collapses onto its stem, even at the identifier 
   expect(forked.endsWith(FORK_SUFFIX)).toBe(true);
 });
 
+/**
+ * Budget for this suite's host-level DDL hooks.
+ *
+ * `DROP DATABASE` forces an IMMEDIATE cluster-wide checkpoint and waits for it
+ * — PostgreSQL has to know the checkpointer has forgotten the dropped
+ * database's sync requests before the files go away — so how long it takes is
+ * set by how much every OTHER suite in the lane has written since the last
+ * checkpoint, not by the size of the database being dropped. Measured on the
+ * PostgreSQL 18 lane server mid-run: 13.7 s to drop a 7 MB database freshly
+ * copied from a template, of which 12.3 s was that checkpoint's fsync phase
+ * (`pg_stat_checkpointer.sync_time` rose by 12,253 ms and `num_requested` by
+ * one), against 0.6 s for the next DROP moments later with the cluster already
+ * flushed, and 0.1 s for the same DROP on an idle server.
+ *
+ * That is why both drops live in `beforeAll`/`afterAll` under this budget and
+ * NOT in the test body: the body measures the fork mechanism — `CREATE
+ * DATABASE ... TEMPLATE`, which costs 43-73 ms on the same loaded server — and
+ * a cluster-wide fsync is no part of it. Budgeting the test body instead would
+ * only move the same unbounded wait behind a larger number.
+ */
+const HOST_DDL_TIMEOUT_MS = 120_000;
+
+const ISOLATED_DATABASE = databaseNameFromUrl(TEST_DATABASE_URL);
+
+/**
+ * The database `branch()`'s `CREATE DATABASE ... TEMPLATE` produces and both of
+ * this suite's drops target. Guarded here rather than only inside
+ * `forkedDatabaseNameFor`'s own unit test above: this is the CONCRETE name a
+ * `DROP DATABASE` is about to be issued against, and if it ever collapsed onto
+ * the suite's own live database the drop would take that with it. A guard, not
+ * an `expect`, because it protects the statement rather than reporting on it.
+ */
+const FORKED_DATABASE = forkedDatabaseNameFor(ISOLATED_DATABASE);
+if (FORKED_DATABASE === ISOLATED_DATABASE)
+  throw new Error(
+    `forkedDatabaseNameFor collapsed onto "${ISOLATED_DATABASE}" — refusing to ` +
+      `drop this suite's own database`,
+  );
+
+/**
+ * `POSTGRES_URL` is read lazily: a skipped suite's body is still collected, so
+ * nothing outside a hook or a test may require it.
+ */
+async function withAdmin<T>(fn: (admin: Pool) => Promise<T>): Promise<T> {
+  const configuredUrl = process.env["POSTGRES_URL"];
+  if (configuredUrl === undefined) throw new Error("unreachable");
+  const admin = new Pool({ connectionString: configuredUrl, max: 1 });
+  try {
+    return await fn(admin);
+  } finally {
+    await admin.end();
+  }
+}
+
+async function forkedDatabaseExists(): Promise<boolean> {
+  return await withAdmin(async (admin) => {
+    const found = await admin.query(
+      `SELECT 1 FROM pg_database WHERE datname = $1`,
+      [FORKED_DATABASE],
+    );
+    return found.rowCount === 1;
+  });
+}
+
+async function dropForkedDatabase(): Promise<void> {
+  await withAdmin(async (admin) => {
+    await admin.query(
+      `DROP DATABASE IF EXISTS ${quoteIdentifier(FORKED_DATABASE)} WITH (FORCE)`,
+    );
+  });
+}
+
 describe.runIf(process.env["POSTGRES_URL"])(
   "forkedWorkingCopyStrategy [postgres, CREATE DATABASE ... TEMPLATE]",
   () => {
+    let forkBranch: GraphBranch<G> | undefined;
+    let basePool: SwappablePool | undefined;
+
+    // Residue from an earlier run of this suite — a crash between the copy and
+    // the teardown leaves the forked database behind. Clearing it is harness
+    // setup, not part of the fork mechanism, so it runs here under the
+    // host-DDL budget rather than inside the timed test body.
+    beforeAll(async () => {
+      await dropForkedDatabase();
+    }, HOST_DDL_TIMEOUT_MS);
+
+    // `close()` is what runs the fork handle's `dispose`, i.e. the DROP that
+    // releases the forked database, so it is teardown and carries the host-DDL
+    // budget. The surviving-database check keeps `dispose` PROVEN rather than
+    // merely invoked; it throws instead of asserting because `expect` outside a
+    // test block reports nothing useful when it fails in a hook.
+    afterAll(async () => {
+      await forkBranch?.close();
+      await basePool?.end();
+      if (await forkedDatabaseExists())
+        throw new Error(
+          `close() did not run the fork handle's dispose: "${FORKED_DATABASE}" survived`,
+        );
+    }, HOST_DDL_TIMEOUT_MS);
+
     it("forks the base database by template, merges a fork write back to the base", async () => {
-      const configuredUrl = process.env["POSTGRES_URL"];
-      if (configuredUrl === undefined) throw new Error("unreachable");
-      const isolatedDatabase = databaseNameFromUrl(TEST_DATABASE_URL);
-      // `branch()`'s own DROP/CREATE DATABASE ... TEMPLATE calls target this
-      // name — assert it before any DROP runs, not only inside
-      // `forkedDatabaseNameFor`'s own unit test above.
-      const forkedDatabase = forkedDatabaseNameFor(isolatedDatabase);
-      expect(forkedDatabase).not.toBe(isolatedDatabase);
-
-      async function withAdmin<T>(fn: (admin: Pool) => Promise<T>): Promise<T> {
-        const admin = new Pool({ connectionString: configuredUrl, max: 1 });
-        try {
-          return await fn(admin);
-        } finally {
-          await admin.end();
-        }
-      }
-
       const swappablePool = new SwappablePool(
         new Pool({ connectionString: TEST_DATABASE_URL, max: 1 }),
       );
+      basePool = swappablePool;
       // Cast: SwappablePool duck-types the subset of `Pool` Drizzle's
       // node-postgres driver actually calls (see the class doc comment).
       const baseDb = drizzle(
@@ -177,14 +262,12 @@ describe.runIf(process.env["POSTGRES_URL"])(
       const strategy = forkedWorkingCopyStrategy<G, PgTemplateFork>({
         fork: async () => {
           // No other session — active or idle-in-pool — may be connected to
-          // the template database while it is copied.
+          // the template database while it is copied. The forked database
+          // itself cannot already exist: `beforeAll` dropped any residue.
           await swappablePool.current.end();
           await withAdmin(async (admin) => {
             await admin.query(
-              `DROP DATABASE IF EXISTS ${quoteIdentifier(forkedDatabase)} WITH (FORCE)`,
-            );
-            await admin.query(
-              `CREATE DATABASE ${quoteIdentifier(forkedDatabase)} TEMPLATE ${quoteIdentifier(isolatedDatabase)}`,
+              `CREATE DATABASE ${quoteIdentifier(FORKED_DATABASE)} TEMPLATE ${quoteIdentifier(ISOLATED_DATABASE)}`,
             );
           });
           // Reconnect the base's pool now that the template copy is done —
@@ -193,16 +276,7 @@ describe.runIf(process.env["POSTGRES_URL"])(
             connectionString: TEST_DATABASE_URL,
             max: 1,
           });
-          return {
-            database: forkedDatabase,
-            dispose: async () => {
-              await withAdmin(async (admin) => {
-                await admin.query(
-                  `DROP DATABASE IF EXISTS ${quoteIdentifier(forkedDatabase)} WITH (FORCE)`,
-                );
-              });
-            },
-          };
+          return { database: FORKED_DATABASE, dispose: dropForkedDatabase };
         },
         connect: (fork) => {
           const pool = new Pool({
@@ -225,9 +299,13 @@ describe.runIf(process.env["POSTGRES_URL"])(
         strategy,
       );
       expect(isOk(branchResult)).toBe(true);
-      const forkBranch = unwrap(branchResult);
+      const forked = unwrap(branchResult);
+      forkBranch = forked;
+      // The host-level copy really happened — `afterAll` proves `dispose`
+      // removes this same database again.
+      expect(await forkedDatabaseExists()).toBe(true);
 
-      await forkBranch.store.nodes.Widget.update(widget.id, {
+      await forked.store.nodes.Widget.update(widget.id, {
         name: "Forked Edit",
       });
 
@@ -235,15 +313,12 @@ describe.runIf(process.env["POSTGRES_URL"])(
       const beforeCommit = await baseStore.nodes.Widget.getById(widget.id);
       expect(beforeCommit?.name).toBe("Original");
 
-      const mergeResult = await merge<G>(baseStore, [forkBranch], {});
+      const mergeResult = await merge<G>(baseStore, [forked], {});
       expect(isOk(mergeResult)).toBe(true);
 
       // The base sees the fork's write after commit.
       const afterCommit = await baseStore.nodes.Widget.getById(widget.id);
       expect(afterCommit?.name).toBe("Forked Edit");
-
-      await forkBranch.close();
-      await swappablePool.current.end();
     });
   },
 );


### PR DESCRIPTION
`tests/backends/postgres/forked-working-copy.test.ts` timed out at its 15 s budget on every full `pnpm test:postgres` run and on CI's PostgreSQL shards, while passing in a few hundred milliseconds when run alone. The issue guessed at `CREATE DATABASE ... TEMPLATE` being serialized against the template's other sessions. It is not: measured against a PostgreSQL 18 lane server mid-run, the template copy costs 43-73 ms, and the 15 s is spent in `DROP DATABASE`.

`DROP DATABASE` forces an immediate, cluster-wide checkpoint and waits for it, because PostgreSQL has to know the checkpointer has forgotten the dropped database's sync requests before the files go away. Its duration is therefore set by how much every *other* suite in the lane has written since the last checkpoint, not by the size of the database being dropped. Dropping a 7 MB database freshly copied from a template took 13.7 s mid-run, of which 12.3 s was the checkpoint's fsync phase (`pg_stat_checkpointer.sync_time` rose by 12,253 ms and `num_requested` by exactly one); the next `DROP DATABASE` moments later, with the cluster already flushed, took 0.6 s, and the same drop on an idle server takes 0.1 s. That is why the test passes alone: alone, there is nothing to flush.

The suite needed two drops and both sat in the timed test body — one clearing residue before the copy, one inside the fork handle's `dispose`, reached through `close()`. Both now run in `beforeAll`/`afterAll` under an explicit 120 s host-DDL budget, leaving the body with the statement it is actually about. Clearing residue from an earlier run is harness setup rather than part of the fork, so `fork()` is now just the template copy; releasing the forked database is teardown, and `dispose` is still the thing that does it. Raising the per-test budget instead would only have moved the same unbounded wait behind a larger number, so the test budget is unchanged at the project default.

Relocating the drops must not cost the suite its proof that `dispose` runs, so the teardown reads `pg_database` and fails when the forked database survives `close()`, and the body asserts the copy exists in the first place. Both are guards that throw rather than `expect` calls, because `expect` outside a test block reports nothing useful from a hook and, for the name check, because the concrete forked name is what protects the `DROP` from ever targeting the suite's own live database.

No workflow change is needed: the PostgreSQL shards just invoke the lane script, and the cause is independent of worker count — the local reproduction runs one worker and CI's shard runs four.

`docs/TESTING.md` gains the measured fact under the per-suite-database notes, since any future suite that creates a database of its own faces the same trap.

Closes #655
