### PR TITLE
build: bring the declaration bundle back under the 8 GB ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 # Declaration bundling traverses the full public backend and store type graph.
 # Keep its worker above Node's default old-space ceiling as that API grows.
 env:
-  NODE_OPTIONS: --max-old-space-size=12288
+  NODE_OPTIONS: --max-old-space-size=8192
 
 jobs:
   detect-release-metadata-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ permissions:
 # Declaration bundling traverses the full public backend and store type graph.
 # Keep its worker above Node's default old-space ceiling as that API grows.
 env:
-  NODE_OPTIONS: --max-old-space-size=12288
+  NODE_OPTIONS: --max-old-space-size=8192
 
 jobs:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .vinxi
 .wrangler
 dist/
+.declaration-emit/
 .turbo
 tmp
 /out-tsc

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ pnpm-workspace.yaml
 src/routeTree.gen.ts
 worker-configuration.d.ts
 dist/
+.declaration-emit/
 node_modules
 
 # Vendor analytics bootstrap: minified is:inline snippet that prettier-plugin-astro cannot parse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,15 @@ To build the package for distribution:
 pnpm build
 ```
 
+The build has two ordered stages, which `packages/typegraph/scripts/build.ts`
+owns: `tsc` emits the declarations once into `.declaration-emit/`, then tsup
+bundles the JavaScript and rolls each entrypoint's `.d.ts` out of that emit.
+Running `tsup` directly skips the first stage, so its declaration entries do not
+resolve and the build fails — use `pnpm build` (or `pnpm dev`, which keeps both
+stages watching). Deriving declarations from source inside the rollup instead
+costs about 10 GiB of resident memory for any entrypoint; rolling the emitted
+tree costs about 1.5 GiB for the whole build.
+
 ## Making Changes
 
 1. **Branch:** Create a new branch for your feature or fix.

--- a/packages/eslint-config/base.mjs
+++ b/packages/eslint-config/base.mjs
@@ -11,6 +11,7 @@ import tseslint from "typescript-eslint";
  * Common ignore patterns for all packages
  */
 export const ignores = [
+  ".declaration-emit/**",
   ".stryker-tmp/**",
   ".wrangler/**",
   "coverage/**",

--- a/packages/typegraph/etc/typegraph-interchange.api.md
+++ b/packages/typegraph/etc/typegraph-interchange.api.md
@@ -701,8 +701,8 @@ export type ConflictStrategy = z.infer<typeof ConflictStrategySchema>;
 // @public
 export const ConflictStrategySchema: z.ZodEnum<{
     error: "error";
-    update: "update";
     skip: "skip";
+    update: "update";
 }>;
 
 // @public
@@ -3262,8 +3262,8 @@ export type ImportOptions = z.input<typeof ImportOptionsSchema>;
 export const ImportOptionsSchema: z.ZodObject<{
     onConflict: z.ZodEnum<{
         error: "error";
-        update: "update";
         skip: "skip";
+        update: "update";
     }>;
     onUnknownProperty: z.ZodDefault<z.ZodEnum<{
         error: "error";

--- a/packages/typegraph/package.json
+++ b/packages/typegraph/package.json
@@ -111,8 +111,8 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "dev": "node --max-old-space-size=12288 node_modules/tsup/dist/cli-default.js --watch",
-    "build": "node --max-old-space-size=12288 node_modules/tsup/dist/cli-default.js",
+    "dev": "node --import tsx scripts/build.ts --watch",
+    "build": "node --import tsx scripts/build.ts",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit --skipLibCheck",
     "test:types": "node --import tsx scripts/test-types.ts all",

--- a/packages/typegraph/scripts/build.ts
+++ b/packages/typegraph/scripts/build.ts
@@ -1,0 +1,199 @@
+/**
+ * The package build: emit declarations with `tsc`, then run tsup.
+ *
+ * tsup bundles the JavaScript from `src` and rolls each entrypoint's `.d.ts`
+ * out of the declaration tree this script emits first (see
+ * `scripts/declaration-emit.ts` for why the rollup no longer derives
+ * declarations from source itself). The two stages therefore have a hard
+ * order, which is what this script owns.
+ *
+ * `--watch` keeps both stages live with ONE compile: `tsc --watch` owns the
+ * declaration tree, and tsup's rollup watches the files it writes, so a source
+ * edit refreshes the bundles and the declarations together. A watch session
+ * survives a type error the way `tsc --watch` does — it keeps watching and
+ * recovers on the next save — so the one-shot compile, whose non-zero exit is
+ * fatal, runs only for a non-watch build. Every argument other than `--watch`
+ * is forwarded to tsup unchanged.
+ */
+import {
+  type ChildProcess,
+  spawn,
+  type SpawnOptions,
+} from "node:child_process";
+import { access, rm } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  assertNoDeclarationOverride,
+  DECLARATION_EMIT_DIR,
+  DECLARATION_ENTRY_FILES,
+  DECLARATION_HEAP_MB,
+  DECLARATION_TSCONFIG,
+  PACKAGE_ROOT,
+} from "./declaration-emit";
+
+const WATCH_FLAG = "--watch";
+
+const TSC_BIN = path.join(PACKAGE_ROOT, "node_modules/typescript/lib/tsc.js");
+const TSUP_BIN = path.join(
+  PACKAGE_ROOT,
+  "node_modules/tsup/dist/cli-default.js",
+);
+const HEAP_ARGUMENT = `--max-old-space-size=${DECLARATION_HEAP_MB}`;
+
+/** How long a watch session waits for `tsc --watch`'s first declaration emit. */
+const FIRST_EMIT_TIMEOUT_MS = 300_000;
+const FIRST_EMIT_POLL_MS = 100;
+
+const SPAWN_OPTIONS: SpawnOptions = {
+  cwd: PACKAGE_ROOT,
+  stdio: "inherit",
+};
+
+const children = new Set<ChildProcess>();
+let shuttingDown = false;
+
+function spawnNode(scriptPath: string, args: readonly string[]): ChildProcess {
+  const child = spawn(
+    process.execPath,
+    [HEAP_ARGUMENT, scriptPath, ...args],
+    SPAWN_OPTIONS,
+  );
+  children.add(child);
+  child.on("close", () => children.delete(child));
+  return child;
+}
+
+function killChildren(): void {
+  shuttingDown = true;
+  for (const child of children) child.kill("SIGTERM");
+  children.clear();
+}
+
+function whenClosed(child: ChildProcess): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    child.on("error", (error) => {
+      reject(error);
+    });
+    child.on("close", (exitCode) => {
+      resolve(exitCode ?? 1);
+    });
+  });
+}
+
+async function runToCompletion(
+  label: string,
+  scriptPath: string,
+  args: readonly string[],
+): Promise<void> {
+  const code = await whenClosed(spawnNode(scriptPath, args));
+  if (code !== 0) {
+    throw new Error(`${label} failed with exit code ${code}.`);
+  }
+}
+
+function declarationEmitArguments(watch: boolean): readonly string[] {
+  return [
+    "--project",
+    DECLARATION_TSCONFIG,
+    ...(watch ? ["--watch", "--preserveWatchOutput"] : []),
+  ];
+}
+
+/**
+ * Rejects if the declaration watcher ever closes. A watcher that exits has
+ * stopped refreshing the tree tsup rolls, so the session would silently serve
+ * declarations frozen at the last emit; fail the pipeline instead. Stays
+ * pending through a deliberate shutdown, where the exit is expected.
+ */
+function superviseWatcher(child: ChildProcess): Promise<never> {
+  return new Promise<never>((_resolve, reject) => {
+    child.on("error", (error) => {
+      reject(error);
+    });
+    child.on("close", (code) => {
+      // A shutdown killed it on purpose: stay pending and let the exit path run.
+      if (shuttingDown) return;
+      reject(
+        new Error(
+          `Declaration watcher (tsc --watch) closed with exit code ${code ?? 1}; declarations would stop refreshing.`,
+        ),
+      );
+    });
+  });
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves once every declaration entry tsup rolls exists, so the rollup's
+ * first pass can resolve its inputs. The emit directory is removed before the
+ * watcher starts, so presence means this session's watcher wrote them — and
+ * `tsc --watch` writes declarations even for a source tree with type errors,
+ * which is what lets a watch session start on one and recover.
+ */
+async function waitForFirstDeclarationEmit(): Promise<void> {
+  const deadline = Date.now() + FIRST_EMIT_TIMEOUT_MS;
+  for (;;) {
+    const present = await Promise.all(
+      DECLARATION_ENTRY_FILES.map((filePath) => fileExists(filePath)),
+    );
+    if (present.every(Boolean)) return;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Declaration watcher wrote no complete declaration tree within ${FIRST_EMIT_TIMEOUT_MS / 1000}s.`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, FIRST_EMIT_POLL_MS));
+  }
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  assertNoDeclarationOverride(args);
+  const watch = args.includes(WATCH_FLAG);
+
+  await rm(DECLARATION_EMIT_DIR, { force: true, recursive: true });
+
+  if (!watch) {
+    await runToCompletion(
+      "Declaration emit (tsc)",
+      TSC_BIN,
+      declarationEmitArguments(false),
+    );
+    await runToCompletion("Bundle (tsup)", TSUP_BIN, args);
+    return;
+  }
+
+  const watcher = spawnNode(TSC_BIN, declarationEmitArguments(true));
+  const watcherClosed = superviseWatcher(watcher);
+  await Promise.race([waitForFirstDeclarationEmit(), watcherClosed]);
+  await Promise.race([
+    runToCompletion("Bundle (tsup)", TSUP_BIN, args),
+    watcherClosed,
+  ]);
+}
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => {
+    killChildren();
+    process.exit(0);
+  });
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  killChildren();
+  process.exit(1);
+} finally {
+  killChildren();
+}

--- a/packages/typegraph/scripts/declaration-emit.ts
+++ b/packages/typegraph/scripts/declaration-emit.ts
@@ -1,0 +1,82 @@
+/**
+ * The declaration-pipeline facts `scripts/build.ts` runs on.
+ *
+ * The package's declarations are emitted ONCE by `tsc` into the directory
+ * `tsup.config.ts` names, and tsup's declaration rollup then bundles the
+ * per-entrypoint `.d.ts` out of that emit instead of re-deriving declarations
+ * from source inside the rollup graph. Rolling from source made
+ * rollup-plugin-dts build a live TypeScript program and call `program.emit()`
+ * once per module, which peaked near 10 GiB of resident memory regardless of
+ * which entrypoint was built; the same rollup over an existing `.d.ts` tree
+ * needs no program at all — a declarations-only tsup run over the emitted tree
+ * measured a 0.46 GiB peak for the whole process, rollup worker included — and
+ * emits semantically identical declarations. The one textual difference is
+ * member ORDER inside two inferred enum literals on the `interchange`
+ * entrypoint, which whole-program emit orders differently from the per-file
+ * emit the rollup used to drive.
+ *
+ * The emit directory and the entry mapping belong to `tsup.config.ts`, which
+ * the rollup reads directly; this module resolves them against the package root
+ * and adds the facts only the pipeline needs.
+ */
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  DECLARATION_EMIT_DIR as RELATIVE_DECLARATION_EMIT_DIR,
+  DECLARATION_ENTRY,
+} from "../tsup.config";
+
+export const PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/** The emit directory `tsup.config.ts` names, resolved for file-system use. */
+export const DECLARATION_EMIT_DIR = path.resolve(
+  PACKAGE_ROOT,
+  RELATIVE_DECLARATION_EMIT_DIR,
+);
+
+/**
+ * Every declaration file the rollup takes as an entry, resolved for
+ * file-system use. A watch session waits for exactly these before starting
+ * tsup, so the files it waits on are the files the rollup will open.
+ */
+export const DECLARATION_ENTRY_FILES: readonly string[] = Object.values(
+  DECLARATION_ENTRY,
+).map((entryPath) => path.resolve(PACKAGE_ROOT, entryPath));
+
+/** The `tsc` project that emits the declaration tree. */
+export const DECLARATION_TSCONFIG = path.join(
+  PACKAGE_ROOT,
+  "tsconfig.declarations.json",
+);
+
+/**
+ * The heap ceiling, in MiB, that both stages of the declaration pipeline run
+ * under. The pipeline script passes it to the `tsc` and tsup child processes
+ * explicitly, so a local `pnpm build` never depends on an ambient
+ * `NODE_OPTIONS`; CI's workflow-wide ceiling covers the remaining steps and
+ * must not fall below this one.
+ */
+export const DECLARATION_HEAP_MB = 8192;
+
+/**
+ * tsup's declaration CLI flags (`--dts`, `--dts-only`, `--dts-resolve`,
+ * `--experimental-dts`) REPLACE the config's `dts` option, which would discard
+ * the emitted declaration roots and silently re-root the rollup at `src` — the
+ * ~10 GiB path this pipeline exists to avoid, which then dies on the heap
+ * ceiling. Refuse them by name instead of forwarding them.
+ */
+export function assertNoDeclarationOverride(args: readonly string[]): void {
+  const DECLARATION_FLAG_PREFIXES = ["--dts", "--experimental-dts"] as const;
+  const override = args.find((argument) =>
+    DECLARATION_FLAG_PREFIXES.some((prefix) => argument.startsWith(prefix)),
+  );
+  if (override !== undefined) {
+    throw new Error(
+      `${override} cannot be passed to the build: it replaces the declaration roots this pipeline emits, re-rooting the declaration rollup at "src". Edit tsup.config.ts's declaration entry instead.`,
+    );
+  }
+}

--- a/packages/typegraph/scripts/drizzle-claim-inventory.ts
+++ b/packages/typegraph/scripts/drizzle-claim-inventory.ts
@@ -43,10 +43,16 @@ export const CLAIM_PHRASE_PATTERN = new RegExp(
   "i",
 );
 
-/** Directories the scan never descends into. */
+/**
+ * Directories the scan never descends into — build outputs and tool state, all
+ * of them gitignored. `.declaration-emit` is the declaration tree
+ * `scripts/build.ts` emits for the declaration rollup: it mirrors `src`, so
+ * every claim site in a source doc comment appears there a second time.
+ */
 export const EXCLUDED_DIRECTORY_NAMES: readonly string[] = [
   "node_modules",
   "dist",
+  ".declaration-emit",
   ".git",
   ".turbo",
   "coverage",

--- a/packages/typegraph/tests/ci-workflow-contract.test.ts
+++ b/packages/typegraph/tests/ci-workflow-contract.test.ts
@@ -12,6 +12,8 @@ import { fileURLToPath } from "node:url";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { DECLARATION_HEAP_MB } from "../scripts/declaration-emit";
+
 const WORKFLOW_PATH = fileURLToPath(
   new URL("../../../.github/workflows/ci.yml", import.meta.url),
 );
@@ -26,6 +28,9 @@ const METADATA_PREDICATE_PATH = fileURLToPath(
 );
 const TSUP_CONFIG_PATH = fileURLToPath(
   new URL("../tsup.config.ts", import.meta.url),
+);
+const BUILD_PIPELINE_PATH = fileURLToPath(
+  new URL("../scripts/build.ts", import.meta.url),
 );
 
 function runGit(fixtureDirectory: string, args: readonly string[]): string {
@@ -115,10 +120,10 @@ describe("CI workflow contract", () => {
   });
 
   it("gives CI and release declaration builds enough worker heap", () => {
-    // The build script carries the declaration-bundling ceiling itself, so a
-    // local `pnpm build` never depends on an ambient NODE_OPTIONS; the
-    // workflow-wide ceiling covers the remaining steps and must not fall
-    // below the script's own.
+    // `scripts/build.ts` carries the declaration-pipeline ceiling itself and
+    // passes it to both of its children, so a local `pnpm build` never depends
+    // on an ambient NODE_OPTIONS; the workflow-wide ceiling covers the
+    // remaining steps and must not fall below the pipeline's own.
     const buildScript = (
       JSON.parse(
         readFileSync(
@@ -127,10 +132,14 @@ describe("CI workflow contract", () => {
         ),
       ) as Readonly<{ scripts: Readonly<Record<string, string>> }>
     ).scripts["build"];
-    expect(buildScript).toContain("--max-old-space-size=12288");
+    expect(buildScript).toBe("node --import tsx scripts/build.ts");
+    expect(readFileSync(BUILD_PIPELINE_PATH, "utf8")).toContain(
+      "`--max-old-space-size=${DECLARATION_HEAP_MB}`",
+    );
+    expect(DECLARATION_HEAP_MB).toBe(8192);
     for (const workflowPath of [WORKFLOW_PATH, RELEASE_WORKFLOW_PATH]) {
       expect(readFileSync(workflowPath, "utf8")).toContain(
-        "NODE_OPTIONS: --max-old-space-size=12288",
+        `NODE_OPTIONS: --max-old-space-size=${DECLARATION_HEAP_MB}`,
       );
     }
   });

--- a/packages/typegraph/tests/declaration-pipeline-contract.test.ts
+++ b/packages/typegraph/tests/declaration-pipeline-contract.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pins the two-stage declaration pipeline: `tsc` emits declarations once into
+ * `scripts/declaration-emit.ts`'s directory, and tsup's rollup bundles each
+ * entrypoint's `.d.ts` out of THAT emit rather than deriving declarations from
+ * source inside the rollup graph.
+ *
+ * The distinction is all but invisible in the published artifacts — the routes
+ * differ only in the member order of two inferred enum literals on the
+ * `interchange` entrypoint — and visible in build memory: a source-rooted
+ * rollup peaked near 10 GiB for every entrypoint, while the two stages
+ * together peak near 1.5 GiB. Nothing else would fail if `dts: true` came
+ * back, so these assertions are the guard.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertNoDeclarationOverride,
+  DECLARATION_EMIT_DIR,
+  DECLARATION_ENTRY_FILES,
+  DECLARATION_TSCONFIG,
+  PACKAGE_ROOT,
+} from "../scripts/declaration-emit";
+import tsupConfig, { declarationEntryFor } from "../tsup.config";
+
+type EntryMap = Readonly<Record<string, string>>;
+
+const BUILD_PIPELINE_PATH = fileURLToPath(
+  new URL("../scripts/build.ts", import.meta.url),
+);
+
+function readEntryMaps(): Readonly<{
+  entry: EntryMap;
+  declarationEntry: EntryMap;
+}> {
+  expect(Array.isArray(tsupConfig)).toBe(false);
+  expect(typeof tsupConfig).toBe("object");
+
+  const config = tsupConfig as Readonly<{
+    entry?: unknown;
+    dts?: unknown;
+  }>;
+  const entry = config.entry;
+  const dts = config.dts;
+
+  expect(typeof entry).toBe("object");
+  // `dts: true` is the regression this file exists to catch: it re-roots the
+  // rollup at `src`, which is what cost ~10 GiB.
+  expect(typeof dts).toBe("object");
+
+  const declarationEntry = (dts as Readonly<{ entry?: unknown }>).entry;
+  expect(typeof declarationEntry).toBe("object");
+
+  return {
+    entry: entry as EntryMap,
+    declarationEntry: declarationEntry as EntryMap,
+  };
+}
+
+describe("declaration pipeline", () => {
+  it("rolls every published entrypoint out of the emitted declaration tree", () => {
+    const { entry, declarationEntry } = readEntryMaps();
+
+    expect(Object.keys(declarationEntry).toSorted()).toEqual(
+      Object.keys(entry).toSorted(),
+    );
+
+    for (const [name, source] of Object.entries(entry)) {
+      const declaration = declarationEntry[name];
+      expect(declaration).toBe(declarationEntryFor(source));
+      expect(
+        path
+          .resolve(PACKAGE_ROOT, String(declaration))
+          .startsWith(`${DECLARATION_EMIT_DIR}${path.sep}`),
+      ).toBe(true);
+      expect(declaration?.endsWith(".d.ts")).toBe(true);
+    }
+  });
+
+  it("waits on exactly the declaration files the rollup opens", () => {
+    // A watch session starts tsup once these files exist. Waiting on a
+    // narrower list would start the rollup before its inputs are all there;
+    // waiting on a wider one would hang a session forever.
+    const { declarationEntry } = readEntryMaps();
+
+    expect(DECLARATION_ENTRY_FILES.toSorted()).toEqual(
+      Object.values(declarationEntry)
+        .map((entry) => path.resolve(PACKAGE_ROOT, entry))
+        .toSorted(),
+    );
+  });
+
+  it("refuses a declaration entry that the emitted tree cannot contain", () => {
+    expect(() => declarationEntryFor("scripts/build.ts")).toThrow(
+      /does not start with "src\/"/,
+    );
+    expect(() => declarationEntryFor("src/index.tsx")).toThrow(
+      /does not end with "\.ts"/,
+    );
+  });
+
+  it("refuses a tsup declaration flag that would re-root the rollup at source", () => {
+    // These CLI flags replace the config's whole `dts` option, so forwarding
+    // one would discard the emitted roots and silently rebuild the ~10 GiB way.
+    for (const flag of [
+      "--dts",
+      "--dts-only",
+      "--dts-resolve",
+      "--experimental-dts",
+    ]) {
+      expect(() => {
+        assertNoDeclarationOverride(["--silent", flag]);
+      }).toThrow(/re-rooting the declaration rollup/);
+    }
+    // `--no-dts` skips declarations outright rather than re-rooting them, and
+    // every unrelated flag is forwarded untouched.
+    expect(() => {
+      assertNoDeclarationOverride(["--no-dts", "--watch", "--silent"]);
+    }).not.toThrow();
+  });
+
+  it("emits declarations only, into the pipeline's own disposable directory", () => {
+    const declarationTsconfig = JSON.parse(
+      readFileSync(DECLARATION_TSCONFIG, "utf8"),
+    ) as Readonly<{
+      compilerOptions: Readonly<Record<string, unknown>>;
+      include: readonly string[];
+    }>;
+
+    expect(declarationTsconfig.compilerOptions["emitDeclarationOnly"]).toBe(
+      true,
+    );
+    expect(declarationTsconfig.compilerOptions["declaration"]).toBe(true);
+    expect(declarationTsconfig.compilerOptions["declarationMap"]).toBe(false);
+    expect(declarationTsconfig.include).toEqual(["src"]);
+
+    // `tsc` reads the emit directory from the tsconfig and the rollup reads it
+    // from the seam, so the two spellings must resolve to the same directory —
+    // otherwise the rollup bundles a stale tree, or none.
+    const configuredOutputDir = declarationTsconfig.compilerOptions["outDir"];
+    expect(typeof configuredOutputDir).toBe("string");
+    expect(path.resolve(PACKAGE_ROOT, String(configuredOutputDir))).toBe(
+      DECLARATION_EMIT_DIR,
+    );
+
+    // Not under `node_modules`: rollup-plugin-dts marks every path it
+    // resolves there as an external library import, which turns the rolled
+    // declarations into bare re-exports of files that do not ship.
+    expect(
+      path.relative(PACKAGE_ROOT, DECLARATION_EMIT_DIR).split(path.sep),
+    ).toEqual([".declaration-emit"]);
+
+    const pipeline = readFileSync(BUILD_PIPELINE_PATH, "utf8");
+    expect(pipeline).toContain("DECLARATION_TSCONFIG");
+  });
+});

--- a/packages/typegraph/tsconfig.declarations.json
+++ b/packages/typegraph/tsconfig.declarations.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": false,
+    "emitDeclarationOnly": true,
+    "sourceMap": false,
+    "outDir": "./.declaration-emit"
+  },
+  "include": ["src"]
+}

--- a/packages/typegraph/tsup.config.ts
+++ b/packages/typegraph/tsup.config.ts
@@ -1,29 +1,95 @@
 import { defineConfig } from "tsup";
 
+/**
+ * The published entrypoints, keyed by their `dist` path. The sole owner of the
+ * dist↔src map: `scripts/drizzle-reachability-scan.ts` cross-checks
+ * `package.json#exports` against it, and the declaration rollup below derives
+ * its own entry list from it, so neither can name a different set of roots.
+ */
+const ENTRY = {
+  index: "src/index.ts",
+  "backend/index": "src/backend/index.ts",
+  "core/index": "src/core/index.ts",
+  "interchange/index": "src/interchange/index.ts",
+  "profiler/index": "src/profiler/index.ts",
+  "schema/index": "src/schema/index.ts",
+  "indexes/index": "src/indexes/index.ts",
+  "graph-extension/index": "src/graph-extension/index.ts",
+  "graph-merge/index": "src/graph-merge/index.ts",
+  "provenance/index": "src/provenance/index.ts",
+  "backend/sqlite/index": "src/backend/sqlite/index.ts",
+  "backend/sqlite/local": "src/backend/sqlite/local.ts",
+  "backend/sqlite/local-store": "src/backend/sqlite/local-store.ts",
+  "backend/sqlite/libsql": "src/backend/sqlite/libsql.ts",
+  "backend/drizzle/indexes": "src/backend/drizzle/indexes.ts",
+  "backend/postgres/index": "src/backend/postgres/index.ts",
+  "backend/postgres/pglite": "src/backend/postgres/pglite.ts",
+  "backend/postgres/pglite-store": "src/backend/postgres/pglite-store.ts",
+  "backend/drizzle/engine/index": "src/backend/drizzle/engine/index.ts",
+} as const;
+
+/**
+ * Where `scripts/build.ts` has `tsc` write the declaration tree that the
+ * rollup below consumes, relative to the package root (which is the build's
+ * working directory). Gitignored, and rebuilt by every build.
+ *
+ * It must NOT live under `node_modules`, even in a cache directory:
+ * rollup-plugin-dts resolves imports through `ts.resolveModuleName` and treats
+ * everything it reports as an external library import — which is every path
+ * under `node_modules` — as external, so a tree emitted there would roll up to
+ * bare re-exports of files that do not ship.
+ *
+ * This module deliberately imports nothing but tsup: it is loaded by
+ * `scripts/drizzle-reachability-scan.ts` through a plain `require`, where a
+ * relative TypeScript import would not resolve.
+ */
+export const DECLARATION_EMIT_DIR = ".declaration-emit";
+
+/**
+ * The emitted declaration file for an entry's source path. `tsc` mirrors the
+ * source tree under the emit directory, so `src/backend/index.ts` becomes
+ * `.declaration-emit/backend/index.d.ts`.
+ *
+ * The sole owner of that mapping: every declaration entry below is derived
+ * through it, so the declaration rollup's roots cannot drift from the
+ * JavaScript build's.
+ */
+export function declarationEntryFor(sourcePath: string): string {
+  const SOURCE_PREFIX = "src/";
+  if (!sourcePath.startsWith(SOURCE_PREFIX)) {
+    throw new Error(
+      `Declaration entry ${JSON.stringify(sourcePath)} does not start with "${SOURCE_PREFIX}"; the emitted declaration tree mirrors "src" only.`,
+    );
+  }
+  if (!sourcePath.endsWith(".ts")) {
+    throw new Error(
+      `Declaration entry ${JSON.stringify(sourcePath)} does not end with ".ts".`,
+    );
+  }
+  const withoutSourcePrefix = sourcePath.slice(SOURCE_PREFIX.length);
+  const withoutExtension = withoutSourcePrefix.slice(0, -".ts".length);
+  return `${DECLARATION_EMIT_DIR}/${withoutExtension}.d.ts`;
+}
+
+/**
+ * The declaration rollup's roots: the `.d.ts` `scripts/build.ts` emitted for
+ * each entry, not the entry's source. Rolling pre-emitted declarations is what
+ * keeps the build's peak memory off the ~10 GiB plateau a source-rooted rollup
+ * needed — see `scripts/declaration-emit.ts`. `pnpm build` is therefore the
+ * supported way to build: a bare `tsup` run has no emit to roll and fails on
+ * the unresolved declaration entries rather than shipping stale ones.
+ */
+export const DECLARATION_ENTRY = Object.fromEntries(
+  Object.entries(ENTRY).map(([name, source]) => [
+    name,
+    declarationEntryFor(source),
+  ]),
+);
+
 export default defineConfig({
-  entry: {
-    index: "src/index.ts",
-    "backend/index": "src/backend/index.ts",
-    "core/index": "src/core/index.ts",
-    "interchange/index": "src/interchange/index.ts",
-    "profiler/index": "src/profiler/index.ts",
-    "schema/index": "src/schema/index.ts",
-    "indexes/index": "src/indexes/index.ts",
-    "graph-extension/index": "src/graph-extension/index.ts",
-    "graph-merge/index": "src/graph-merge/index.ts",
-    "provenance/index": "src/provenance/index.ts",
-    "backend/sqlite/index": "src/backend/sqlite/index.ts",
-    "backend/sqlite/local": "src/backend/sqlite/local.ts",
-    "backend/sqlite/local-store": "src/backend/sqlite/local-store.ts",
-    "backend/sqlite/libsql": "src/backend/sqlite/libsql.ts",
-    "backend/drizzle/indexes": "src/backend/drizzle/indexes.ts",
-    "backend/postgres/index": "src/backend/postgres/index.ts",
-    "backend/postgres/pglite": "src/backend/postgres/pglite.ts",
-    "backend/postgres/pglite-store": "src/backend/postgres/pglite-store.ts",
-    "backend/drizzle/engine/index": "src/backend/drizzle/engine/index.ts",
-  },
+  entry: ENTRY,
   format: ["esm", "cjs"],
-  dts: true,
+  dts: { entry: DECLARATION_ENTRY },
   splitting: true,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
The declaration bundle peaked at 9.9 GiB of resident memory on this branch, which is what forced the CI ceiling up to 12 GB as a stopgap. Measuring each entrypoint on its own refutes the type-surface explanation: the peak is the same wherever the rollup is rooted, including at `core` — a small barrel whose closure contains no query, store, merge or ontology surface at all — so no public type family drives it, and collapsing the deep conditional types on the query surface could not have moved the number.

| `--dts-only` entry | Peak RSS |
| --- | --- |
| `src/backend/index.ts` | 9.33 GiB |
| `src/index.ts` | 9.20 GiB |
| `src/graph-merge/index.ts` | 8.85 GiB |
| `src/core/index.ts` | 8.84 GiB |
| `src/store/index.ts` | 8.76 GiB |
| `src/query/index.ts` | 8.41 GiB |
| `src/ontology/index.ts` | 8.30 GiB |
| `src/provenance/index.ts` | 8.18 GiB |
| `src/backend/drizzle/engine/index.ts` | 7.28 GiB |

The cost is in how the declarations are produced, not in what they say. `dts: true` roots rollup-plugin-dts at `src`, and the plugin then builds a live TypeScript program and calls `program.emit()` once per module from inside the rollup transform hook, holding that per-module emit state for all 449 modules alongside the rollup module graph. TypeScript's own whole-program declaration emit over the same sources costs 1.53 GiB and 7 seconds, and rolling the entrypoints out of that emitted tree costs 0.46 GiB and 1 second — the plugin skips program creation entirely once its inputs are already `.d.ts`.

So the build is now two ordered stages owned by `scripts/build.ts`: `tsc` emits the declarations once into a gitignored `.declaration-emit/`, then tsup bundles the JavaScript from `src` and rolls each entrypoint's declarations out of that emit. The rollup's entry list is derived from the same `entry` map the JavaScript build uses, so the two cannot name different roots, and the emit directory and heap ceiling have one spelling each in `scripts/declaration-emit.ts`. `pnpm dev` keeps both stages watching off a single compile: it runs `tsc --watch` alone, starts tsup once the declaration tree it waits on exists, and rollup then watches those emitted files, so a rewrite re-rolls the declarations. A watch session therefore survives a type error and recovers on the next save the way `tsc --watch` does, and it fails loudly if the watcher ever closes, since declarations would otherwise freeze at the last emit while the bundles kept refreshing. The pipeline refuses tsup's `--dts`, `--dts-only`, `--dts-resolve` and `--experimental-dts` flags rather than forwarding them, because each replaces the config's whole `dts` option and would silently re-root the rollup at source again.

Peak for the complete build, JavaScript and declarations together, is now 1.48–1.54 GiB over consecutive runs, so the ceiling goes back to 8192 MiB with room to spare and #652's bump is reverted in both workflows.

The published declarations are the same artifacts. Normalizing the content-hash suffixes in chunk names, 40 of 40 emitted chunks and 37 of 38 entry declarations are byte-identical to the old output; `interchange/index.d.ts` differs only in the member order of two `z.ZodEnum<{…}>` literals, which whole-program emit orders differently from per-file emit, and that ordering is the only API-report change this work causes.

Shared declaration chunks are renamed cosmetically, from `foo-HASH.d.ts` to `foo.d-HASH.d.ts`, because the rollup now derives a chunk's basename from a `.d.ts` input rather than a `.ts` one. Nothing imports those names by hand: every entry declaration references its chunks through the rollup's own rewritten specifiers, the content hashes are unchanged, and `package.json#exports` points only at entry declarations.

`experimentalDts` was measured and rejected on correctness rather than memory: it peaks at 2.97 GiB, but api-extractor aborts on the emitted tree with `Internal Error: Unable to follow symbol for "const"` and produces no declarations.

Closes #653
